### PR TITLE
Fix the crash caused by pushing without a branch

### DIFF
--- a/src/ViewModels/Repository.cs
+++ b/src/ViewModels/Repository.cs
@@ -385,7 +385,10 @@ namespace SourceGit.ViewModels
             }
 
             if (Branches.Find(x => x.IsCurrent) == null)
+            {
                 App.RaiseException(_fullpath, "Can NOT found current branch!!!");
+                return;
+            }
             PopupHost.ShowPopup(new Push(this, null));
         }
 


### PR DESCRIPTION
When pushing without a branch, it seems that it did not return correctly.