### PR TITLE
Register to directory MimeType to open folders in unix systems

### DIFF
--- a/build/resources/_common/applications/sourcegit.desktop
+++ b/build/resources/_common/applications/sourcegit.desktop
@@ -6,3 +6,4 @@ Icon=/usr/share/icons/sourcegit.png
 Terminal=false
 Type=Application
 Categories=Development
+MimeType=inode/directory;


### PR DESCRIPTION
This will automatically add sourcegit to right-click menu for folders in file managers.