### PR TITLE
Fix spelling errors in configuration keys

### DIFF
--- a/src/SourceGit/ViewModels/RepositoryConfigure.cs
+++ b/src/SourceGit/ViewModels/RepositoryConfigure.cs
@@ -44,7 +44,7 @@ namespace SourceGit.ViewModels
             if (_cached.ContainsKey("user.email")) UserEmail = _cached["user.email"];
             if (_cached.ContainsKey("commit.gpgsign")) GPGSigningEnabled = _cached["commit.gpgsign"] == "true";
             if (_cached.ContainsKey("user.signingkey")) GPGUserSigningKey = _cached["user.signingkey"];
-            if (_cached.ContainsKey("http.proxy")) HttpProxy = _cached["user.signingkey"];
+            if (_cached.ContainsKey("http.proxy")) HttpProxy = _cached["http.proxy"];
 
             View = new Views.RepositoryConfigure() { DataContext = this };
         }


### PR DESCRIPTION
Fix spelling errors in configuration keys

Before this PR:

- An exception is occured when the user open the repository settings.

After this PR:

- The exception is fixed.

![image](https://github.com/sourcegit-scm/sourcegit/assets/9959623/095cdb05-f26b-435f-8ab1-9279b06033ad)
