### PR TITLE
Tweak English translations.

### DIFF
--- a/src/Resources/Locales/en_US.axaml
+++ b/src/Resources/Locales/en_US.axaml
@@ -12,7 +12,7 @@
   <x:String x:Key="Text.Apply.Error.Desc" xml:space="preserve">Raise errors and refuses to apply the patch</x:String>
   <x:String x:Key="Text.Apply.ErrorAll" xml:space="preserve">Error All</x:String>
   <x:String x:Key="Text.Apply.ErrorAll.Desc" xml:space="preserve">Similar to 'error', but shows more</x:String>
-  <x:String x:Key="Text.Apply.File" xml:space="preserve">Patch File :</x:String>
+  <x:String x:Key="Text.Apply.File" xml:space="preserve">Patch File:</x:String>
   <x:String x:Key="Text.Apply.File.Placeholder" xml:space="preserve">Select .patch file to apply</x:String>
   <x:String x:Key="Text.Apply.IgnoreWS" xml:space="preserve">Ignore whitespace changes</x:String>
   <x:String x:Key="Text.Apply.NoWarn" xml:space="preserve">No Warn</x:String>
@@ -20,11 +20,11 @@
   <x:String x:Key="Text.Apply.Title" xml:space="preserve">Apply Patch</x:String>
   <x:String x:Key="Text.Apply.Warn" xml:space="preserve">Warn</x:String>
   <x:String x:Key="Text.Apply.Warn.Desc" xml:space="preserve">Outputs warnings for a few such errors, but applies</x:String>
-  <x:String x:Key="Text.Apply.WS" xml:space="preserve">Whitespace :</x:String>
-  <x:String x:Key="Text.Archive" xml:space="preserve">Archive ...</x:String>
-  <x:String x:Key="Text.Archive.File" xml:space="preserve">Save Archive To :</x:String>
+  <x:String x:Key="Text.Apply.WS" xml:space="preserve">Whitespace:</x:String>
+  <x:String x:Key="Text.Archive" xml:space="preserve">Archive...</x:String>
+  <x:String x:Key="Text.Archive.File" xml:space="preserve">Save Archive To:</x:String>
   <x:String x:Key="Text.Archive.File.Placeholder" xml:space="preserve">Select archive file path</x:String>
-  <x:String x:Key="Text.Archive.Revision" xml:space="preserve">Revision :</x:String>
+  <x:String x:Key="Text.Archive.Revision" xml:space="preserve">Revision:</x:String>
   <x:String x:Key="Text.Archive.Title" xml:space="preserve">Archive</x:String>
   <x:String x:Key="Text.AssumeUnchanged" xml:space="preserve">FILES ASSUME UNCHANGED</x:String>
   <x:String x:Key="Text.AssumeUnchanged.Empty" xml:space="preserve">NO FILES ASSUMED AS UNCHANGED</x:String>
@@ -32,23 +32,23 @@
   <x:String x:Key="Text.BinaryNotSupported" xml:space="preserve">BINARY FILE NOT SUPPORTED!!!</x:String>
   <x:String x:Key="Text.Blame" xml:space="preserve">Blame</x:String>
   <x:String x:Key="Text.BlameTypeNotSupported" xml:space="preserve">BLAME ON THIS FILE IS NOT SUPPORTED!!!</x:String>
-  <x:String x:Key="Text.BranchCM.Checkout" xml:space="preserve">Checkout${0}$</x:String>
+  <x:String x:Key="Text.BranchCM.Checkout" xml:space="preserve">Checkout${0}...</x:String>
   <x:String x:Key="Text.BranchCM.CompareWithBranch" xml:space="preserve">Compare with Branch</x:String>
   <x:String x:Key="Text.BranchCM.CompareWithHead" xml:space="preserve">Compare with HEAD</x:String>
   <x:String x:Key="Text.BranchCM.CompareWithWorktree" xml:space="preserve">Compare with Worktree</x:String>
   <x:String x:Key="Text.BranchCM.CopyName" xml:space="preserve">Copy Branch Name</x:String>
-  <x:String x:Key="Text.BranchCM.Delete" xml:space="preserve">Delete${0}$</x:String>
+  <x:String x:Key="Text.BranchCM.Delete" xml:space="preserve">Delete${0}...</x:String>
   <x:String x:Key="Text.BranchCM.DeleteMultiBranches" xml:space="preserve">Delete selected {0} branches</x:String>
   <x:String x:Key="Text.BranchCM.DiscardAll" xml:space="preserve">Discard all changes</x:String>
   <x:String x:Key="Text.BranchCM.FastForward" xml:space="preserve">Fast-Forward to${0}$</x:String>
   <x:String x:Key="Text.BranchCM.Finish" xml:space="preserve">Git Flow - Finish${0}$</x:String>
-  <x:String x:Key="Text.BranchCM.Merge" xml:space="preserve">Merge${0}$into${1}$</x:String>
+  <x:String x:Key="Text.BranchCM.Merge" xml:space="preserve">Merge${0}$into${1}...</x:String>
   <x:String x:Key="Text.BranchCM.Pull" xml:space="preserve">Pull${0}$</x:String>
-  <x:String x:Key="Text.BranchCM.PullInto" xml:space="preserve">Pull${0}$into${1}$</x:String>
+  <x:String x:Key="Text.BranchCM.PullInto" xml:space="preserve">Pull${0}$into${1}...</x:String>
   <x:String x:Key="Text.BranchCM.Push" xml:space="preserve">Push${0}$</x:String>
-  <x:String x:Key="Text.BranchCM.Rebase" xml:space="preserve">Rebase${0}$on${1}$</x:String>
-  <x:String x:Key="Text.BranchCM.Rename" xml:space="preserve">Rename${0}$</x:String>
-  <x:String x:Key="Text.BranchCM.Tracking" xml:space="preserve">Tracking ...</x:String>
+  <x:String x:Key="Text.BranchCM.Rebase" xml:space="preserve">Rebase${0}$on${1}...</x:String>
+  <x:String x:Key="Text.BranchCM.Rename" xml:space="preserve">Rename${0}...</x:String>
+  <x:String x:Key="Text.BranchCM.Tracking" xml:space="preserve">Set Tracking Branch</x:String>
   <x:String x:Key="Text.BranchCM.UnsetUpstream" xml:space="preserve">Unset Upstream</x:String>
   <x:String x:Key="Text.BranchCompare" xml:space="preserve">Branch Compare</x:String>
   <x:String x:Key="Text.Bytes" xml:space="preserve">Bytes</x:String>
