### PR TITLE
Reduce Minimum window size

### DIFF
--- a/src/Views/Launcher.axaml
+++ b/src/Views/Launcher.axaml
@@ -10,7 +10,7 @@
                     x:DataType="vm:Launcher"
                     Icon="/App.ico"
                     Title="SourceGit"
-                    MinWidth="1280" MinHeight="720"
+                    MinWidth="1024" MinHeight="600"
                     WindowStartupLocation="CenterScreen"> 
   <Grid x:Name="MainLayout">
     <Grid.RowDefinitions>


### PR DESCRIPTION
From 1280x720 to 1024x600, to fit window in top-half / top-third of portrait 1920x1080 monitor:
Tested on Windows.
Setting font size to 11.0 mitigates issues with text being cut off due to reduced width.

```
     x=1080     
+------------+
| SourceGit  |  y=640
|            |      \
+------------+        \
|File Browser|  y=640  } y=1920
|            |        /
+------------+      /
| Web Browser|  y=640
|            |
+------------+