### PR TITLE
feat: add gpg format switcher (#154)

### DIFF
--- a/src/Models/GPGFormat.cs
+++ b/src/Models/GPGFormat.cs
@@ -1,0 +1,25 @@
+﻿using System.Collections.Generic;
+
+namespace SourceGit.Models
+{
+    public class GPGFormat(string name, string value, string desc)
+    {
+        public string Name { get; set; } = name;
+        public string Value { get; set; } = value;
+        public string Desc { get; set; } = desc;
+
+        public static readonly GPGFormat OPENPGP = new GPGFormat("OPENPGP", "openpgp", "DEFAULT");
+
+        public static readonly GPGFormat SSH = new GPGFormat("SSH", "ssh", "Git >= 2.34.0");
+
+        public static readonly List<GPGFormat> Supported = new List<GPGFormat>() {
+            OPENPGP,
+            SSH,
+        };
+
+        public bool Equals(GPGFormat other)
+        {
+            return Value == other.Value;
+        }
+    }
+}

--- a/src/Resources/Locales/en_US.axaml
+++ b/src/Resources/Locales/en_US.axaml
@@ -310,7 +310,9 @@
   <x:String x:Key="Text.Preference.Git.Version" xml:space="preserve">Git version</x:String>
   <x:String x:Key="Text.Preference.Git.Invalid" xml:space="preserve">Git (>= 2.23.0) is required by this app</x:String>
   <x:String x:Key="Text.Preference.GPG" xml:space="preserve">GPG SIGNING</x:String>
-  <x:String x:Key="Text.Preference.GPG.Enabled" xml:space="preserve">Commit GPG signing</x:String>
+  <x:String x:Key="Text.Preference.GPG.CommitEnabled" xml:space="preserve">Commit GPG signing</x:String>
+  <x:String x:Key="Text.Preference.GPG.TagEnabled" xml:space="preserve">Tag GPG signing</x:String>
+  <x:String x:Key="Text.Preference.GPG.Format" xml:space="preserve">GPG Format</x:String>
   <x:String x:Key="Text.Preference.GPG.Path" xml:space="preserve">Install Path</x:String>
   <x:String x:Key="Text.Preference.GPG.Path.Placeholder" xml:space="preserve">Input path for installed gpg program</x:String>
   <x:String x:Key="Text.Preference.GPG.UserKey" xml:space="preserve">User Signing Key</x:String>

--- a/src/Resources/Locales/zh_CN.axaml
+++ b/src/Resources/Locales/zh_CN.axaml
@@ -310,7 +310,9 @@
   <x:String x:Key="Text.Preference.Git.Version" xml:space="preserve">Git 版本</x:String>
   <x:String x:Key="Text.Preference.Git.Invalid" xml:space="preserve">本软件要求GIT最低版本为2.23.0</x:String>
   <x:String x:Key="Text.Preference.GPG" xml:space="preserve">GPG签名</x:String>
-  <x:String x:Key="Text.Preference.GPG.Enabled" xml:space="preserve">启用提交签名</x:String>
+  <x:String x:Key="Text.Preference.GPG.CommitEnabled" xml:space="preserve">启用提交签名</x:String>
+  <x:String x:Key="Text.Preference.GPG.TagEnabled" xml:space="preserve">启用标签签名</x:String>
+  <x:String x:Key="Text.Preference.GPG.Format" xml:space="preserve">GPG签名格式</x:String>
   <x:String x:Key="Text.Preference.GPG.Path" xml:space="preserve">可执行文件位置</x:String>
   <x:String x:Key="Text.Preference.GPG.Path.Placeholder" xml:space="preserve">gpg.exe所在路径</x:String>
   <x:String x:Key="Text.Preference.GPG.UserKey" xml:space="preserve">用户签名KEY</x:String>

--- a/src/ViewModels/RepositoryConfigure.cs
+++ b/src/ViewModels/RepositoryConfigure.cs
@@ -17,7 +17,19 @@ namespace SourceGit.ViewModels
             set;
         }
 