@@ -60,25 +60,25 @@
   <x:String x:Key="Text.Checkout" xml:space="preserve">Checkout Branch</x:String>
   <x:String x:Key="Text.Checkout.Commit" xml:space="preserve">Checkout Commit</x:String>
   <x:String x:Key="Text.Checkout.Commit.Warning" xml:space="preserve">Warning: By doing a commit checkout, your Head will be detached</x:String>
-  <x:String x:Key="Text.Checkout.Commit.Target" xml:space="preserve">Commit :</x:String>
-  <x:String x:Key="Text.Checkout.Target" xml:space="preserve">Branch :</x:String>
-  <x:String x:Key="Text.Checkout.LocalChanges" xml:space="preserve">Local Changes :</x:String>
+  <x:String x:Key="Text.Checkout.Commit.Target" xml:space="preserve">Commit:</x:String>
+  <x:String x:Key="Text.Checkout.Target" xml:space="preserve">Branch:</x:String>
+  <x:String x:Key="Text.Checkout.LocalChanges" xml:space="preserve">Local Changes:</x:String>
   <x:String x:Key="Text.Checkout.LocalChanges.Discard" xml:space="preserve">Discard</x:String>
   <x:String x:Key="Text.Checkout.LocalChanges.DoNothing" xml:space="preserve">Do Nothing</x:String>
   <x:String x:Key="Text.Checkout.LocalChanges.StashAndReply" xml:space="preserve">Stash &amp; Reapply</x:String>
   <x:String x:Key="Text.CherryPick" xml:space="preserve">Cherry-Pick This Commit</x:String>
-  <x:String x:Key="Text.CherryPick.Commit" xml:space="preserve">Commit :</x:String>
+  <x:String x:Key="Text.CherryPick.Commit" xml:space="preserve">Commit:</x:String>
   <x:String x:Key="Text.CherryPick.CommitChanges" xml:space="preserve">Commit all changes</x:String>
   <x:String x:Key="Text.CherryPick.Title" xml:space="preserve">Cherry Pick</x:String>
   <x:String x:Key="Text.ClearStashes" xml:space="preserve">Clear Stashes</x:String>
   <x:String x:Key="Text.ClearStashes.Message" xml:space="preserve">You are trying to clear all stashes. Are you sure to continue?</x:String>
   <x:String x:Key="Text.Clone" xml:space="preserve">Clone Remote Repository</x:String>
-  <x:String x:Key="Text.Clone.AdditionalParam" xml:space="preserve">Extra Parameters :</x:String>
+  <x:String x:Key="Text.Clone.AdditionalParam" xml:space="preserve">Extra Parameters:</x:String>
   <x:String x:Key="Text.Clone.AdditionalParam.Placeholder" xml:space="preserve">Additional arguments to clone repository. Optional.</x:String>
-  <x:String x:Key="Text.Clone.LocalName" xml:space="preserve">Local Name :</x:String>
+  <x:String x:Key="Text.Clone.LocalName" xml:space="preserve">Local Name:</x:String>
   <x:String x:Key="Text.Clone.LocalName.Placeholder" xml:space="preserve">Repository name. Optional.</x:String>
-  <x:String x:Key="Text.Clone.ParentFolder" xml:space="preserve">Parent Folder :</x:String>
-  <x:String x:Key="Text.Clone.RemoteURL" xml:space="preserve">Repository URL :</x:String>
+  <x:String x:Key="Text.Clone.ParentFolder" xml:space="preserve">Parent Folder:</x:String>
+  <x:String x:Key="Text.Clone.RemoteURL" xml:space="preserve">Repository URL:</x:String>
   <x:String x:Key="Text.Close" xml:space="preserve">CLOSE</x:String>
   <x:String x:Key="Text.CommitCM.CherryPick" xml:space="preserve">Cherry-Pick This Commit</x:String>
   <x:String x:Key="Text.CommitCM.Checkout" xml:space="preserve">Checkout Commit</x:String>
@@ -89,10 +89,10 @@
   <x:String x:Key="Text.CommitCM.Reset" xml:space="preserve">Reset${0}$to Here</x:String>
   <x:String x:Key="Text.CommitCM.Revert" xml:space="preserve">Revert Commit</x:String>
   <x:String x:Key="Text.CommitCM.Reword" xml:space="preserve">Reword</x:String>
-  <x:String x:Key="Text.CommitCM.SaveAsPatch" xml:space="preserve">Save as Patch ...</x:String>
+  <x:String x:Key="Text.CommitCM.SaveAsPatch" xml:space="preserve">Save as Patch...</x:String>
   <x:String x:Key="Text.CommitCM.Squash" xml:space="preserve">Squash Into Parent</x:String>
   <x:String x:Key="Text.CommitDetail.Changes" xml:space="preserve">CHANGES</x:String>
-  <x:String x:Key="Text.CommitDetail.Changes.Search" xml:space="preserve">Search Changes ...</x:String>
+  <x:String x:Key="Text.CommitDetail.Changes.Search" xml:space="preserve">Search Changes...</x:String>
   <x:String x:Key="Text.CommitDetail.Files" xml:space="preserve">FILES</x:String>
   <x:String x:Key="Text.CommitDetail.Files.LFS" xml:space="preserve">LFS File</x:String>
   <x:String x:Key="Text.CommitDetail.Files.Submodule" xml:space="preserve">Submodule</x:String>
@@ -114,43 +114,43 @@
   <x:String x:Key="Text.Copy" xml:space="preserve">Copy</x:String>
   <x:String x:Key="Text.CopyPath" xml:space="preserve">Copy Path</x:String>
   <x:String x:Key="Text.CopyFileName" xml:space="preserve">Copy File Name</x:String>
