### PR TITLE
Use system API to get default font name

### DIFF
--- a/src/SourceGit/Native/Windows.cs
+++ b/src/SourceGit/Native/Windows.cs
@@ -60,7 +60,11 @@ namespace SourceGit.Native
             builder.With(new FontManagerOptions()
             {
                 DefaultFamilyName = SystemParameters.GetSystemDefaultFontName() ?? "Segoe UI",
-                FontFallbacks = [new FontFallback { FontFamily = "Segoe UI" }],
+                FontFallbacks =
+                [
+                    new FontFallback { FontFamily = "Segoe UI" },
+                    new FontFallback { FontFamily = "Tahoma" },
+                ],
             });
 
             // Fix drop shadow issue on Windows 10

--- a/src/SourceGit/Native/Windows.cs
+++ b/src/SourceGit/Native/Windows.cs
@@ -9,6 +9,8 @@ using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Media;
 
+using SourceGit.Native.WindowsNative;
+
 namespace SourceGit.Native
 {
     [SupportedOSPlatform("windows")]
@@ -57,8 +59,8 @@ namespace SourceGit.Native
         {
             builder.With(new FontManagerOptions()
             {
-                DefaultFamilyName = "Microsoft YaHei UI",
-                FontFallbacks = [new FontFallback { FontFamily = "Microsoft YaHei" }],
+                DefaultFamilyName = SystemParameters.GetSystemDefaultFontName() ?? "Segoe UI",
+                FontFallbacks = [new FontFallback { FontFamily = "Segoe UI" }],
             });
 
             // Fix drop shadow issue on Windows 10

--- a/src/SourceGit/Native/WindowsNative/SystemParameters.cs
+++ b/src/SourceGit/Native/WindowsNative/SystemParameters.cs
@@ -1,0 +1,75 @@
+﻿#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SourceGit.Native.WindowsNative
+{
+    [SupportedOSPlatform("windows")]
+    internal static class SystemParameters
+    {
+        public static string? GetSystemDefaultFontName()
+        {
+            var ncm = new NONCLIENTMETRICS
+            {
+                cbSize = Marshal.SizeOf(typeof(NONCLIENTMETRICS))
+            };
+
+            return SystemParametersInfo(SPI_GETNONCLIENTMETRICS, ncm.cbSize, ref ncm, 0)
+                ? ncm.lfMessageFont.lfFaceName
+                : null;
+        }
+
+        private const int SPI_GETNONCLIENTMETRICS = 0x0029;
+
+        [DllImport("user32.dll", CharSet = CharSet.Auto)]
+        private static extern bool SystemParametersInfo(int uAction, int uParam, ref NONCLIENTMETRICS lpvParam, int fuWinIni);
+
+        [StructLayout(LayoutKind.Sequential)]
+        internal struct NONCLIENTMETRICS
+        {
+            public int cbSize;
+            public int iBorderWidth;
+            public int iScrollWidth;
+            public int iScrollHeight;
+            public int iCaptionWidth;
+            public int iCaptionHeight;
+            public LOGFONT lfCaptionFont;
+            public int iSmCaptionWidth;
+            public int iSmCaptionHeight;
+            public LOGFONT lfSmCaptionFont;
+            public int iMenuWidth;
+            public int iMenuHeight;
+            public LOGFONT lfMenuFont;
+            public LOGFONT lfStatusFont;
+            public LOGFONT lfMessageFont;
+            [SupportedOSPlatform("windows6.0.6000" /* Vista */)]
+            public int iPaddedBorderWidth;
+        }
+
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+        internal struct LOGFONT
+        {
+            public int lfHeight;
+            public int lfWidth;
+            public int lfEscapement;
+            public int lfOrientation;
+            public int lfWeight;
+            public byte lfItalic;
+            public byte lfUnderline;
+            public byte lfStrikeOut;
+            public byte lfCharSet;
+            public byte lfOutPrecision;
+            public byte lfClipPrecision;
+            public byte lfQuality;
+            public byte lfPitchAndFamily;
+            [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 32)]
+            public string lfFaceName;
+        }
+    }
+}


### PR DESCRIPTION
Use system API to get default font name instead of setting a constant value.

These are the default font name for each culture:

| Language                          | Default font name  |
| --------------------------------- | ------------------ |
| 日语（Japanese）                  | Meiryo             |
| 韩语（Korean）                    | Malgun Gothic      |
| 繁体中文（Chinese (Traditional)） | Microsoft JhengHei |
| 简体中文（Chinese (Simplified)）  | Microsoft YaHei    |
| 希伯来语（Hebrew）                | Gisha              |
| 泰语（Thai）                      | Leelawadee         |

See my blog for more details:

- [Windows 系统的默认字体是什么？应用的默认字体是什么？](https://blog.walterlv.com/post/windows-default-font-family.html)