### PR TITLE
fix: show AddFolder menu in context menu of RepositoryNode

### DIFF
--- a/src/ViewModels/Preference.cs
+++ b/src/ViewModels/Preference.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
@@ -479,6 +480,12 @@ namespace SourceGit.ViewModels
         {
             var data = JsonSerializer.Serialize(_instance, JsonCodeGen.Default.Preference);
             File.WriteAllText(_savePath, data);
+        }
+
+        public static RepositoryNode FindParentNode(RepositoryNode node)
+        {
+            var container = FindNodeContainer(node, _instance._repositoryNodes);
+            return container == null ? null : _instance._repositoryNodes.FirstOrDefault(parentNode => parentNode.SubNodes == container);
         }
 
         private static RepositoryNode FindNodeRecursive(string id, AvaloniaList<RepositoryNode> collection)

--- a/src/ViewModels/Welcome.cs
+++ b/src/ViewModels/Welcome.cs
@@ -151,19 +151,7 @@ namespace SourceGit.ViewModels
                 menu.Items.Add(terminal);
             }
 
-            if (folderNode == null)
-            {
-                var addFolder = new MenuItem();
-                addFolder.Header = App.Text("Welcome.AddRootFolder");
-                addFolder.Icon = App.CreateMenuIcon("Icons.Folder.Add");
-                addFolder.Click += (_, e) =>
-                {
-                    AddRootNode();
-                    e.Handled = true;
-                };
-                menu.Items.Add(addFolder);
-            }
-            else
+            if (folderNode != null)
             {
                 var addSubFolder = new MenuItem();
                 addSubFolder.Header = App.Text("Welcome.AddSubFolder");

--- a/src/ViewModels/Welcome.cs
+++ b/src/ViewModels/Welcome.cs
@@ -23,7 +23,7 @@ namespace SourceGit.ViewModels
             set
             {
                 if (SetProperty(ref _searchFilter, value))
-                    Referesh();
+                    Refresh();
             }
         }
 
@@ -122,6 +122,9 @@ namespace SourceGit.ViewModels
                 e.Handled = true;
             };
             menu.Items.Add(edit);
+            
+            var parentNode = Preference.FindParentNode(node);
+            var folderNode = !node.IsRepository ? node : (parentNode is { IsRepository: false } ? parentNode : null);
 
             if (node.IsRepository)
             {
@@ -147,6 +150,19 @@ namespace SourceGit.ViewModels
                 };
                 menu.Items.Add(terminal);
             }
+
+            if (folderNode == null)
+            {
+                var addFolder = new MenuItem();
+                addFolder.Header = App.Text("Welcome.AddRootFolder");
+                addFolder.Icon = App.CreateMenuIcon("Icons.Folder.Add");
+                addFolder.Click += (_, e) =>
+                {
+                    AddRootNode();
+                    e.Handled = true;
+                };
+                menu.Items.Add(addFolder);
+            }
             else
             {
                 var addSubFolder = new MenuItem();
@@ -154,7 +170,7 @@ namespace SourceGit.ViewModels
                 addSubFolder.Icon = App.CreateMenuIcon("Icons.Folder.Add");
                 addSubFolder.Click += (_, e) =>
                 {
-                    node.AddSubFolder();
+                    folderNode.AddSubFolder();
                     e.Handled = true;
                 };
                 menu.Items.Add(addSubFolder);
@@ -173,7 +189,7 @@ namespace SourceGit.ViewModels
             return menu;
         }
 
-        private void Referesh()
+        private void Refresh()
         {
             if (string.IsNullOrWhiteSpace(_searchFilter))
             {

--- a/src/Views/Welcome.axaml
+++ b/src/Views/Welcome.axaml
@@ -22,6 +22,10 @@
         <Button Classes="icon_button" Width="32" Command="{Binding OpenTerminal}" ToolTip.Tip="{DynamicResource Text.Welcome.OpenTerminal}">
           <Path Width="13" Height="13" Data="{StaticResource Icons.Terminal}"/>
         </Button>
+
+        <Button Classes="icon_button" Width="32" Command="{Binding AddRootNode}" ToolTip.Tip="{DynamicResource Text.Welcome.AddRootFolder}">
+          <Path Width="16" Height="16" Data="{StaticResource Icons.Folder.Add}" Margin="0,4,0,0"/>
+        </Button>
       </StackPanel>
     </Border>
 


### PR DESCRIPTION
When displays more than one page of repositories on the welcome page, the new group menu button only a small area on the left side of the bookmark can be called out. This PR is to solve this problem.