### PR TITLE
Add branch and tag search box to repository Workspace section

### DIFF
--- a/src/Models/BranchTreeNode.cs
+++ b/src/Models/BranchTreeNode.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-
+using System.Text.RegularExpressions;
 using Avalonia.Collections;
 
 namespace SourceGit.Models
@@ -10,6 +10,7 @@ namespace SourceGit.Models
         Remote,
         Folder,
         Branch,
+        Tag,
     }
 
     public class BranchTreeNode
@@ -20,6 +21,7 @@ namespace SourceGit.Models
         public bool IsExpanded { get; set; }
         public bool IsFiltered { get; set; }
         public List<BranchTreeNode> Children { get; set; } = new List<BranchTreeNode>();
+        public List<BranchTreeNode> ChildrenVisible { get; set; } = new List<BranchTreeNode>();
 
         public bool IsUpstreamTrackStatusVisible
         {
@@ -45,6 +47,11 @@ namespace SourceGit.Models
         {
             get => Type == BranchTreeNodeType.Branch;
         }
+        
+        public bool IsTag
+        {
+            get => Type == BranchTreeNodeType.Tag;
+        }
 
         public bool IsCurrent
         {
@@ -55,6 +62,25 @@ namespace SourceGit.Models
         {
             public List<BranchTreeNode> Locals => _locals;
             public List<BranchTreeNode> Remotes => _remotes;
+            public List<BranchTreeNode> Tags => _tags;
+            
+            public List<BranchTreeNode> LocalsVisible => _localsVisible;
+            public List<BranchTreeNode> RemotesVisible => _remotesVisible;
+            public List<BranchTreeNode> TagsVisible => _tagsVisible;
+
+            public void Run(List<Tag> tags)
+            {
+                foreach (var tag in tags)
+                {
+                    var isFiltered = _filters.Contains(tag.Name);
+                    MakeTagNode(tag, _tags, "tag", isFiltered);
+                }
+
+                SortNodes(_tags);
+
+                var filter = Filter.Create(_searchQuery);
+                filter.Apply(_tags, _tagsVisible);
+            }
 
             public void Run(List<Branch> branches, List<Remote> remotes)
             {
@@ -90,6 +116,10 @@ namespace SourceGit.Models
 
                 SortNodes(_locals);
                 SortNodes(_remotes);
+
+                var filter = Filter.Create(_searchQuery);
+                filter.Apply(_locals, _localsVisible);
+                filter.Apply(_remotes, _remotesVisible);
             }
 
             public void SetFilters(AvaloniaList<string> filters)
@@ -97,17 +127,29 @@ namespace SourceGit.Models
                 _filters.AddRange(filters);
             }
 
-            public void CollectExpandedNodes(List<BranchTreeNode> nodes, bool isLocal)
+            public void SetSearchQuery(string searchQuery)
+            {
+                _searchQuery = searchQuery;
+            }
+
+            public void CollectBranchExpandedNodes(List<BranchTreeNode> nodes, bool isLocal)
             {
                 CollectExpandedNodes(nodes, isLocal ? "local" : "remote");
             }
 
+            public void CollectTagExpandedNodes(List<BranchTreeNode> nodes)
+            {
+                CollectExpandedNodes(nodes, "tag");
+            }
+            
             private void CollectExpandedNodes(List<BranchTreeNode> nodes, string prefix)
             {
                 foreach (var node in nodes)
                 {
                     var path = prefix + "/" + node.Name;
-                    if (node.Type != BranchTreeNodeType.Branch && node.IsExpanded)
+                    if (node.Type != BranchTreeNodeType.Branch
+                        && node.Type != BranchTreeNodeType.Tag
+                        && node.IsExpanded)
                         _expanded.Add(path);
                     CollectExpandedNodes(node.Children, path);
                 }
@@ -120,13 +162,13 @@ namespace SourceGit.Models
                 if (subs.Length == 1)
                 {
                     var node = new BranchTreeNode()
-                    {
-                        Name = subs[0],
-                        Type = BranchTreeNodeType.Branch,
-                        Backend = branch,
-                        IsExpanded = false,
-                        IsFiltered = isFiltered,
-                    };
+                        {
+                            Name = subs[0],
+                            Type = BranchTreeNodeType.Branch,
+                            Backend = branch,
+                            IsExpanded = false,
+                            IsFiltered = isFiltered,
+                        };
                     roots.Add(node);
                     return;
                 }
@@ -176,6 +218,69 @@ namespace SourceGit.Models
                 lastFolder.Children.Add(last);
             }
 
+            private void MakeTagNode(Tag tag, List<BranchTreeNode> roots, string prefix, bool isFiltered)
+            {
+                var subs = tag.Name.Split(new char[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
+
+                if (subs.Length == 1)
+                {
+                    var node = new BranchTreeNode()
+                        {
+                            Name = subs[0],
+                            Type = BranchTreeNodeType.Tag,
+                            Backend = tag,
+                            IsExpanded = false,
+                            IsFiltered = isFiltered,
+                        };
+                    roots.Add(node);
+                    return;
+                }
+
+                BranchTreeNode lastFolder = null;
+                string path = prefix;
+                for (int i = 0; i < subs.Length - 1; i++)
+                {
+                    path = string.Concat(path, "/", subs[i]);
+                    if (_maps.TryGetValue(path, out var value))
+                    {
+                        lastFolder = value;
+                    }
+                    else if (lastFolder == null)
+                    {
+                        lastFolder = new BranchTreeNode()
+                        {
+                            Name = subs[i],
+                            Type = BranchTreeNodeType.Folder,
+                            IsExpanded = _expanded.Contains(path),
+                        };
+                        roots.Add(lastFolder);
+                        _maps.Add(path, lastFolder);
+                    }
+                    else
+                    {
+                        var folder = new BranchTreeNode()
+                        {
+                            Name = subs[i],
+                            Type = BranchTreeNodeType.Folder,
+                            IsExpanded = _expanded.Contains(path),
+                        };
+                        _maps.Add(path, folder);
+                        lastFolder.Children.Add(folder);
+                        lastFolder = folder;
+                    }
+                }
+
+                var last = new BranchTreeNode()
+                {
+                    Name = subs[subs.Length - 1],
+                    Type = BranchTreeNodeType.Branch,
+                    Backend = tag,
+                    IsExpanded = false,
+                    IsFiltered = isFiltered,
+                };
+                lastFolder.Children.Add(last);
+            }
+
             private void SortNodes(List<BranchTreeNode> nodes)
             {
                 nodes.Sort((l, r) =>
@@ -196,9 +301,108 @@ namespace SourceGit.Models
 
             private readonly List<BranchTreeNode> _locals = new List<BranchTreeNode>();
             private readonly List<BranchTreeNode> _remotes = new List<BranchTreeNode>();
+            private readonly List<BranchTreeNode> _tags = new List<BranchTreeNode>();
+            private readonly List<BranchTreeNode> _localsVisible = new List<BranchTreeNode>();
+            private readonly List<BranchTreeNode> _remotesVisible = new List<BranchTreeNode>();
+            private readonly List<BranchTreeNode> _tagsVisible = new List<BranchTreeNode>();
             private readonly HashSet<string> _expanded = new HashSet<string>();
             private readonly List<string> _filters = new List<string>();
             private readonly Dictionary<string, BranchTreeNode> _maps = new Dictionary<string, BranchTreeNode>();
+            private string _searchQuery;
+        }
+        
+        public class Filter
+        {
+            public void Apply(List<BranchTreeNode> sourceNodes, List<BranchTreeNode> visibleNodes)
+            {
+                _applyQueryAction(sourceNodes, visibleNodes);
+            }
+            
+            public List<BranchTreeNode> Apply(List<BranchTreeNode> sourceNodes)
+            {
+                var visibleNodes = new List<BranchTreeNode>(sourceNodes.Count);
+                _applyQueryAction(sourceNodes, visibleNodes);
+                return visibleNodes;
+            }
+            
+            public static Filter Create(string query)
+            {
+                if (string.IsNullOrEmpty(query)
+                    || string.IsNullOrWhiteSpace(query))
+                {
+                    return s_allPassFilter;
+                }
+
+                try
+                {
+                    var searchQueryRegex = new Regex(query, RegexOptions.IgnoreCase);
+                    return new Filter(searchQueryRegex);
+                }
+                catch (RegexParseException e)
+                {
+                    // invalid regex, do nothing untill user type valid regex
+                }
+                
+                return s_allPassFilter;
+            }
+            
+            private Filter()
+            {
+                _applyQueryAction = AllNodesVisible;
+            }
+            
+            private Filter(Regex searchQueryRegex)
+            {
+                _applyQueryAction = (source, visible) => 
+                    BranchNameMatchesRegexNodesVisible(searchQueryRegex, source, visible);
+            }
+            
+            private readonly Action<List<BranchTreeNode>, List<BranchTreeNode>> _applyQueryAction;
+            
+            private static readonly Filter s_allPassFilter = new();
+            
+            private static bool BranchNameMatchesRegexNodesVisible(Regex searchQueryRegex, List<BranchTreeNode> sourceNodes, List<BranchTreeNode> visibleNodes)
+            {
+                var isAnyBranchMatchesFilter = false;
+                foreach (var node in sourceNodes)
+                {
+                    if (node.IsBranch
+                        && node.Backend is Branch branch
+                        && searchQueryRegex.IsMatch(branch.Name))
+                    {
+                        isAnyBranchMatchesFilter = true;
+                        visibleNodes.Add(node);
+                    }
+                    else if (node.IsTag
+                             && node.Backend is Tag tag
+                             && searchQueryRegex.IsMatch(tag.Name))
+                    {
+                        isAnyBranchMatchesFilter = true;
+                        visibleNodes.Add(node);
+                    }
+                    else
+                    {
+                        node.ChildrenVisible.Clear();
+                        if (BranchNameMatchesRegexNodesVisible(searchQueryRegex, node.Children, node.ChildrenVisible))
+                        {
+                            isAnyBranchMatchesFilter = true;
+                            visibleNodes.Add(node);
+                        }
+                    }
+                }
+
+                return isAnyBranchMatchesFilter;
+            }
+            
+            private static void AllNodesVisible(List<BranchTreeNode> sourceNodes, List<BranchTreeNode> visibleNodes)
+            {
+                visibleNodes.AddRange(sourceNodes);
+                foreach (var node in sourceNodes)
+                {
+                    node.ChildrenVisible.Clear();
+                    AllNodesVisible(node.Children, node.ChildrenVisible);
+                }
+            }
         }
     }
 }

--- a/src/Resources/Locales/en_US.axaml
+++ b/src/Resources/Locales/en_US.axaml
@@ -348,6 +348,7 @@
   <x:String x:Key="Text.Repository.Resolve" xml:space="preserve">RESOLVE</x:String>
   <x:String x:Key="Text.Repository.Search" xml:space="preserve">Search Commit</x:String>
   <x:String x:Key="Text.Repository.SearchTip" xml:space="preserve">Search Author/Committer/Message/SHA</x:String>
+  <x:String x:Key="Text.Repository.SearchBranchesOrTagsTip" xml:space="preserve">Search Branches or Tags</x:String>
   <x:String x:Key="Text.Repository.Statistics" xml:space="preserve">Statistics</x:String>
   <x:String x:Key="Text.Repository.Submodules" xml:space="preserve">SUBMODULES</x:String>
   <x:String x:Key="Text.Repository.Submodules.Add" xml:space="preserve">ADD SUBMODULE</x:String>

--- a/src/Resources/Locales/zh_CN.axaml
+++ b/src/Resources/Locales/zh_CN.axaml
@@ -348,6 +348,7 @@
   <x:String x:Key="Text.Repository.Resolve" xml:space="preserve">解决冲突</x:String>
   <x:String x:Key="Text.Repository.Search" xml:space="preserve">查找提交</x:String>
   <x:String x:Key="Text.Repository.SearchTip" xml:space="preserve">支持搜索作者/提交者/主题/指纹</x:String>
+  <x:String x:Key="Text.Repository.SearchBranchesOrTagsTip" xml:space="preserve">搜索分支或标签</x:String>
   <x:String x:Key="Text.Repository.Statistics" xml:space="preserve">提交统计</x:String>
   <x:String x:Key="Text.Repository.Submodules" xml:space="preserve">子模块列表</x:String>
   <x:String x:Key="Text.Repository.Submodules.Add" xml:space="preserve">添加子模块</x:String>

--- a/src/Views/Launcher.axaml.cs
+++ b/src/Views/Launcher.axaml.cs
@@ -149,7 +149,7 @@ namespace SourceGit.Views
                     }
                     else if (e.Key == Key.F)
                     {
-                        repo.IsSearching = true;
+                        repo.IsSearchingCommits = true;
                         e.Handled = true;
                         return;
                     }

--- a/src/Views/Launcher.axaml.cs
+++ b/src/Views/Launcher.axaml.cs
@@ -161,7 +161,7 @@ namespace SourceGit.Views
 
                 if (vm.ActivePage.Data is ViewModels.Repository repo)
                 {
-                    repo.IsSearching = false;
+                    repo.IsSearchingCommits = false;
                 }
 
                 e.Handled = true;

--- a/src/Views/Repository.axaml
+++ b/src/Views/Repository.axaml
@@ -235,8 +235,7 @@
                               Margin="0,0,8,0"
                               Background="Transparent"
                               IsVisible="{Binding IsBranch}"
-                              Checked="OnToggleFilter"
-                              Unchecked="OnToggleFilter"
+                              IsCheckedChanged="OnToggleFilter"
                               IsChecked="{Binding IsFiltered}"/>
               </Grid>
             </TreeDataTemplate>
@@ -324,8 +323,7 @@
                               Classes="filter"
                               Margin="0,0,8,0"
                               Background="Transparent"
-                              Checked="OnToggleFilter"
-                              Unchecked="OnToggleFilter"
+                              IsCheckedChanged="OnToggleFilter"
                               IsVisible="{Binding IsTag}"
                               IsChecked="{Binding IsFiltered}"/>
               </Grid>

--- a/src/Views/Repository.axaml
+++ b/src/Views/Repository.axaml
@@ -162,7 +162,7 @@
         <!-- Search branches or tags -->
         <TextBox Grid.Row="2"
                  x:Name="txtSearchBranchesAndTagsBox"
-                 Margin="6,4,4,4"
+                 Margin="9,4,4,4"
                  Height="24"
                  BorderThickness="1"
                  BorderBrush="{DynamicResource Brush.Border2}"

--- a/src/Views/Repository.axaml
+++ b/src/Views/Repository.axaml
@@ -28,7 +28,7 @@
           
           <ToggleButton Width="32"
                         Background="Transparent"
-                        IsChecked="{Binding IsSearching, Mode=TwoWay}">
+                        IsChecked="{Binding IsSearchingCommits, Mode=TwoWay}">
             <ToolTip.Tip>
               <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
                 <TextBlock Text="{DynamicResource Text.Repository.Search}" VerticalAlignment="Center"/>
@@ -109,7 +109,7 @@
       </Grid.ColumnDefinitions>
 
       <!-- Left Normal Mode -->
-      <Grid Grid.Column="0" RowDefinitions="28,Auto,28,Auto,28,*,28,Auto,28,Auto" Margin="0,0,0,4" IsVisible="{Binding !IsSearching}">
+      <Grid Grid.Column="0" RowDefinitions="28,Auto,28,28,Auto,28,*,28,Auto,28,Auto" Margin="0,0,0,4" IsVisible="{Binding !IsSearchingCommits}">
         <!-- WorkingCopy -->
         <TextBlock Grid.Row="0" Classes="group_header_label" Text="{DynamicResource Text.Repository.Workspace}"/>
         <ListBox Grid.Row="1" Classes="page_switcher" Background="Transparent" SelectedIndex="{Binding SelectedViewIndex, Mode=TwoWay}">
@@ -158,13 +158,49 @@
             </Grid>
           </ListBoxItem>
         </ListBox>
+        
+        <!-- Search branches or tags -->
+        <TextBox Grid.Row="2"
+                 x:Name="txtSearchBranchesAndTagsBox"
+                 Margin="6,4,4,4"
+                 Height="24"
+                 BorderThickness="1"
+                 BorderBrush="{DynamicResource Brush.Border2}"
+                 CornerRadius="3"
+                 Background="{DynamicResource Brush.Contents}"
+                 Watermark="{DynamicResource Text.Repository.SearchBranchesOrTagsTip}"
+                 Text="{Binding SearchBranchOrTagFilter, Mode=TwoWay}"
+                 VerticalContentAlignment="Center"
+                 KeyDown="OnSearchBranchesAndTagsKeyDown">
+          <TextBox.InnerLeftContent>
+            <Path Width="14" Height="14"
+                  Margin="6,0,0,0"
+                  Fill="{DynamicResource Brush.FG2}"
+                  Data="{StaticResource Icons.Search}"/>
+          </TextBox.InnerLeftContent>
+
+          <TextBox.InnerRightContent>
+            <Button Classes="icon_button"
+                    Width="16"
+                    Margin="0,0,6,0"
+                    Command="{Binding ClearSearchBranchOrTagFilter}"
+                    IsVisible="{Binding SearchBranchOrTagFilter, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"
+                    IsTabStop="False"
+                    HorizontalAlignment="Right">
+              <Path Width="14" Height="14"
+                    Margin="0,1,0,0"
+                    Fill="{DynamicResource Brush.FG1}"
+                    Data="{StaticResource Icons.Clear}"/>
+            </Button>
+          </TextBox.InnerRightContent>
+        </TextBox>
 
         <!-- Local Branches -->
-        <TextBlock Grid.Row="2" Classes="group_header_label" Text="{DynamicResource Text.Repository.LocalBranches}"/>
-        <TreeView Grid.Row="3"
+        <TextBlock Grid.Row="3" Classes="group_header_label" Text="{DynamicResource Text.Repository.LocalBranches}"/>
+        <TreeView Grid.Row="4"
                   x:Name="localBranchTree"
                   MaxHeight="400"
-                  ItemsSource="{Binding LocalBranchTrees}"
+                  ItemsSource="{Binding LocalBranchTreesVisible}"
                   ScrollViewer.HorizontalScrollBarVisibility="Disabled"
                   ScrollViewer.VerticalScrollBarVisibility="Auto"
                   LostFocus="OnLocalBranchTreeLostFocus"
@@ -175,8 +211,8 @@
             </Style>
           </TreeView.Styles>
           <TreeView.ItemTemplate>
-            <TreeDataTemplate ItemsSource="{Binding Children}" x:DataType="{x:Type m:BranchTreeNode}">
-              <Grid Height="24" ColumnDefinitions="20,*,Auto,Auto" Background="Transparent" ContextRequested="OnLocalBranchContextMenuRequested" DoubleTapped="OnDoubleTappedLocalBranchNode">
+            <TreeDataTemplate ItemsSource="{Binding ChildrenVisible}" x:DataType="{x:Type m:BranchTreeNode}">
+              <Grid Height="24" ColumnDefinitions="20,*,Auto,Auto" Background="Transparent" ContextRequested="OnLocalBranchContextMenuRequested" DoubleTapped="OnDoubleTappedBranchNode">
                 <Path Grid.Column="0" Classes="folder_icon" Width="12" Height="12" HorizontalAlignment="Left" Margin="0,1,0,0" IsVisible="{Binding IsFolder}"/>
                 <Path Grid.Column="0" Width="12" Height="12" HorizontalAlignment="Left" Margin="0,2,0,0" Data="{StaticResource Icons.Check}" IsVisible="{Binding IsCurrent}" VerticalAlignment="Center"/>
                 <Path Grid.Column="0" Width="12" Height="12" HorizontalAlignment="Left" Margin="2,0,0,0" Data="{StaticResource Icons.Branch}" VerticalAlignment="Center">
@@ -208,15 +244,15 @@
         </TreeView>
 
         <!-- Remotes -->
-        <Grid Grid.Row="4" ColumnDefinitions="*,Auto">
+        <Grid Grid.Row="5" ColumnDefinitions="*,Auto">
           <TextBlock Grid.Column="0" Classes="group_header_label" Text="{DynamicResource Text.Repository.Remotes}"/>
           <Button Grid.Column="1" Classes="icon_button" Width="14" Margin="8,0" Command="{Binding AddRemote}" ToolTip.Tip="{DynamicResource Text.Repository.Remotes.Add}">
             <Path Width="12" Height="12" Data="{StaticResource Icons.Remote.Add}"/>
           </Button>
         </Grid>
-        <TreeView Grid.Row="5"
+        <TreeView Grid.Row="6"
                   x:Name="remoteBranchTree"
-                  ItemsSource="{Binding RemoteBranchTrees}"
+                  ItemsSource="{Binding RemoteBranchTreesVisible}"
                   ScrollViewer.HorizontalScrollBarVisibility="Disabled"
                   ScrollViewer.VerticalScrollBarVisibility="Auto"
                   LostFocus="OnRemoteBranchTreeLostFocus"
@@ -228,8 +264,8 @@
           </TreeView.Styles>
 
           <TreeView.ItemTemplate>
-            <TreeDataTemplate ItemsSource="{Binding Children}" x:DataType="{x:Type m:BranchTreeNode}">
-              <Grid Height="24" ColumnDefinitions="20,*,Auto" Background="Transparent" ContextRequested="OnRemoteBranchContextMenuRequested">
+            <TreeDataTemplate ItemsSource="{Binding ChildrenVisible}" x:DataType="{x:Type m:BranchTreeNode}">
+              <Grid Height="24" ColumnDefinitions="20,*,Auto" Background="Transparent" ContextRequested="OnRemoteBranchContextMenuRequested"  DoubleTapped="OnDoubleTappedBranchNode">
                 <Path Grid.Column="0" Classes="folder_icon" Width="10" Height="10" HorizontalAlignment="Left" Margin="0,2,0,0" IsVisible="{Binding IsFolder}" VerticalAlignment="Center"/>
                 <Path Grid.Column="0" Width="12" Height="12" HorizontalAlignment="Left" Margin="0,2,0,0" Data="{StaticResource Icons.Remote}" IsVisible="{Binding IsRemote}" VerticalAlignment="Center"/>
                 <Path Grid.Column="0" Width="12" Height="12" HorizontalAlignment="Left" Margin="2,0,0,0" Data="{StaticResource Icons.Branch}" IsVisible="{Binding IsBranch}" VerticalAlignment="Center"/>
@@ -250,7 +286,7 @@
         </TreeView>
 
         <!-- Tags -->
-        <ToggleButton Grid.Row="6" Classes="group_expander" IsChecked="{Binding IsTagGroupExpanded, Mode=TwoWay}">
+        <ToggleButton Grid.Row="7" Classes="group_expander" IsChecked="{Binding IsTagGroupExpanded, Mode=TwoWay}">
           <Grid ColumnDefinitions="Auto,*,Auto">
             <TextBlock Grid.Column="0" Classes="group_header_label" Margin="4,0,0,0" Text="{DynamicResource Text.Repository.Tags}"/>
             <TextBlock Grid.Column="1" Text="{Binding Tags, Converter={x:Static c:ListConverters.ToCount}}" Foreground="{DynamicResource Brush.FG2}" FontWeight="Bold"/>
@@ -259,58 +295,46 @@
             </Button>
           </Grid>
         </ToggleButton>
-        <DataGrid Grid.Row="7"
+        <TreeView Grid.Row="8"
                   MaxHeight="200"
                   Background="Transparent"
-                  ItemsSource="{Binding Tags}"
-                  SelectionMode="Single"
-                  CanUserReorderColumns="False"
-                  CanUserResizeColumns="False"
-                  CanUserSortColumns="False"
-                  IsReadOnly="True"
-                  HeadersVisibility="None"
-                  Focusable="False"
-                  RowHeight="24"
-                  HorizontalScrollBarVisibility="Disabled"
-                  VerticalScrollBarVisibility="Auto"
-                  LostFocus="OnTagDataGridLostFocus"
+                  x:Name="tagTree"
+                  ItemsSource="{Binding TagTreesVisible}"
+                  ScrollViewer.HorizontalScrollBarVisibility="Disabled"
+                  ScrollViewer.VerticalScrollBarVisibility="Auto"
                   IsVisible="{Binding IsTagGroupExpanded, Mode=OneWay}"
-                  SelectionChanged="OnTagDataGridSelectionChanged"
-                  ContextRequested="OnTagContextRequested">
-          <DataGrid.Columns>
-            <DataGridTemplateColumn Header="ICON">
-              <DataGridTemplateColumn.CellTemplate>
-                <DataTemplate x:DataType="{x:Type m:Tag}">
-                  <Path Width="10" Height="10" Margin="16,0,8,0" Data="{StaticResource Icons.Tag}"/>
-                </DataTemplate>
-              </DataGridTemplateColumn.CellTemplate>
-            </DataGridTemplateColumn>
+                  SelectionMode="Single"
+                  SelectionChanged="OnTagTreeSelectionChanged"
+                  LostFocus="OnTagTreeLostFocus">
+          <TreeView.Styles>
+            <Style Selector="TreeViewItem" x:DataType="m:BranchTreeNode">
+              <Setter Property="IsExpanded" Value="{Binding IsExpanded, Mode=TwoWay}"/>
+            </Style>
+          </TreeView.Styles>
 
-            <DataGridTemplateColumn Width="*" Header="NAME">
-              <DataGridTemplateColumn.CellTemplate>
-                <DataTemplate x:DataType="{x:Type m:Tag}">
-                  <TextBlock Text="{Binding Name}" Classes="monospace" TextTrimming="CharacterEllipsis" />
-                </DataTemplate>
-              </DataGridTemplateColumn.CellTemplate>
-            </DataGridTemplateColumn>
+          <TreeView.ItemTemplate>
+            <TreeDataTemplate ItemsSource="{Binding ChildrenVisible}" x:DataType="{x:Type m:BranchTreeNode}">
+              <Grid Height="24" ColumnDefinitions="20,*,Auto" Background="Transparent" ContextRequested="OnTagContextRequested" DoubleTapped="OnDoubleTappedBranchNode">
+                <Path Grid.Column="0" Classes="folder_icon" Width="10" Height="10" HorizontalAlignment="Left" Margin="0,2,0,0" IsVisible="{Binding IsFolder}" VerticalAlignment="Center"/>
+                <Path Grid.Column="0" Width="12" Height="12" HorizontalAlignment="Left" Margin="16,0,8,0" Data="{StaticResource Icons.Tag}" IsVisible="{Binding IsTag}" VerticalAlignment="Center"/>
 
-            <DataGridTemplateColumn Header="FILTER">
-              <DataGridTemplateColumn.CellTemplate>
-                <DataTemplate x:DataType="{x:Type m:Tag}">
-                  <ToggleButton Classes="filter"
-                                Margin="0,0,8,0"
-                                Background="Transparent"
-                                Checked="OnToggleFilter"
-                                Unchecked="OnToggleFilter"
-                                IsChecked="{Binding IsFiltered}"/>
-                </DataTemplate>
-              </DataGridTemplateColumn.CellTemplate>
-            </DataGridTemplateColumn>
-          </DataGrid.Columns>
-        </DataGrid>
+                <TextBlock Grid.Column="1" Text="{Binding Name}" Classes="monospace" TextTrimming="CharacterEllipsis"/>
+
+                <ToggleButton Grid.Column="2"
+                              Classes="filter"
+                              Margin="0,0,8,0"
+                              Background="Transparent"
+                              Checked="OnToggleFilter"
+                              Unchecked="OnToggleFilter"
+                              IsVisible="{Binding IsTag}"
+                              IsChecked="{Binding IsFiltered}"/>
+              </Grid>
+            </TreeDataTemplate>
+          </TreeView.ItemTemplate>
+        </TreeView>
 
         <!-- Submodules -->
-        <ToggleButton Grid.Row="8" Classes="group_expander" IsChecked="{Binding IsSubmoduleGroupExpanded, Mode=TwoWay}">
+        <ToggleButton Grid.Row="9" Classes="group_expander" IsChecked="{Binding IsSubmoduleGroupExpanded, Mode=TwoWay}">
           <Grid ColumnDefinitions="Auto,*,Auto,Auto">
             <TextBlock Grid.Column="0" Classes="group_header_label" Margin="4,0,0,0" Text="{DynamicResource Text.Repository.Submodules}"/>
             <TextBlock Grid.Column="1" Text="{Binding Submodules, Converter={x:Static c:ListConverters.ToCount}}" Foreground="{DynamicResource Brush.FG2}" FontWeight="Bold"/>
@@ -328,7 +352,7 @@
             </Button>
           </Grid>
         </ToggleButton>
-        <DataGrid Grid.Row="9"
+        <DataGrid Grid.Row="10"
                   MaxHeight="200"
                   Background="Transparent"
                   ItemsSource="{Binding Submodules}"
@@ -365,7 +389,7 @@
       </Grid>
 
       <!-- Left Search Mode -->
-      <Grid Grid.Column="0" RowDefinitions="32,*" IsVisible="{Binding IsSearching}" PropertyChanged="OnSearchCommitPanelPropertyChanged">
+      <Grid Grid.Column="0" RowDefinitions="32,*" IsVisible="{Binding IsSearchingCommits}" PropertyChanged="OnSearchCommitPanelPropertyChanged">
         <!-- Search -->
         <TextBox Grid.Row="0"
                  x:Name="txtSearchCommitsBox"
@@ -377,7 +401,7 @@
                  Watermark="{DynamicResource Text.Repository.SearchTip}"
                  Text="{Binding SearchCommitFilter, Mode=TwoWay}"
                  VerticalContentAlignment="Center"
-                 KeyDown="OnSearchKeyDown">
+                 KeyDown="OnSearchCommitsKeyDown">
           <TextBox.InnerLeftContent>
             <Path Width="14" Height="14"
                   Margin="6,0,0,0"


### PR DESCRIPTION
Hello!

This pull request adds two features:
1) Tags display is implemented as a tree to support tag subfolders for organazing tags.
This is done by extending the BranchTree to support tag nodes and modifiyng the xaml markup to tree instead of DataGrid.
2) Ability to search tags and branches in wokspace with a single search box.
The search box implementation is aware of possible large amount of branches/tags and does not spam the search for each input key intentionnaly. The search itself is done via regex and valid regex will work, while invalid will just show a default view.

![image](https://github.com/sourcegit-scm/sourcegit/assets/125465407/24d9763d-9236-4028-9d9d-13897eca3b6e)

Best regards, Alexander Bogomolets.

