### PR TITLE
Enhance launcherTabsScroller scroll behavior

### DIFF
--- a/src/Resources/Styles.axaml
+++ b/src/Resources/Styles.axaml
@@ -230,16 +230,16 @@
     <Setter Property="Background" Value="Red"/>
   </Style>
 
-  <Style Selector="Button.icon_button">
+  <Style Selector="Button.icon_button, RepeatButton.icon_button">
     <Setter Property="BorderThickness" Value="0"/>
     <Setter Property="Background" Value="Transparent"/>
     <Setter Property="VerticalAlignment" Value="Center"/>
   </Style>
-  <Style Selector="Button.icon_button /template/ ContentPresenter#PART_ContentPresenter">
+  <Style Selector="Button.icon_button /template/ ContentPresenter#PART_ContentPresenter, RepeatButton.icon_button /template/ ContentPresenter#PART_ContentPresenter">
     <Setter Property="Background" Value="Transparent"/>
     <Setter Property="Opacity" Value="0.8"/>
   </Style>
-  <Style Selector="Button.icon_button:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+  <Style Selector="Button.icon_button:pointerover /template/ ContentPresenter#PART_ContentPresenter, RepeatButton.icon_button:pointerover /template/ ContentPresenter#PART_ContentPresenter">
     <Setter Property="Opacity" Value="1"/>
   </Style>
 

--- a/src/Views/Launcher.axaml
+++ b/src/Views/Launcher.axaml
@@ -96,7 +96,8 @@
                       VerticalScrollBarVisibility="Disabled"
                       DoubleTapped="MaximizeOrRestoreWindow"
                       PointerPressed="BeginMoveWindow"
-                      PointerWheelChanged="ScrollTabs">
+                      PointerWheelChanged="ScrollTabs"
+                      ScrollChanged="OnTabsScrollChanged">
           <StackPanel x:Name="launcherTabsBar" Orientation="Horizontal" SizeChanged="UpdateScrollIndicator">
             <ListBox Classes="launcher_page_tabbar"
                      ItemsSource="{Binding Pages}"

--- a/src/Views/Launcher.axaml
+++ b/src/Views/Launcher.axaml
@@ -86,9 +86,9 @@
 
       <!-- Pages Tabs-->
       <Grid x:Name="launcherTabsContainer" Grid.Column="1" Height="30" ColumnDefinitions="Auto,*,Auto" VerticalAlignment="Bottom" SizeChanged="UpdateScrollIndicator">
-        <Button x:Name="leftScrollIndicator" Grid.Column="0" Classes="icon_button" Width="18" Height="30" Click="ScrollTabsLeft">
+        <RepeatButton x:Name="leftScrollIndicator" Grid.Column="0" Classes="icon_button" Width="18" Height="30" Click="ScrollTabsLeft">
           <Path Width="8" Height="14" Stretch="Fill" Data="{StaticResource Icons.TriangleLeft}"/>
-        </Button>
+        </RepeatButton>
 
         <ScrollViewer Grid.Column="1"
                       x:Name="launcherTabsScroller"
@@ -241,9 +241,9 @@
           </StackPanel>
         </ScrollViewer>
 
-        <Button x:Name="rightScrollIndicator" Grid.Column="2" Classes="icon_button" Width="18" Height="30" Click="ScrollTabsRight">
+        <RepeatButton x:Name="rightScrollIndicator" Grid.Column="2" Classes="icon_button" Width="18" Height="30" Click="ScrollTabsRight">
           <Path Width="8" Height="14" Stretch="Fill" Data="{StaticResource Icons.TriangleRight}"/>
-        </Button>
+        </RepeatButton>
       </Grid>
 
       <!-- Caption Buttons (Windows/Linux)-->

--- a/src/Views/Launcher.axaml.cs
+++ b/src/Views/Launcher.axaml.cs
@@ -265,6 +265,15 @@ namespace SourceGit.Views
             e.Handled = true;
         }
 
+        private void OnTabsScrollChanged(object sender, ScrollChangedEventArgs e)
+        {
+            if (sender is ScrollViewer scrollViewer)
+            {
+                leftScrollIndicator.IsEnabled = scrollViewer.Offset.X > 0;
+                rightScrollIndicator.IsEnabled = scrollViewer.Offset.X < scrollViewer.Extent.Width - scrollViewer.Viewport.Width;
+            }
+        }
+
         private void SetupDragAndDrop(object sender, RoutedEventArgs e)
         {
             if (sender is Border border)

--- a/src/Views/Launcher.axaml.cs
+++ b/src/Views/Launcher.axaml.cs
@@ -232,7 +232,7 @@ namespace SourceGit.Views
             {
                 if (e.Delta.Y < 0)
                     launcherTabsScroller.LineRight();
-                else
+                else if (e.Delta.Y > 0)
                     launcherTabsScroller.LineLeft();
                 e.Handled = true;
             }


### PR DESCRIPTION
Commit `e5516b5` is used to fix the rebound problem that occurs when scrolling on mice such as Logitech G903 that support left and right scrolling.