### PR TITLE
Allowing Azure DevOps / Azure Repos URLs

### DIFF
--- a/SourceGit.sln
+++ b/SourceGit.sln
@@ -75,6 +75,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "SPECS", "SPECS", "{7802CD7A
 		build\resources\rpm\SPECS\build.spec = build\resources\rpm\SPECS\build.spec
 	EndProjectSection
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{47ADA48B-96C5-493B-8B9F-F7F41FD52779}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SourceGit.UnitTests", "tests\SourceGit.UnitTests\SourceGit.UnitTests.csproj", "{69B7CE82-849E-4972-B295-9725BBDD9065}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -85,6 +89,10 @@ Global
 		{2091C34D-4A17-4375-BEF3-4D60BE8113E4}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2091C34D-4A17-4375-BEF3-4D60BE8113E4}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2091C34D-4A17-4375-BEF3-4D60BE8113E4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{69B7CE82-849E-4972-B295-9725BBDD9065}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{69B7CE82-849E-4972-B295-9725BBDD9065}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{69B7CE82-849E-4972-B295-9725BBDD9065}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{69B7CE82-849E-4972-B295-9725BBDD9065}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -104,6 +112,7 @@ Global
 		{F101849D-BDB7-40D4-A516-751150C3CCFC} = {9C2F0CDA-B56E-44A5-94B6-F3EA7AC20CDC}
 		{9BA0B044-0CC9-46F8-B551-204F149BF45D} = {FD384607-ED99-47B7-AF31-FB245841BC92}
 		{7802CD7A-591B-4EDD-96F8-9BF3F61692E4} = {9BA0B044-0CC9-46F8-B551-204F149BF45D}
+		{69B7CE82-849E-4972-B295-9725BBDD9065} = {47ADA48B-96C5-493B-8B9F-F7F41FD52779}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {7FF1B9C6-B5BF-4A50-949F-4B407A0E31C9}

--- a/src/Models/Remote.cs
+++ b/src/Models/Remote.cs
@@ -4,9 +4,9 @@ namespace SourceGit.Models
 {
     public partial class Remote
     {
-        [GeneratedRegex(@"^http[s]?://([\w\-]+@)?[\w\.\-]+(\:[0-9]+)?/[\w\-/]+/[\w\-\.]+\.git$")]
+        [GeneratedRegex(@"^http[s]?://([\w\-]+@)?[\w\.\-]+(\:[0-9]+)?/[\w\-/]+/[\w\-\.]+(\.git)?$")]
         private static partial Regex REG_HTTPS();
-        [GeneratedRegex(@"^[\w\-]+@[\w\.\-]+(\:[0-9]+)?:[\w\-/]+/[\w\-\.]+\.git$")]
+        [GeneratedRegex(@"^[\w\-]+@[\w\.\-]+(\:[0-9]+)?:[\w\-/]+/[\w\-\.]+(\.git)?$")]
         private static partial Regex REG_SSH1();
         [GeneratedRegex(@"^ssh://([\w\-]+@)?[\w\.\-]+(\:[0-9]+)?/[\w\-/]+/[\w\-\.]+\.git$")]
         private static partial Regex REG_SSH2();

--- a/tests/SourceGit.UnitTests/RemoteTests.cs
+++ b/tests/SourceGit.UnitTests/RemoteTests.cs
@@ -1,0 +1,16 @@
+using SourceGit.Models;
+
+namespace SourceGit.UnitTests;
+
+public class RemoteTests
+{
+    [Theory]
+    [InlineData("git@github.com:sourcegit-scm/sourcegit.git")]
+    [InlineData("https://github.com/sourcegit-scm/sourcegit.git")]
+    [InlineData("git@ssh.dev.azure.com:v3/Organization/Project/Repository")]
+    [InlineData("https://organization@dev.azure.com/Organization/Project/_git/Repository")]
+    public void IsValidURL_WhenURLProvidedIsValid_ShouldReturnTrue(string url)
+    {
+        Assert.True(Remote.IsValidURL(url));
+    }
+}

--- a/tests/SourceGit.UnitTests/SourceGit.UnitTests.csproj
+++ b/tests/SourceGit.UnitTests/SourceGit.UnitTests.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\SourceGit.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
### Reason for changing

Currently, it is not possible to clone repositories hosted in **Azure DevOps / Azure Repos**.

![image](https://github.com/sourcegit-scm/sourcegit/assets/2065159/b6938e56-9d75-4c01-9577-913a3f676359)

This is due to **the way the URL is built**, both for HTTPS and SSH. Differently from mostly Git providers, the repository lacks a `.git` suffix.

### What has been changed
 - Changed the RegEx to make the `.git` suffix optional.
 - Added Unit Tests to ensure GitHub and Azure Repos URLs are considered valid.

### Links
https://learn.microsoft.com/en-us/azure/devops/repos/git/clone?view=azure-devops&tabs=visual-studio-2022
https://stackoverflow.com/questions/52355510/what-is-the-url-for-a-new-azure-git-repos-if-the-project-is-in-visual-studio-on