### PR TITLE
FindRepository Fix

### DIFF
--- a/src/ViewModels/Preference.cs
+++ b/src/ViewModels/Preference.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
@@ -363,6 +364,20 @@ namespace SourceGit.ViewModels
 
         public static Repository FindRepository(string path)
         {
+
+            if (!_instance.Repositories.Any(i => i.FullPath == path))
+            {
+                var node = _instance.RepositoryNodes.FirstOrDefault(m => m.Id == path);
+                if (node != null)
+                {
+                    _instance.Repositories.Add(new Repository()
+                    {
+                        FullPath = node.Id,
+                        GitDir = Path.GetFullPath(Path.Combine(node.Id, ".git"))
+                    });
+                }
+            }
+            
             foreach (var repo in _instance.Repositories)
             {
                 if (repo.FullPath == path)


### PR DESCRIPTION
The problem I found in https://github.com/sourcegit-scm/sourcegit/issues/90 was essentially a difference between "Repositories" and "RepositoryNodes" in some scenarios "Repositories" get an empty list when in other hand "RepositoryNodes" get elements inside, that make visible all repos in the UI but not accessible because it's not present in "Repositories"

![image](https://github.com/sourcegit-scm/sourcegit/assets/1206858/415e1841-a974-4196-b2f0-3d74936da920)

This workaround basically copies existing repos from "RepositoryNodes" into Repositories when the user tries to open it, and for some reason this is not in the "Repository" node from the preferences.

I rather to check this Json file, because as far I saw this, looks like there is no need to have two "Repositories" nodes inside same Json file, but for now this is my workaround.

