### PR TITLE
Fix windows terminal startup directory

### DIFF
--- a/src/Native/Windows.cs
+++ b/src/Native/Windows.cs
@@ -161,6 +161,7 @@ namespace SourceGit.Native
                     }
 
                     startInfo.FileName = FindWindowsTerminalApp();
+                    startInfo.Arguments = $"-d \"{workdir}\"";
                     break;
                 default:
                     App.RaiseException(workdir, $"Bad shell configuration!");


### PR DESCRIPTION
Before this PR:

The Windows Terminal always use the default startup directory of the default profile.

After this PR:

The Windows Terminal will use the repository directory as the startup directory.