### PR TITLE
Add dependencies to build script for windows

### DIFF
--- a/build/build.windows.ps1
+++ b/build/build.windows.ps1
@@ -6,6 +6,9 @@ if (Test-Path SourceGit) {
 
 Remove-Item *.zip -Force
 
+# Add dependencies for build
+dotnet add ..\src\SourceGit.csproj package Avalonia --version 11.0.10
+
 dotnet publish ..\src\SourceGit.csproj -c Release -r win-x64 -o SourceGit -p:PublishAot=true -p:PublishTrimmed=true -p:TrimMode=link --self-contained
 
 Remove-Item SourceGit\*.pdb -Force


### PR DESCRIPTION
Project don't build without dependencies on Windows.
Please add command for download the package Avalonia special version.