-  <x:String x:Key="Text.CreateBranch" xml:space="preserve">Create Branch</x:String>
-  <x:String x:Key="Text.CreateBranch.BasedOn" xml:space="preserve">Based On :</x:String>
-  <x:String x:Key="Text.CreateBranch.Checkout" xml:space="preserve">Check out after created</x:String>
-  <x:String x:Key="Text.CreateBranch.LocalChanges" xml:space="preserve">Local Changes :</x:String>
+  <x:String x:Key="Text.CreateBranch" xml:space="preserve">Create Branch...</x:String>
+  <x:String x:Key="Text.CreateBranch.BasedOn" xml:space="preserve">Based On:</x:String>
+  <x:String x:Key="Text.CreateBranch.Checkout" xml:space="preserve">Check out the created branch</x:String>
+  <x:String x:Key="Text.CreateBranch.LocalChanges" xml:space="preserve">Local Changes:</x:String>
   <x:String x:Key="Text.CreateBranch.LocalChanges.Discard" xml:space="preserve">Discard</x:String>
   <x:String x:Key="Text.CreateBranch.LocalChanges.DoNothing" xml:space="preserve">Do Nothing</x:String>
   <x:String x:Key="Text.CreateBranch.LocalChanges.StashAndReply" xml:space="preserve">Stash &amp; Reapply</x:String>
-  <x:String x:Key="Text.CreateBranch.Name" xml:space="preserve">New Branch Name :</x:String>
+  <x:String x:Key="Text.CreateBranch.Name" xml:space="preserve">New Branch Name:</x:String>
   <x:String x:Key="Text.CreateBranch.Name.Placeholder" xml:space="preserve">Enter branch name.</x:String>
   <x:String x:Key="Text.CreateBranch.Title" xml:space="preserve">Create Local Branch</x:String>
-  <x:String x:Key="Text.CreateTag" xml:space="preserve">Create Tag</x:String>
-  <x:String x:Key="Text.CreateTag.BasedOn" xml:space="preserve">New Tag At :</x:String>
+  <x:String x:Key="Text.CreateTag" xml:space="preserve">Create Tag...</x:String>
+  <x:String x:Key="Text.CreateTag.BasedOn" xml:space="preserve">New Tag At:</x:String>
   <x:String x:Key="Text.CreateTag.GPGSign" xml:space="preserve">GPG signing</x:String>
-  <x:String x:Key="Text.CreateTag.Message" xml:space="preserve">Tag Message :</x:String>
+  <x:String x:Key="Text.CreateTag.Message" xml:space="preserve">Tag Message:</x:String>
   <x:String x:Key="Text.CreateTag.Message.Placeholder" xml:space="preserve">Optional.</x:String>
-  <x:String x:Key="Text.CreateTag.Name" xml:space="preserve">Tag Name :</x:String>
-  <x:String x:Key="Text.CreateTag.Name.Placeholder" xml:space="preserve">Recommended format ：v1.0.0-alpha</x:String>
+  <x:String x:Key="Text.CreateTag.Name" xml:space="preserve">Tag Name:</x:String>
+  <x:String x:Key="Text.CreateTag.Name.Placeholder" xml:space="preserve">Recommended format: v1.0.0-alpha</x:String>
   <x:String x:Key="Text.CreateTag.PushToAllRemotes" xml:space="preserve">Push to all remotes after created</x:String>
-  <x:String x:Key="Text.CreateTag.Type" xml:space="preserve">Kind ：</x:String>
+  <x:String x:Key="Text.CreateTag.Type" xml:space="preserve">Kind:</x:String>
   <x:String x:Key="Text.CreateTag.Type.Annotated" xml:space="preserve">annotated</x:String>
   <x:String x:Key="Text.CreateTag.Type.Lightweight" xml:space="preserve">lightweight</x:String>
   <x:String x:Key="Text.Cut" xml:space="preserve">Cut</x:String>
   <x:String x:Key="Text.DeleteBranch" xml:space="preserve">Delete Branch</x:String>
-  <x:String x:Key="Text.DeleteBranch.Branch" xml:space="preserve">Branch :</x:String>
+  <x:String x:Key="Text.DeleteBranch.Branch" xml:space="preserve">Branch:</x:String>
   <x:String x:Key="Text.DeleteBranch.IsRemoteTip" xml:space="preserve">You are about to delete a remote branch!!!</x:String>
   <x:String x:Key="Text.DeleteBranch.WithTrackingRemote" xml:space="preserve">Also delete remote branch${0}$</x:String>
   <x:String x:Key="Text.DeleteMultiBranch" xml:space="preserve">Delete Multiple Branches</x:String>
   <x:String x:Key="Text.DeleteMultiBranch.Tip" xml:space="preserve">You are trying to delete multiple branches at one time. Be sure to double-check before taking action!</x:String>
   <x:String x:Key="Text.DeleteRemote" xml:space="preserve">Delete Remote</x:String>
-  <x:String x:Key="Text.DeleteRemote.Remote" xml:space="preserve">Remote :</x:String>
-  <x:String x:Key="Text.DeleteRepositoryNode.Target" xml:space="preserve">Target :</x:String>
+  <x:String x:Key="Text.DeleteRemote.Remote" xml:space="preserve">Remote:</x:String>
+  <x:String x:Key="Text.DeleteRepositoryNode.Target" xml:space="preserve">Target:</x:String>
   <x:String x:Key="Text.DeleteRepositoryNode.TitleForGroup" xml:space="preserve">Confirm Deleting Group</x:String>
   <x:String x:Key="Text.DeleteRepositoryNode.TitleForRepository" xml:space="preserve">Confirm Deleting Repository</x:String>
   <x:String x:Key="Text.DeleteSubmodule" xml:space="preserve">Delete Submodule</x:String>
-  <x:String x:Key="Text.DeleteSubmodule.Path" xml:space="preserve">Submodule Path ：</x:String>
+  <x:String x:Key="Text.DeleteSubmodule.Path" xml:space="preserve">Submodule Path:</x:String>
   <x:String x:Key="Text.DeleteTag" xml:space="preserve">Delete Tag</x:String>
