### PR TITLE
Add fetch all branches on pull option (acts like fetch+pull)

### DIFF
--- a/src/Models/RepositorySettings.cs
+++ b/src/Models/RepositorySettings.cs
@@ -34,6 +34,12 @@ namespace SourceGit.Models
             set;
         } = false;
 
+        public bool FetchAllBranchesOnPull
+        {
+            get;
+            set;
+        } = false;
+
         public bool PushAllTags
         {
             get;

--- a/src/Resources/Locales/en_US.axaml
+++ b/src/Resources/Locales/en_US.axaml
@@ -403,6 +403,7 @@
   <x:String x:Key="Text.PruneWorktrees.Tip" xml:space="preserve">Prune worktree information in `$GIT_DIR/worktrees`</x:String>
   <x:String x:Key="Text.Pull" xml:space="preserve">Pull</x:String>
   <x:String x:Key="Text.Pull.Branch" xml:space="preserve">Branch:</x:String>
+  <x:String x:Key="Text.Pull.FetchAllBranchesOnPull" xml:space="preserve">Fetch all branches on pull</x:String>
   <x:String x:Key="Text.Pull.Into" xml:space="preserve">Into:</x:String>
   <x:String x:Key="Text.Pull.LocalChanges" xml:space="preserve">Local Changes:</x:String>
   <x:String x:Key="Text.Pull.LocalChanges.Discard" xml:space="preserve">Discard</x:String>

--- a/src/ViewModels/Pull.cs
+++ b/src/ViewModels/Pull.cs
@@ -58,6 +58,12 @@ namespace SourceGit.ViewModels
             get => _repo.Settings.PreferRebaseInsteadOfMerge;
             set => _repo.Settings.PreferRebaseInsteadOfMerge = value;
         }
+        
+        public bool FetchAllBranchesOnPull
+        {
+            get => _repo.Settings.FetchAllBranchesOnPull;
+            set => _repo.Settings.FetchAllBranchesOnPull = value;
+        }
 
         public bool NoTags
         {
@@ -149,6 +155,12 @@ namespace SourceGit.ViewModels
                         SetProgressDescription("Discard local changes ...");
                         Commands.Discard.All(_repo.FullPath);
                     }
+                }
+
+                if (FetchAllBranchesOnPull)
+                {
+                    SetProgressDescription($"Fetching remote: {_selectedRemote.Name}...");
+                    new Commands.Fetch(_repo.FullPath, _selectedRemote.Name, false, NoTags, SetProgressDescription).Exec();
                 }
 
                 SetProgressDescription($"Pull {_selectedRemote.Name}/{_selectedBranch.Name}...");

--- a/src/Views/Pull.axaml
+++ b/src/Views/Pull.axaml
@@ -12,7 +12,7 @@
     <TextBlock FontSize="18"
                Classes="bold"
                Text="{DynamicResource Text.Pull.Title}"/>
-    <Grid Margin="0,16,0,0" RowDefinitions="32,32,32,32,32,32" ColumnDefinitions="140,*">
+    <Grid Margin="0,16,0,0" RowDefinitions="32,32,32,32,32,32,32" ColumnDefinitions="140,*">
       <TextBlock Grid.Row="0" Grid.Column="0"
                  HorizontalAlignment="Right" VerticalAlignment="Center"
                  Margin="0,0,8,0"
@@ -91,6 +91,10 @@
       <CheckBox Grid.Row="5" Grid.Column="1"
                 Content="{DynamicResource Text.Pull.NoTags}"
                 IsChecked="{Binding NoTags, Mode=TwoWay}"/>
+      
+      <CheckBox Grid.Row="6" Grid.Column="1"
+                Content="{DynamicResource Text.Pull.FetchAllBranchesOnPull}"
+                IsChecked="{Binding FetchAllBranchesOnPull, Mode=TwoWay}"/>
     </Grid>
   </StackPanel>
 </UserControl>


### PR DESCRIPTION
By default Pull doesn't fetch all branches.
Add fetch (without Prune) all branches on pull option to Pull window (acts like fetch+pull)
Reduces one click in many workflows and optional.