### PR TITLE
Alternative path for save settings

### DIFF
--- a/src/App.axaml.cs
+++ b/src/App.axaml.cs
@@ -43,8 +43,8 @@ namespace SourceGit
                 builder.Append(ex.StackTrace);
 
                 var time = DateTime.Now.ToString("yyyy-MM-dd_HH-mm-ss");
-                var file = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
-                    "SourceGit",
+                var file = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+                    ".source-git",
                     $"crash_{time}.log");
                 File.WriteAllText(file, builder.ToString());
             }

--- a/src/Models/AvatarManager.cs
+++ b/src/Models/AvatarManager.cs
@@ -25,7 +25,7 @@ namespace SourceGit.Models
 
         static AvatarManager()
         {
-            _storePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "SourceGit", "avatars");
+            _storePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".source-git", "avatars");
             if (!Directory.Exists(_storePath))
                 Directory.CreateDirectory(_storePath);
 

--- a/src/ViewModels/Preference.cs
+++ b/src/ViewModels/Preference.cs
@@ -435,8 +435,8 @@ namespace SourceGit.ViewModels
 
         private static Preference _instance = null;
         private static readonly string _savePath = Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
-            "SourceGit",
+            Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+            ".source-git",
             "preference.json");
 
         private string _locale = "en_US";


### PR DESCRIPTION
Some users with not good skills may not found folder with setting when delete installation

Using `~/.source-git` folder can reduce difficult for delete settings.

it's difficult to found cached settings at `~\AppData\Roaming\SourceGit` on Windows for beginning users, when `AppData` is hidden. `SourceGit` is distributed as zip archive and don't have installer which can delete settings at removing installation.