-  <x:String x:Key="Text.DeleteTag.Tag" xml:space="preserve">Tag :</x:String>
+  <x:String x:Key="Text.DeleteTag.Tag" xml:space="preserve">Tag:</x:String>
   <x:String x:Key="Text.DeleteTag.WithRemote" xml:space="preserve">Delete from remote repositories</x:String>
   <x:String x:Key="Text.Diff.Binary" xml:space="preserve">BINARY DIFF</x:String>
   <x:String x:Key="Text.Diff.Binary.New" xml:space="preserve">NEW</x:String>
@@ -173,19 +173,19 @@
   <x:String x:Key="Text.DiffWithMerger" xml:space="preserve">Open In Merge Tool</x:String>
   <x:String x:Key="Text.Discard" xml:space="preserve">Discard Changes</x:String>
   <x:String x:Key="Text.Discard.All" xml:space="preserve">All local changes in working copy.</x:String>
-  <x:String x:Key="Text.Discard.Changes" xml:space="preserve">Changes :</x:String>
+  <x:String x:Key="Text.Discard.Changes" xml:space="preserve">Changes:</x:String>
   <x:String x:Key="Text.Discard.Total" xml:space="preserve">Total {0} changes will be discard</x:String>
   <x:String x:Key="Text.Discard.Warning" xml:space="preserve">You can't undo this action!!!</x:String>
-  <x:String x:Key="Text.EditRepositoryNode.Bookmark" xml:space="preserve">Bookmark :</x:String>
-  <x:String x:Key="Text.EditRepositoryNode.Name" xml:space="preserve">New Name :</x:String>
-  <x:String x:Key="Text.EditRepositoryNode.Target" xml:space="preserve">Target :</x:String>
+  <x:String x:Key="Text.EditRepositoryNode.Bookmark" xml:space="preserve">Bookmark:</x:String>
+  <x:String x:Key="Text.EditRepositoryNode.Name" xml:space="preserve">New Name:</x:String>
+  <x:String x:Key="Text.EditRepositoryNode.Target" xml:space="preserve">Target:</x:String>
   <x:String x:Key="Text.EditRepositoryNode.TitleForGroup" xml:space="preserve">Edit Selected Group</x:String>
   <x:String x:Key="Text.EditRepositoryNode.TitleForRepository" xml:space="preserve">Edit Selected Repository</x:String>
   <x:String x:Key="Text.FastForwardWithoutCheck" xml:space="preserve">Fast-Forward (without checkout)</x:String>
   <x:String x:Key="Text.Fetch" xml:space="preserve">Fetch</x:String>
   <x:String x:Key="Text.Fetch.AllRemotes" xml:space="preserve">Fetch all remotes</x:String>
   <x:String x:Key="Text.Fetch.Prune" xml:space="preserve">Prune remote dead branches</x:String>
-  <x:String x:Key="Text.Fetch.Remote" xml:space="preserve">Remote :</x:String>
+  <x:String x:Key="Text.Fetch.Remote" xml:space="preserve">Remote:</x:String>
   <x:String x:Key="Text.Fetch.Title" xml:space="preserve">Fetch Remote Changes</x:String>
   <x:String x:Key="Text.FileCM.AssumeUnchanged" xml:space="preserve">Assume unchanged</x:String>
   <x:String x:Key="Text.FileCM.Discard" xml:space="preserve">Discard...</x:String>
@@ -193,8 +193,8 @@
   <x:String x:Key="Text.FileCM.DiscardSelectedLines" xml:space="preserve">Discard Changes in Selected Line(s)</x:String>
   <x:String x:Key="Text.FileCM.OpenWithExternalMerger" xml:space="preserve">Open External Merge Tool</x:String>
   <x:String x:Key="Text.FileCM.SaveAsPatch" xml:space="preserve">Save As Patch...</x:String>
-  <x:String x:Key="Text.FileCM.Stage" xml:space="preserve">Stage...</x:String>
-  <x:String x:Key="Text.FileCM.StageMulti" xml:space="preserve">Stage {0} files...</x:String>
+  <x:String x:Key="Text.FileCM.Stage" xml:space="preserve">Stage</x:String>
+  <x:String x:Key="Text.FileCM.StageMulti" xml:space="preserve">Stage {0} files</x:String>
   <x:String x:Key="Text.FileCM.StageSelectedLines" xml:space="preserve">Stage Changes in Selected Line(s)</x:String>
   <x:String x:Key="Text.FileCM.Stash" xml:space="preserve">Stash...</x:String>
   <x:String x:Key="Text.FileCM.StashMulti" xml:space="preserve">Stash {0} files...</x:String>
@@ -206,28 +206,28 @@
   <x:String x:Key="Text.FileHistory" xml:space="preserve">File History</x:String>
   <x:String x:Key="Text.Filter" xml:space="preserve">FILTER</x:String>
   <x:String x:Key="Text.GitFlow" xml:space="preserve">Git-Flow</x:String>
-  <x:String x:Key="Text.GitFlow.DevelopBranch" xml:space="preserve">Development Branch :</x:String>
-  <x:String x:Key="Text.GitFlow.Feature" xml:space="preserve">Feature :</x:String>
-  <x:String x:Key="Text.GitFlow.FeaturePrefix" xml:space="preserve">Feature Prefix :</x:String>
+  <x:String x:Key="Text.GitFlow.DevelopBranch" xml:space="preserve">Development Branch:</x:String>
+  <x:String x:Key="Text.GitFlow.Feature" xml:space="preserve">Feature:</x:String>
+  <x:String x:Key="Text.GitFlow.FeaturePrefix" xml:space="preserve">Feature Prefix:</x:String>
   <x:String x:Key="Text.GitFlow.FinishFeature" xml:space="preserve">FLOW - Finish Feature</x:String>
   <x:String x:Key="Text.GitFlow.FinishHotfix" xml:space="preserve">FLOW - Finish Hotfix</x:String>
   <x:String x:Key="Text.GitFlow.FinishRelease" xml:space="preserve">FLOW - Finish Release</x:String>
