### PR TITLE
fix: DoubleTapped on launcherTabsScroller not triggered correctly

### DIFF
--- a/src/Views/Launcher.axaml.cs
+++ b/src/Views/Launcher.axaml.cs
@@ -223,7 +223,10 @@ namespace SourceGit.Views
 
         private void BeginMoveWindow(object sender, PointerPressedEventArgs e)
         {
-            BeginMoveDrag(e);
+            if (e.ClickCount != 2)
+            {
+                BeginMoveDrag(e);
+            }
         }
 
         private void ScrollTabs(object sender, PointerWheelEventArgs e)


### PR DESCRIPTION
Depending on the implementation of the desktop environment, the BeginMoveDrag method may cause WindowState assign to not take effect or the window size to flicker.