-        public bool GPGSigningEnabled
+        public Models.GPGFormat GPGFormat
+        {
+            get;
+            set;
+        }
+
+        public bool GPGCommitSigningEnabled
+        {
+            get;
+            set;
+        }
+
+        public bool GPGTagSigningEnabled
         {
             get;
             set;
@@ -44,8 +56,14 @@ namespace SourceGit.ViewModels
                 UserName = name;
             if (_cached.TryGetValue("user.email", out var email))
                 UserEmail = email;
-            if (_cached.TryGetValue("commit.gpgsign", out var gpgsign))
-                GPGSigningEnabled = gpgsign == "true";
+            if (_cached.TryGetValue("commit.gpgsign", out var gpgCommitSign))
+                GPGCommitSigningEnabled = gpgCommitSign == "true";
+            if (_cached.TryGetValue("tag.gpgSign", out var gpgTagSign))
+                GPGTagSigningEnabled = gpgTagSign == "true";
+            if (_cached.TryGetValue("gpg.format", out var gpgFormat))
+                GPGFormat = Models.GPGFormat.Supported.Find(x => x.Value == gpgFormat);
+            else
+                GPGFormat = Models.GPGFormat.OPENPGP;
             if (_cached.TryGetValue("user.signingkey", out var signingKey))
                 GPGUserSigningKey = signingKey;
             if (_cached.TryGetValue("http.proxy", out var proxy))
@@ -58,20 +76,22 @@ namespace SourceGit.ViewModels
         {
             SetIfChanged("user.name", UserName);
             SetIfChanged("user.email", UserEmail);
-            SetIfChanged("commit.gpgsign", GPGSigningEnabled ? "true" : "false");
+            SetIfChanged("commit.gpgsign", GPGCommitSigningEnabled ? "true" : "false");
+            SetIfChanged("tag.gpgSign", GPGTagSigningEnabled ? "true" : "false");
+            SetIfChanged("gpg.format", GPGFormat?.Value, Models.GPGFormat.OPENPGP.Value);
             SetIfChanged("user.signingkey", GPGUserSigningKey);
             SetIfChanged("http.proxy", HttpProxy);
             return null;
         }
 
-        private void SetIfChanged(string key, string value)
+        private void SetIfChanged(string key, string value, string defaultValue = null)
         {
             bool changed = false;
             if (_cached.TryGetValue(key, out var old))
             {
                 changed = old != value;
             }
-            else if (!string.IsNullOrEmpty(value))
+            else if (!string.IsNullOrEmpty(value) && value != defaultValue)
             {
                 changed = true;
             }

--- a/src/Views/Preference.axaml
+++ b/src/Views/Preference.axaml
@@ -5,6 +5,7 @@
         xmlns:sys="clr-namespace:System;assembly=mscorlib"
         xmlns:m="using:SourceGit.Models"
         xmlns:c="using:SourceGit.Converters"
+        xmlns:ac="using:Avalonia.Controls.Converters"
         xmlns:vm="using:SourceGit.ViewModels"
         xmlns:v="using:SourceGit.Views"
         mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
@@ -403,16 +404,41 @@
           <TabItem.Header>
             <TextBlock Classes="tab_header" Text="{DynamicResource Text.Preference.GPG}"/>
           </TabItem.Header>
+          
+          <TabItem.Resources>
+            <ac:EnumToBoolConverter x:Key="EnumToBoolConverter"/>
+          </TabItem.Resources>
 
-          <Grid Margin="8" RowDefinitions="32,32,32" ColumnDefinitions="Auto,*">
+          <Grid Margin="8" RowDefinitions="32,32,32,32,32" ColumnDefinitions="Auto,*">
             <TextBlock Grid.Row="0" Grid.Column="0"
+                       Text="{DynamicResource Text.Preference.GPG.Format}"
+                       HorizontalAlignment="Right"
+                       Margin="0,0,16,0"/>
+            <ComboBox Grid.Row="0" Grid.Column="1"
+                      MinHeight="28"
+                      Padding="8,0"
+                      HorizontalAlignment="Stretch"
+                      ItemsSource="{Binding Source={x:Static m:GPGFormat.Supported}}"
+                      SelectedItem="{Binding #me.GPGFormat, Mode=TwoWay, FallbackValue={x:Static m:GPGFormat.OPENPGP}}">
+              <ComboBox.ItemTemplate>
+                <DataTemplate x:DataType="{x:Type m:GPGFormat}">
+                  <Grid ColumnDefinitions="Auto,*">
+                    <TextBlock Grid.Column="0" Text="{Binding Name}"/>
+                    <TextBlock Grid.Column="1" Text="{Binding Desc}" Foreground="{DynamicResource Brush.FG2}" HorizontalAlignment="Right"/>
+                  </Grid>
+                </DataTemplate>
+              </ComboBox.ItemTemplate>
+            </ComboBox>
+
+            <TextBlock Grid.Row="1" Grid.Column="0"
                        Text="{DynamicResource Text.Preference.GPG.Path}"
                        HorizontalAlignment="Right"
                        Margin="0,0,16,0"/>
-            <TextBox Grid.Row="0" Grid.Column="1"
+            <TextBox Grid.Row="1" Grid.Column="1"
                      Height="28"
                      CornerRadius="3"
-                     Text="{Binding #me.GPGExecutableFile, Mode=TwoWay}">
+                     Text="{Binding #me.GPGExecutableFile, Mode=TwoWay}"
+                     IsEnabled="{Binding #me.GPGFormat, Converter={StaticResource EnumToBoolConverter}, ConverterParameter={x:Static m:GPGFormat.OPENPGP}}">
               <TextBox.InnerRightContent>
                 <Button Classes="icon_button" Width="30" Height="30" Click="SelectGPGExecutable">
                   <Path Data="{StaticResource Icons.Folder.Open}" Fill="{DynamicResource Brush.FG1}"/>
@@ -420,19 +446,23 @@
               </TextBox.InnerRightContent>
             </TextBox>
 
-            <TextBlock Grid.Row="1" Grid.Column="0"
+            <TextBlock Grid.Row="2" Grid.Column="0"
                        Text="{DynamicResource Text.Preference.GPG.UserKey}"
                        HorizontalAlignment="Right"
                        Margin="0,0,16,0"/>
-            <TextBox Grid.Row="1" Grid.Column="1"
+            <TextBox Grid.Row="2" Grid.Column="1"
                      Height="28"
                      CornerRadius="3"
                      Text="{Binding #me.GPGUserKey, Mode=TwoWay}"
                      Watermark="{DynamicResource Text.Preference.GPG.UserKey.Placeholder}"/>
 
-            <CheckBox Grid.Row="2" Grid.Column="1"
-                      Content="{DynamicResource Text.Preference.GPG.Enabled}"
-                      IsChecked="{Binding #me.EnableGPGSigning, Mode=TwoWay}"/>
+            <CheckBox Grid.Row="3" Grid.Column="1"
+                      Content="{DynamicResource Text.Preference.GPG.CommitEnabled}"
+                      IsChecked="{Binding #me.EnableGPGCommitSigning, Mode=TwoWay}"/>
+
+            <CheckBox Grid.Row="4" Grid.Column="1"
+                      Content="{DynamicResource Text.Preference.GPG.TagEnabled}"
+                      IsChecked="{Binding #me.EnableGPGTagSigning, Mode=TwoWay}"/>
           </Grid>
         </TabItem>
 

--- a/src/Views/Preference.axaml
+++ b/src/Views/Preference.axaml
@@ -438,7 +438,7 @@
                      Height="28"
                      CornerRadius="3"
                      Text="{Binding #me.GPGExecutableFile, Mode=TwoWay}"
-                     IsEnabled="{Binding #me.GPGFormat, Converter={StaticResource EnumToBoolConverter}, ConverterParameter={x:Static m:GPGFormat.OPENPGP}}">
+                     IsEnabled="{Binding #me.GPGFormat, Mode=TwoWay, Converter={StaticResource EnumToBoolConverter}, ConverterParameter={x:Static m:GPGFormat.OPENPGP}}">
               <TextBox.InnerRightContent>
                 <Button Classes="icon_button" Width="30" Height="30" Click="SelectGPGExecutable">
                   <Path Data="{StaticResource Icons.Folder.Open}" Fill="{DynamicResource Brush.FG1}"/>

--- a/src/Views/Preference.axaml.cs
+++ b/src/Views/Preference.axaml.cs
@@ -54,7 +54,19 @@ namespace SourceGit.Views
             set => SetValue(GitVersionProperty, value);
         }
 
-        public bool EnableGPGSigning
+        public bool EnableGPGCommitSigning
+        {
+            get;
+            set;
+        }
+
+        public bool EnableGPGTagSigning
+        {
+            get;
+            set;
+        }
+
+        public Models.GPGFormat GPGFormat
         {
             get;
             set;
@@ -140,8 +152,14 @@ namespace SourceGit.Views
                     GPGUserKey = signingKey;
                 if (config.TryGetValue("core.autocrlf", out var crlf))
                     CRLFMode = Models.CRLFMode.Supported.Find(x => x.Value == crlf);
-                if (config.TryGetValue("commit.gpgsign", out var gpgsign))
-                    EnableGPGSigning = (gpgsign == "true");
+                if (config.TryGetValue("commit.gpgsign", out var gpgCommitSign))
+                    EnableGPGCommitSigning = (gpgCommitSign == "true");
+                if (config.TryGetValue("tag.gpgSign", out var gpgTagSign))
+                    EnableGPGTagSigning = (gpgTagSign == "true");
+                if (config.TryGetValue("gpg.format", out var gpgFormat))
+                    GPGFormat = Models.GPGFormat.Supported.Find(x => x.Value == gpgFormat);
+                else
+                    GPGFormat = Models.GPGFormat.OPENPGP;
                 if (config.TryGetValue("gpg.program", out var gpgProgram))
                     GPGExecutableFile = gpgProgram;
 
@@ -166,7 +184,9 @@ namespace SourceGit.Views
             var oldEmail = config.TryGetValue("user.email", out var email) ? email : string.Empty;
             var oldGPGSignKey = config.TryGetValue("user.signingkey", out var signingKey) ? signingKey : string.Empty;
             var oldCRLF = config.TryGetValue("core.autocrlf", out var crlf) ? crlf : string.Empty;
-            var oldGPGSignEnable = config.TryGetValue("commit.gpgsign", out var gpgsign) ? gpgsign : "false";
+            var oldGPGFormat = config.TryGetValue("gpg.format", out var gpgFormat) ? gpgFormat : Models.GPGFormat.OPENPGP.Value;
+            var oldGPGCommitSignEnable = config.TryGetValue("commit.gpgsign", out var gpgCommitSign) ? gpgCommitSign : "false";
+            var oldGPGTagSignEnable = config.TryGetValue("tag.gpgSign", out var gpgTagSign) ? gpgTagSign : "false";
             var oldGPGExec = config.TryGetValue("gpg.program", out var program) ? program : string.Empty;
 
             if (DefaultUser != oldUser)
@@ -177,8 +197,12 @@ namespace SourceGit.Views
                 cmd.Set("user.signingkey", GPGUserKey);
             if (CRLFMode != null && CRLFMode.Value != oldCRLF)
                 cmd.Set("core.autocrlf", CRLFMode.Value);
-            if (EnableGPGSigning != (oldGPGSignEnable == "true"))
-                cmd.Set("commit.gpgsign", EnableGPGSigning ? "true" : "false");
+            if (EnableGPGCommitSigning != (oldGPGCommitSignEnable == "true"))
+                cmd.Set("commit.gpgsign", EnableGPGCommitSigning ? "true" : "false");
+            if (EnableGPGTagSigning != (oldGPGTagSignEnable == "true"))
+                cmd.Set("tag.gpgSign", EnableGPGTagSigning ? "true" : "false");
+            if (GPGFormat != null && GPGFormat.Value != oldGPGFormat)
+                cmd.Set("gpg.format", GPGFormat.Value);
             if (GPGExecutableFile != oldGPGExec)
                 cmd.Set("gpg.program", GPGExecutableFile);
 

--- a/src/Views/Preference.axaml.cs
+++ b/src/Views/Preference.axaml.cs
@@ -66,10 +66,13 @@ namespace SourceGit.Views
             set;
         }
 
+        public static readonly StyledProperty<Models.GPGFormat> GPGFormatProperty =
+            AvaloniaProperty.Register<Preference, Models.GPGFormat>(nameof(GPGFormat));
+
         public Models.GPGFormat GPGFormat
         {
-            get;
-            set;
+            get => GetValue(GPGFormatProperty);
+            set => SetValue(GPGFormatProperty, value);
         }
 
         public static readonly StyledProperty<string> GPGExecutableFileProperty =

--- a/src/Views/RepositoryConfigure.axaml
+++ b/src/Views/RepositoryConfigure.axaml
@@ -14,7 +14,7 @@
                Classes="bold"
                Text="{DynamicResource Text.Configure}"/>
 
-    <Grid Margin="0,16,0,0" RowDefinitions="32,32,32,32,32" ColumnDefinitions="150,*">
+    <Grid Margin="0,16,0,0" RowDefinitions="32,32,32,32,32,32,32" ColumnDefinitions="150,*">
       <TextBlock Grid.Column="0"
                  HorizontalAlignment="Right" VerticalAlignment="Center"
                  Margin="0,0,8,0"
@@ -47,18 +47,42 @@
                Text="{Binding HttpProxy, Mode=TwoWay}"/>
 
       <TextBlock Grid.Row="3" Grid.Column="0"
+                 Text="{DynamicResource Text.Preference.GPG.Format}"
+                 HorizontalAlignment="Right"
+                 Margin="0,0,16,0"/>
+      <ComboBox Grid.Row="3" Grid.Column="1"
+                MinHeight="28"
+                Padding="8,0"
+                HorizontalAlignment="Stretch"
+                ItemsSource="{Binding Source={x:Static m:GPGFormat.Supported}}"
+                SelectedItem="{Binding GPGFormat, Mode=TwoWay, FallbackValue={x:Static m:GPGFormat.OPENPGP}}">
+        <ComboBox.ItemTemplate>
+          <DataTemplate x:DataType="{x:Type m:GPGFormat}">
+            <Grid ColumnDefinitions="Auto,*">
+              <TextBlock Grid.Column="0" Text="{Binding Name}"/>
+              <TextBlock Grid.Column="1" Text="{Binding Desc}" Foreground="{DynamicResource Brush.FG2}" HorizontalAlignment="Right"/>
+            </Grid>
+          </DataTemplate>
+        </ComboBox.ItemTemplate>
+      </ComboBox>
+
+      <TextBlock Grid.Row="4" Grid.Column="0"
                  HorizontalAlignment="Right" VerticalAlignment="Center"
                  Margin="0,0,8,0"
                  Text="{DynamicResource Text.Preference.GPG.UserKey}"/>
-      <TextBox Grid.Row="3" Grid.Column="1"
+      <TextBox Grid.Row="4" Grid.Column="1"
                Height="28"
                CornerRadius="3"
                Watermark="{DynamicResource Text.Preference.GPG.UserKey.Placeholder}"
                Text="{Binding GPGUserSigningKey, Mode=TwoWay}"/>
 
-      <CheckBox Grid.Row="4" Grid.Column="1"
-                Content="{DynamicResource Text.Preference.GPG.Enabled}"
-                IsChecked="{Binding GPGSigningEnabled, Mode=TwoWay}"/>
+      <CheckBox Grid.Row="5" Grid.Column="1"
+                Content="{DynamicResource Text.Preference.GPG.CommitEnabled}"
+                IsChecked="{Binding GPGCommitSigningEnabled, Mode=TwoWay}"/>
+
+      <CheckBox Grid.Row="6" Grid.Column="1"
+                Content="{DynamicResource Text.Preference.GPG.TagEnabled}"
+                IsChecked="{Binding GPGTagSigningEnabled, Mode=TwoWay}"/>
     </Grid>
   </StackPanel>
 </UserControl>


### PR DESCRIPTION
This commit is signed with ssh on Windows 10. This PR didn't add X.509 because I cannot test that format.

SSH commit sign default use `ssh-keygen` and use specific public key file, so I didn't add the config of `gpg.ssh.program`

![image](https://github.com/sourcegit-scm/sourcegit/assets/28685179/8e7b0748-34ff-4012-bb95-bb1b8047700c)

![image](https://github.com/sourcegit-scm/sourcegit/assets/28685179/4590e560-5685-4ec3-940e-3afb8c3cdf3d)

![image](https://github.com/sourcegit-scm/sourcegit/assets/28685179/30173c3d-d7e2-4636-b588-221812d54fb7)

![image](https://github.com/sourcegit-scm/sourcegit/assets/28685179/944dc674-cd64-4dfe-aa6f-945e1f71050e)