-  <x:String x:Key="Text.GitFlow.FinishTarget" xml:space="preserve">Target :</x:String>
-  <x:String x:Key="Text.GitFlow.Hotfix" xml:space="preserve">Hotfix :</x:String>
-  <x:String x:Key="Text.GitFlow.HotfixPrefix" xml:space="preserve">Hotfix Prefix :</x:String>
+  <x:String x:Key="Text.GitFlow.FinishTarget" xml:space="preserve">Target:</x:String>
+  <x:String x:Key="Text.GitFlow.Hotfix" xml:space="preserve">Hotfix:</x:String>
+  <x:String x:Key="Text.GitFlow.HotfixPrefix" xml:space="preserve">Hotfix Prefix:</x:String>
   <x:String x:Key="Text.GitFlow.Init" xml:space="preserve">Initialize Git-Flow</x:String>
   <x:String x:Key="Text.GitFlow.KeepBranchAfterFinish" xml:space="preserve">Keep branch</x:String>
-  <x:String x:Key="Text.GitFlow.ProductionBranch" xml:space="preserve">Production Branch :</x:String>
-  <x:String x:Key="Text.GitFlow.Release" xml:space="preserve">Release :</x:String>
-  <x:String x:Key="Text.GitFlow.ReleasePrefix" xml:space="preserve">Release Prefix :</x:String>
-  <x:String x:Key="Text.GitFlow.StartFeature" xml:space="preserve">Start Feature ...</x:String>
+  <x:String x:Key="Text.GitFlow.ProductionBranch" xml:space="preserve">Production Branch:</x:String>
+  <x:String x:Key="Text.GitFlow.Release" xml:space="preserve">Release:</x:String>
+  <x:String x:Key="Text.GitFlow.ReleasePrefix" xml:space="preserve">Release Prefix:</x:String>
+  <x:String x:Key="Text.GitFlow.StartFeature" xml:space="preserve">Start Feature...</x:String>
   <x:String x:Key="Text.GitFlow.StartFeatureTitle" xml:space="preserve">FLOW - Start Feature</x:String>
-  <x:String x:Key="Text.GitFlow.StartHotfix" xml:space="preserve">Start Hotfix ...</x:String>
+  <x:String x:Key="Text.GitFlow.StartHotfix" xml:space="preserve">Start Hotfix...</x:String>
   <x:String x:Key="Text.GitFlow.StartHotfixTitle" xml:space="preserve">FLOW - Start Hotfix</x:String>
   <x:String x:Key="Text.GitFlow.StartPlaceholder" xml:space="preserve">Enter name</x:String>
-  <x:String x:Key="Text.GitFlow.StartRelease" xml:space="preserve">Start Release ...</x:String>
+  <x:String x:Key="Text.GitFlow.StartRelease" xml:space="preserve">Start Release...</x:String>
   <x:String x:Key="Text.GitFlow.StartReleaseTitle" xml:space="preserve">FLOW - Start Release</x:String>
-  <x:String x:Key="Text.GitFlow.TagPrefix" xml:space="preserve">Version Tag Prefix :</x:String>
+  <x:String x:Key="Text.GitFlow.TagPrefix" xml:space="preserve">Version Tag Prefix:</x:String>
   <x:String x:Key="Text.GitLFS" xml:space="preserve">Git LFS</x:String>
   <x:String x:Key="Text.GitLFS.Fetch" xml:space="preserve">Fetch ...</x:String>
   <x:String x:Key="Text.GitLFS.Fetch.Title" xml:space="preserve">Fetch LFS Objects</x:String>
@@ -275,7 +275,7 @@
   <x:String x:Key="Text.Hotkeys.TextEditor.GotoPrevMatch" xml:space="preserve">Find previous match</x:String>
   <x:String x:Key="Text.Hotkeys.TextEditor.Search" xml:space="preserve">Open search panel</x:String>
   <x:String x:Key="Text.Init" xml:space="preserve">Initialize Repository</x:String>
-  <x:String x:Key="Text.Init.Path" xml:space="preserve">Path :</x:String>
+  <x:String x:Key="Text.Init.Path" xml:space="preserve">Path:</x:String>
   <x:String x:Key="Text.Init.Tip" xml:space="preserve">Invalid repository detected. Run `git init` under this path?</x:String>
   <x:String x:Key="Text.InProgress.CherryPick" xml:space="preserve">Cherry-Pick in progress. Press 'Abort' to restore original HEAD.</x:String>
   <x:String x:Key="Text.InProgress.Merge" xml:space="preserve">Merge request in progress. Press 'Abort' to restore original HEAD.</x:String>
@@ -286,14 +286,14 @@
   <x:String x:Key="Text.Launcher.Info" xml:space="preserve">NOTICE</x:String>
   <x:String x:Key="Text.Launcher.Menu" xml:space="preserve">Open Main Menu</x:String>
   <x:String x:Key="Text.Merge" xml:space="preserve">Merge Branch</x:String>
-  <x:String x:Key="Text.Merge.Into" xml:space="preserve">Into :</x:String>
-  <x:String x:Key="Text.Merge.Mode" xml:space="preserve">Merge Option :</x:String>
-  <x:String x:Key="Text.Merge.Source" xml:space="preserve">Source Branch :</x:String>
-  <x:String x:Key="Text.Name" xml:space="preserve">Name :</x:String>
+  <x:String x:Key="Text.Merge.Into" xml:space="preserve">Into:</x:String>
+  <x:String x:Key="Text.Merge.Mode" xml:space="preserve">Merge Option:</x:String>
+  <x:String x:Key="Text.Merge.Source" xml:space="preserve">Source Branch:</x:String>
+  <x:String x:Key="Text.Name" xml:space="preserve">Name:</x:String>
   <x:String x:Key="Text.NotConfigured" xml:space="preserve">Git has NOT been configured. Please to go [Preference] and configure it first.</x:String>
   <x:String x:Key="Text.Notice" xml:space="preserve">NOTICE</x:String>
   <x:String x:Key="Text.OpenFolder" xml:space="preserve">SELECT FOLDER</x:String>
-  <x:String x:Key="Text.OpenWith" xml:space="preserve">Open With ...</x:String>
+  <x:String x:Key="Text.OpenWith" xml:space="preserve">Open With...</x:String>
   <x:String x:Key="Text.Optional" xml:space="preserve">Optional.</x:String>
   <x:String x:Key="Text.PageTabBar.New" xml:space="preserve">Create New Page</x:String>
   <x:String x:Key="Text.PageTabBar.Tab.Bookmark" xml:space="preserve">Bookmark</x:String>
