### PR TITLE
fix: SearchFilter radio button checked status

### DIFF
--- a/src/Views/Repository.axaml
+++ b/src/Views/Repository.axaml
@@ -191,7 +191,8 @@
           <RadioButton Grid.Column="2"
                        Width="48"
                        Classes="icon_button"
-                       GroupName="SearchGroup">
+                       GroupName="SearchGroup"
+                       IsChecked="{Binding IsSearching, Mode=TwoWay}">
             <Path Width="14" Height="14" Stretch="Fill" HorizontalAlignment="Center" Data="{StaticResource Icons.Search}"/>
           </RadioButton>
         </Grid>


### PR DESCRIPTION
This PR fixes the issue where the radio button does not highlight when switching using the Ctrl+F shortcut.