@@ -346,51 +346,52 @@
   <x:String x:Key="Text.Preference.Merger.Path.Placeholder" xml:space="preserve">Input path for merge tool</x:String>
   <x:String x:Key="Text.Preference.Merger.Type" xml:space="preserve">Merger</x:String>
   <x:String x:Key="Text.PruneRemote" xml:space="preserve">Prune Remote</x:String>
-  <x:String x:Key="Text.PruneRemote.Target" xml:space="preserve">Target :</x:String>
+  <x:String x:Key="Text.PruneRemote.Target" xml:space="preserve">Target:</x:String>
   <x:String x:Key="Text.Pull" xml:space="preserve">Pull</x:String>
-  <x:String x:Key="Text.Pull.Branch" xml:space="preserve">Branch :</x:String>
-  <x:String x:Key="Text.Pull.Into" xml:space="preserve">Into :</x:String>
-  <x:String x:Key="Text.Pull.LocalChanges" xml:space="preserve">Local Changes :</x:String>
+  <x:String x:Key="Text.Pull.Branch" xml:space="preserve">Branch:</x:String>
+  <x:String x:Key="Text.Pull.Into" xml:space="preserve">Into:</x:String>
+  <x:String x:Key="Text.Pull.LocalChanges" xml:space="preserve">Local Changes:</x:String>
   <x:String x:Key="Text.Pull.LocalChanges.Discard" xml:space="preserve">Discard</x:String>
   <x:String x:Key="Text.Pull.LocalChanges.DoNothing" xml:space="preserve">Do Nothing</x:String>
   <x:String x:Key="Text.Pull.LocalChanges.StashAndReply" xml:space="preserve">Stash &amp; Reapply</x:String>
-  <x:String x:Key="Text.Pull.Remote" xml:space="preserve">Remote :</x:String>
+  <x:String x:Key="Text.Pull.Remote" xml:space="preserve">Remote:</x:String>
   <x:String x:Key="Text.Pull.Title" xml:space="preserve">Pull (Fetch &amp; Merge)</x:String>
   <x:String x:Key="Text.Pull.UseRebase" xml:space="preserve">Use rebase instead of merge</x:String>
   <x:String x:Key="Text.Push" xml:space="preserve">Push</x:String>
   <x:String x:Key="Text.Push.Force" xml:space="preserve">Force push</x:String>
-  <x:String x:Key="Text.Push.Local" xml:space="preserve">Local Branch :</x:String>
-  <x:String x:Key="Text.Push.Remote" xml:space="preserve">Remote :</x:String>
+  <x:String x:Key="Text.Push.Local" xml:space="preserve">Local Branch:</x:String>
+  <x:String x:Key="Text.Push.Remote" xml:space="preserve">Remote:</x:String>
   <x:String x:Key="Text.Push.Title" xml:space="preserve">Push Changes To Remote</x:String>
-  <x:String x:Key="Text.Push.To" xml:space="preserve">Remote Branch :</x:String>
-  <x:String x:Key="Text.Push.Tracking" xml:space="preserve">Tracking remote branch</x:String>
+  <x:String x:Key="Text.Push.To" xml:space="preserve">Remote Branch:</x:String>
+  <x:String x:Key="Text.Push.Tracking" xml:space="preserve">Set as tracking branch</x:String>
   <x:String x:Key="Text.Push.WithAllTags" xml:space="preserve">Push all tags</x:String>
   <x:String x:Key="Text.PushTag" xml:space="preserve">Push Tag To Remote</x:String>
   <x:String x:Key="Text.PushTag.PushAllRemotes" xml:space="preserve">Push to all remotes</x:String>
-  <x:String x:Key="Text.PushTag.Remote" xml:space="preserve">Remote :</x:String>
-  <x:String x:Key="Text.PushTag.Tag" xml:space="preserve">Tag :</x:String>
+  <x:String x:Key="Text.PushTag.Remote" xml:space="preserve">Remote:</x:String>
+  <x:String x:Key="Text.PushTag.Tag" xml:space="preserve">Tag:</x:String>
   <x:String x:Key="Text.Quit" xml:space="preserve">Quit</x:String>
   <x:String x:Key="Text.Rebase" xml:space="preserve">Rebase Current Branch</x:String>
   <x:String x:Key="Text.Rebase.AutoStash" xml:space="preserve">Stash &amp; reapply local changes</x:String>
-  <x:String x:Key="Text.Rebase.On" xml:space="preserve">On :</x:String>
-  <x:String x:Key="Text.Rebase.Target" xml:space="preserve">Rebase :</x:String>
+  <x:String x:Key="Text.Rebase.On" xml:space="preserve">On:</x:String>
+  <x:String x:Key="Text.Rebase.Target" xml:space="preserve">Rebase:</x:String>
   <x:String x:Key="Text.RefetchAvatar" xml:space="preserve">Refresh</x:String>
   <x:String x:Key="Text.Remote.AddTitle" xml:space="preserve">Add Remote</x:String>
   <x:String x:Key="Text.Remote.EditTitle" xml:space="preserve">Edit Remote</x:String>
-  <x:String x:Key="Text.Remote.Name" xml:space="preserve">Name :</x:String>
+  <x:String x:Key="Text.Remote.Name" xml:space="preserve">Name:</x:String>
   <x:String x:Key="Text.Remote.Name.Placeholder" xml:space="preserve">Remote name</x:String>
-  <x:String x:Key="Text.Remote.URL" xml:space="preserve">Repository URL :</x:String>
+  <x:String x:Key="Text.Remote.URL" xml:space="preserve">Repository URL:</x:String>
   <x:String x:Key="Text.Remote.URL.Placeholder" xml:space="preserve">Remote git repository URL</x:String>
   <x:String x:Key="Text.RemoteCM.CopyURL" xml:space="preserve">Copy URL</x:String>
-  <x:String x:Key="Text.RemoteCM.Delete" xml:space="preserve">Delete ...</x:String>
-  <x:String x:Key="Text.RemoteCM.Edit" xml:space="preserve">Edit ...</x:String>
-  <x:String x:Key="Text.RemoteCM.Fetch" xml:space="preserve">Fetch ...</x:String>
+  <x:String x:Key="Text.RemoteCM.Delete" xml:space="preserve">Delete...</x:String>
+  <x:String x:Key="Text.RemoteCM.Edit" xml:space="preserve">Edit...</x:String>
+  <x:String x:Key="Text.RemoteCM.Fetch" xml:space="preserve">Fetch</x:String>
   <x:String x:Key="Text.RemoteCM.OpenInBrowser" xml:space="preserve">Open In Browser</x:String>
-  <x:String x:Key="Text.RemoteCM.Prune" xml:space="preserve">Prune ...</x:String>
+  <x:String x:Key="Text.RemoteCM.Prune" xml:space="preserve">Prune</x:String>
+  <x:String x:Key="Text.RemoteCM.Prune.Target" xml:space="preserve">Target:</x:String>
   <x:String x:Key="Text.RenameBranch" xml:space="preserve">Rename Branch</x:String>
-  <x:String x:Key="Text.RenameBranch.Name" xml:space="preserve">New Name :</x:String>
+  <x:String x:Key="Text.RenameBranch.Name" xml:space="preserve">New Name:</x:String>
   <x:String x:Key="Text.RenameBranch.Name.Placeholder" xml:space="preserve">Unique name for this branch</x:String>
-  <x:String x:Key="Text.RenameBranch.Target" xml:space="preserve">Branch :</x:String>
+  <x:String x:Key="Text.RenameBranch.Target" xml:space="preserve">Branch:</x:String>
   <x:String x:Key="Text.Repository.Abort" xml:space="preserve">ABORT</x:String>
   <x:String x:Key="Text.Repository.Clean" xml:space="preserve">Cleanup(GC &amp; Prune)</x:String>
   <x:String x:Key="Text.Repository.CleanTips" xml:space="preserve">Run `git gc` command for this repository.</x:String>
@@ -400,7 +401,7 @@
   <x:String x:Key="Text.Repository.FilterBranchTip" xml:space="preserve">Filter Branches</x:String>
   <x:String x:Key="Text.Repository.LocalBranches" xml:space="preserve">LOCAL BRANCHES</x:String>
   <x:String x:Key="Text.Repository.NavigateToCurrentHead" xml:space="preserve">Navigate To HEAD</x:String>
-  <x:String x:Key="Text.Repository.NewBranch" xml:space="preserve">Create Branch</x:String>
+  <x:String x:Key="Text.Repository.NewBranch" xml:space="preserve">Create Branch...</x:String>
   <x:String x:Key="Text.Repository.OpenIn" xml:space="preserve">Open In {0}</x:String>
   <x:String x:Key="Text.Repository.OpenWithExternalTools" xml:space="preserve">Open In External Tools</x:String>
   <x:String x:Key="Text.Repository.Refresh" xml:space="preserve">Refresh</x:String>
@@ -421,21 +422,21 @@
   <x:String x:Key="Text.Repository.Workspace" xml:space="preserve">WORKSPACE</x:String>
   <x:String x:Key="Text.RepositoryURL" xml:space="preserve">Git Repository URL</x:String>
   <x:String x:Key="Text.Reset" xml:space="preserve">Reset Current Branch To Revision</x:String>
-  <x:String x:Key="Text.Reset.Mode" xml:space="preserve">Reset Mode :</x:String>
-  <x:String x:Key="Text.Reset.MoveTo" xml:space="preserve">Move To :</x:String>
-  <x:String x:Key="Text.Reset.Target" xml:space="preserve">Current Branch :</x:String>
+  <x:String x:Key="Text.Reset.Mode" xml:space="preserve">Reset Mode:</x:String>
+  <x:String x:Key="Text.Reset.MoveTo" xml:space="preserve">Move To:</x:String>
+  <x:String x:Key="Text.Reset.Target" xml:space="preserve">Current Branch:</x:String>
   <x:String x:Key="Text.RevealFile" xml:space="preserve">Reveal in File Explorer</x:String>
   <x:String x:Key="Text.Revert" xml:space="preserve">Revert Commit</x:String>
-  <x:String x:Key="Text.Revert.Commit" xml:space="preserve">Commit :</x:String>
+  <x:String x:Key="Text.Revert.Commit" xml:space="preserve">Commit:</x:String>
   <x:String x:Key="Text.Revert.CommitChanges" xml:space="preserve">Commit revert changes</x:String>
   <x:String x:Key="Text.Reword" xml:space="preserve">Reword Commit Message</x:String>
-  <x:String x:Key="Text.Reword.Message" xml:space="preserve">Message :</x:String>
-  <x:String x:Key="Text.Reword.On" xml:space="preserve">On :</x:String>
-  <x:String x:Key="Text.Running" xml:space="preserve">Running. Please wait ...</x:String>
+  <x:String x:Key="Text.Reword.Message" xml:space="preserve">Message:</x:String>
+  <x:String x:Key="Text.Reword.On" xml:space="preserve">On:</x:String>
+  <x:String x:Key="Text.Running" xml:space="preserve">Running. Please wait...</x:String>
   <x:String x:Key="Text.Save" xml:space="preserve">SAVE</x:String>
-  <x:String x:Key="Text.SaveAs" xml:space="preserve">Save As ...</x:String>
+  <x:String x:Key="Text.SaveAs" xml:space="preserve">Save As...</x:String>
   <x:String x:Key="Text.SaveAsPatchSuccess" xml:space="preserve">Patch has been saved successfully!</x:String>
-  <x:String x:Key="Text.SelfUpdate" xml:space="preserve">Check for Updates ...</x:String>
+  <x:String x:Key="Text.SelfUpdate" xml:space="preserve">Check for Updates...</x:String>
   <x:String x:Key="Text.SelfUpdate.Available" xml:space="preserve">New version of this software is available: </x:String>
   <x:String x:Key="Text.SelfUpdate.Error" xml:space="preserve">Check for updates failed!</x:String>
   <x:String x:Key="Text.SelfUpdate.GotoDownload" xml:space="preserve">Download</x:String>
@@ -443,22 +444,22 @@
   <x:String x:Key="Text.SelfUpdate.Title" xml:space="preserve">Software Update</x:String>
   <x:String x:Key="Text.SelfUpdate.UpToDate" xml:space="preserve">There are currently no updates available.</x:String>
   <x:String x:Key="Text.Squash" xml:space="preserve">Squash HEAD Into Parent</x:String>
-  <x:String x:Key="Text.Squash.Head" xml:space="preserve">HEAD :</x:String>
-  <x:String x:Key="Text.Squash.Message" xml:space="preserve">Reword :</x:String>
-  <x:String x:Key="Text.Squash.To" xml:space="preserve">To :</x:String>
-  <x:String x:Key="Text.SSHKey" xml:space="preserve">SSH Private Key :</x:String>
+  <x:String x:Key="Text.Squash.Head" xml:space="preserve">HEAD:</x:String>
+  <x:String x:Key="Text.Squash.Message" xml:space="preserve">Reword:</x:String>
+  <x:String x:Key="Text.Squash.To" xml:space="preserve">To:</x:String>
+  <x:String x:Key="Text.SSHKey" xml:space="preserve">SSH Private Key:</x:String>
   <x:String x:Key="Text.SSHKey.Placeholder" xml:space="preserve">Private SSH key store path</x:String>
   <x:String x:Key="Text.Start" xml:space="preserve">START</x:String>
   <x:String x:Key="Text.Stash" xml:space="preserve">Stash</x:String>
   <x:String x:Key="Text.Stash.IncludeUntracked" xml:space="preserve">Include untracked files</x:String>
-  <x:String x:Key="Text.Stash.Message" xml:space="preserve">Message :</x:String>
+  <x:String x:Key="Text.Stash.Message" xml:space="preserve">Message:</x:String>
   <x:String x:Key="Text.Stash.Message.Placeholder" xml:space="preserve">Optional. Name of this stash</x:String>
   <x:String x:Key="Text.Stash.Title" xml:space="preserve">Stash Local Changes</x:String>
   <x:String x:Key="Text.StashCM.Apply" xml:space="preserve">Apply</x:String>
   <x:String x:Key="Text.StashCM.Drop" xml:space="preserve">Drop</x:String>
   <x:String x:Key="Text.StashCM.Pop" xml:space="preserve">Pop</x:String>
   <x:String x:Key="Text.StashDropConfirm" xml:space="preserve">Drop Stash</x:String>
-  <x:String x:Key="Text.StashDropConfirm.Label" xml:space="preserve">Drop :</x:String>
+  <x:String x:Key="Text.StashDropConfirm.Label" xml:space="preserve">Drop:</x:String>
   <x:String x:Key="Text.Stashes" xml:space="preserve">Stashes</x:String>
   <x:String x:Key="Text.Stashes.Changes" xml:space="preserve">CHANGES</x:String>
   <x:String x:Key="Text.Stashes.Stashes" xml:space="preserve">STASHES</x:String>
@@ -475,14 +476,14 @@
   <x:String x:Key="Text.Submodule.CopyPath" xml:space="preserve">Copy Relative Path</x:String>
   <x:String x:Key="Text.Submodule.FetchNested" xml:space="preserve">Fetch nested submodules</x:String>
   <x:String x:Key="Text.Submodule.Open" xml:space="preserve">Open Submodule Repository</x:String>
-  <x:String x:Key="Text.Submodule.RelativePath" xml:space="preserve">Relative Path :</x:String>
+  <x:String x:Key="Text.Submodule.RelativePath" xml:space="preserve">Relative Path:</x:String>
   <x:String x:Key="Text.Submodule.RelativePath.Placeholder" xml:space="preserve">Relative folder to store this module.</x:String>
   <x:String x:Key="Text.Submodule.Remove" xml:space="preserve">Delete Submodule</x:String>
   <x:String x:Key="Text.Sure" xml:space="preserve">OK</x:String>
   <x:String x:Key="Text.TagCM.Copy" xml:space="preserve">Copy Tag Name</x:String>
-  <x:String x:Key="Text.TagCM.Delete" xml:space="preserve">Delete${0}$</x:String>
-  <x:String x:Key="Text.TagCM.Push" xml:space="preserve">Push${0}$</x:String>
-  <x:String x:Key="Text.URL" xml:space="preserve">URL :</x:String>
+  <x:String x:Key="Text.TagCM.Delete" xml:space="preserve">Delete${0}...</x:String>
+  <x:String x:Key="Text.TagCM.Push" xml:space="preserve">Push${0}...</x:String>
+  <x:String x:Key="Text.URL" xml:space="preserve">URL:</x:String>
   <x:String x:Key="Text.UpdateSubmodules" xml:space="preserve">Update Submodules</x:String>
   <x:String x:Key="Text.UpdateSubmodules.Tip" xml:space="preserve">Run `submodule update` command for this repository.</x:String>
   <x:String x:Key="Text.Warn" xml:space="preserve">Warning</x:String>
@@ -494,7 +495,7 @@
   <x:String x:Key="Text.Welcome.Edit" xml:space="preserve">Edit</x:String>
   <x:String x:Key="Text.Welcome.OpenOrInit" xml:space="preserve">Open Repository</x:String>
   <x:String x:Key="Text.Welcome.OpenTerminal" xml:space="preserve">Open Terminal</x:String>
-  <x:String x:Key="Text.Welcome.Search" xml:space="preserve">Search Repositories ...</x:String>
+  <x:String x:Key="Text.Welcome.Search" xml:space="preserve">Search Repositories...</x:String>
   <x:String x:Key="Text.Welcome.Sort" xml:space="preserve">Sort</x:String>
   <x:String x:Key="Text.WorkingCopy" xml:space="preserve">Changes</x:String>
   <x:String x:Key="Text.WorkingCopy.AddToGitIgnore" xml:space="preserve">Git Ignore</x:String>


### PR DESCRIPTION
- Menu entries that require additional input end with ellipsis.
- No blank space before ellipsis or colon.
- A few minor tweaks e.g. to unify the style of adjacent choices.

While I'm not a native English speaker, I'd like to suggest some changes to make the English translation better follow en-US conventions as well as the recommended use of ellipses in most interface guidelines to indicate further dialog or such, as [Apple puts it](https://developer.apple.com/design/human-interface-guidelines/menus):

> Append an ellipsis to a menu item’s label when the action requires more information before it can complete.