### PR TITLE
Automatic CI releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,12 @@ jobs:
       - name: Rename executable file
         if: ${{ startsWith(matrix.runtime, 'linux-') }}
         run: mv publish/SourceGit publish/sourcegit
+      - name: Tar artifact
+        if: ${{ startsWith(matrix.runtime, 'linux-') }}
+        run: |
+          tar -cvf "sourcegit.${{ matrix.runtime }}.tar" -C publish .
+          rm -r publish/*
+          mv "sourcegit.${{ matrix.runtime }}.tar" publish
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,9 +26,9 @@ jobs:
           - name : Linux
             os: ubuntu-20.04
             runtime: linux-x64
-          - name : Linux (arm64)
-            os: ubuntu-20.04
-            runtime: linux-arm64
+        #   - name : Linux (arm64)
+        #     os: ubuntu-20.04
+        #     runtime: linux-arm64
     name: Build ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,11 +61,8 @@ jobs:
       - name: Rename executable file
         if: ${{ startsWith(matrix.runtime, 'linux-') }}
         run: mv publish/SourceGit publish/sourcegit
-      - name: Package program
-        if: ${{ ! startsWith(matrix.runtime, 'win-') }}
-        run:  tar -cvf sourcegit.${{ matrix.runtime }}.tar -C publish/ .
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: sourcegit.${{ matrix.runtime }}
-          path: ${{ startsWith(matrix.runtime, 'win-') && 'publish' || format('sourcegit.{0}.tar', matrix.runtime) }}
+          path: publish

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,9 @@ jobs:
           - name : Windows x64
             os: windows-2019
             runtime: win-x64
+          - name : Windows ARM64
+            os: windows-2019
+            runtime: win-arm64
           - name : macOS (Intel)
             os: macos-13
             runtime: osx-x64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
   pull_request:
     branches: [develop]
   workflow_dispatch:
+  workflow_call:
 jobs:
   build:
     strategy:
@@ -33,8 +34,6 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,107 +1,32 @@
 name: Continuous Integration
 on:
   push:
-    branches:
-      - develop
+    branches: [develop]
   pull_request:
     branches: [develop]
   workflow_dispatch:
 jobs:
-  build-windows:
-    name: Build Windows x64
-    runs-on: windows-2019
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: 8.0.x
-      - name: Build
-        run: dotnet build -c Release
-      - name: Publish
-        run: dotnet publish src/SourceGit.csproj -c Release -o publish -r win-x64
-      - name: Upload Artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: sourcegit.win-x64
-          path: publish
-  build-macos-intel:
-    name: Build macOS (Intel)
-    runs-on: macos-13
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: 8.0.x
-      - name: Build
-        run: dotnet build -c Release
-      - name: Publish
-        run: dotnet publish src/SourceGit.csproj -c Release -o publish -r osx-x64
-      - name: Packing Program
-        run:  tar -cvf sourcegit.osx-x64.tar -C publish/ .
-      - name: Upload Artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: sourcegit.osx-x64
-          path: sourcegit.osx-x64.tar
-  build-macos-arm64:
-    name: Build macOS (Apple Silicon)
-    runs-on: macos-latest
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: 8.0.x
-      - name: Build
-        run: dotnet build -c Release
-      - name: Publish
-        run: dotnet publish src/SourceGit.csproj -c Release -o publish -r osx-arm64
-      - name: Packing Program
-        run: tar -cvf sourcegit.osx-arm64.tar -C publish/ .
-      - name: Upload Artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: sourcegit.osx-arm64
-          path: sourcegit.osx-arm64.tar
-  build-linux:
-    name: Build Linux
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: 8.0.x
-      - name: Build
-        run: dotnet build -c Release
-      - name: Publish
-        run: dotnet publish src/SourceGit.csproj -c Release -o publish -r linux-x64
-      - name: Rename Executable File
-        run: mv publish/SourceGit publish/sourcegit
-      - name: Packing Program
-        run: tar -cvf sourcegit.linux-x64.tar -C publish/ .
-      - name: Upload Artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: sourcegit.linux-x64
-          path: sourcegit.linux-x64.tar
-  build-linux-arm64:
-    name: Build Linux (arm64)
-    runs-on: ubuntu-20.04
+  build:
+    strategy:
+      matrix:
+        include:
+          - name : Windows x64
+            os: windows-2019
+            runtime: win-x64
+          - name : macOS (Intel)
+            os: macos-13
+            runtime: osx-x64
+          - name : macOS (Apple Silicon)
+            os: macos-latest
+            runtime: osx-arm64
+          - name : Linux
+            os: ubuntu-20.04
+            runtime: linux-x64
+          - name : Linux (arm64)
+            os: ubuntu-20.04
+            runtime: linux-arm64
+    name: Build ${{ matrix.name }}
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -112,6 +37,7 @@ jobs:
         with:
           dotnet-version: 8.0.x
       - name: Configure arm64 packages
+        if: ${{ matrix.runtime == 'linux-arm64' }}
         run: |
           sudo dpkg --add-architecture arm64
           echo 'deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ focal main restricted
@@ -121,19 +47,22 @@ jobs:
           sudo sed -i -e 's/^deb http/deb [arch=amd64] http/g' /etc/apt/sources.list
           sudo sed -i -e 's/^deb mirror/deb [arch=amd64] mirror/g' /etc/apt/sources.list
       - name: Install cross-compiling dependencies
+        if: ${{ matrix.runtime == 'linux-arm64' }}
         run: |
           sudo apt-get update
           sudo apt-get install clang llvm gcc-aarch64-linux-gnu zlib1g-dev:arm64
       - name: Build
         run: dotnet build -c Release
       - name: Publish
-        run: dotnet publish src/SourceGit.csproj -c Release -o publish -r linux-arm64
-      - name: Rename Executable File
+        run: dotnet publish src/SourceGit.csproj -c Release -o publish -r ${{ matrix.runtime }}
+      - name: Rename executable file
+        if: ${{ startsWith(matrix.runtime, 'linux-') }}
         run: mv publish/SourceGit publish/sourcegit
-      - name: Packing Program
-        run: tar -cvf sourcegit.linux-arm64.tar -C publish/ .
-      - name: Upload Artifact
+      - name: Package program
+        if: ${{ ! startsWith(matrix.runtime, 'win-') }}
+        run:  tar -cvf sourcegit.${{ matrix.runtime }}.tar -C publish/ .
+      - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: sourcegit.linux-arm64
-          path: sourcegit.linux-arm64.tar
+          name: sourcegit.${{ matrix.runtime }}
+          path: ${{ startsWith(matrix.runtime, 'win-') && 'publish' || format('sourcegit.{0}.tar', matrix.runtime) }}

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -79,12 +79,15 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: sourcegit.${{ matrix.runtime }}
-          path: build/SourceGit
+          path: build
       - name: Package
         env:
           VERSION: ${{ inputs.version }}
           RUNTIME: ${{ matrix.runtime }}
-        run: ./build/ci/package.linux.sh
+        run: |
+          mkdir build/SourceGit
+          tar -xf "build/sourcegit.${{ matrix.runtime }}.tar" -C build/SourceGit
+          ./build/ci/package.linux.sh
       - name: Upload package artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,0 +1,95 @@
+name: Package
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: Source Git package version
+        required: true
+        type: string
+jobs:
+  build:
+    name: Build
+    uses: ./.github/workflows/ci.yml
+  windows-portable:
+    name: Package portable Windows app
+    needs: build
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        runtime: [win-x64, win-arm64]
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+      - name: Download build
+        uses: actions/download-artifact@v4
+        with:
+          name: sourcegit.${{ matrix.runtime }}
+          path: build/SourceGit
+      - name: Package
+        env:
+          VERSION: ${{ inputs.version }}
+          RUNTIME: ${{ matrix.runtime }}
+        run: ./build/ci/package.windows-portable.sh
+      - name: Upload package artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: package.${{ matrix.runtime }}
+          path: build/sourcegit_*.zip
+  osx-app:
+    name: Package OSX app
+    needs: build
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        runtime: [osx-x64, osx-arm64]
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+      - name: Download build
+        uses: actions/download-artifact@v4
+        with:
+          name: sourcegit.${{ matrix.runtime }}
+          path: build/SourceGit
+      - name: Package
+        env:
+          VERSION: ${{ inputs.version }}
+          RUNTIME: ${{ matrix.runtime }}
+        run: ./build/ci/package.osx-app.sh
+      - name: Upload package artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: package.${{ matrix.runtime }}
+          path: build/sourcegit_*.zip
+  linux:
+    name: Package Linux
+    needs: build
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        runtime: [linux-x64, linux-arm64]
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+      - name: Download package dependencies
+        run: |
+          sudo add-apt-repository universe
+          sudo apt-get update
+          sudo apt-get install desktop-file-utils rpm libfuse2
+      - name: Download build
+        uses: actions/download-artifact@v4
+        with:
+          name: sourcegit.${{ matrix.runtime }}
+          path: build/SourceGit
+      - name: Package
+        env:
+          VERSION: ${{ inputs.version }}
+          RUNTIME: ${{ matrix.runtime }}
+        run: ./build/ci/package.linux.sh
+      - name: Upload package artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: package.${{ matrix.runtime }}
+          path: |
+            build/sourcegit-*.AppImage
+            build/sourcegit_*.deb
+            build/sourcegit-*.rpm

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -66,7 +66,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        runtime: [linux-x64, linux-arm64]
+        # runtime: [linux-x64, linux-arm64]
+        runtime: [linux-x64]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,49 @@
+name: Release
+on:
+  push:
+    tags:
+      - v*
+jobs:
+  version:
+    name: Prepare version string
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - name: Output version string
+        id: version
+        env:
+          TAG: ${{ github.ref_name }}
+        run: echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
+  package:
+    needs: version
+    name: Package
+    uses: ./.github/workflows/package.yml
+    with:
+      version: ${{ needs.version.outputs.version }}
+  release:
+    needs: [version, package]
+    name: Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+      - name: Create release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+        run: gh release create "$TAG" -t "Release ${TAG#v}" --notes-from-tag
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: package.*
+          path: packages
+          merge-multiple: true
+      - name: Upload assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+          VERSION: ${{ needs.version.outputs.version }}
+        run: gh release upload "$TAG" packages/*

--- a/build/build.linux.sh
+++ b/build/build.linux.sh
@@ -24,7 +24,7 @@ ln -sf ../../opt/sourcegit/sourcegit resources/deb/usr/bin
 cp -r resources/_common/applications resources/deb/usr/share/
 cp -r resources/_common/icons resources/deb/usr/share/
 sed -i "2s/.*/Version: ${version}/g" resources/deb/DEBIAN/control
-dpkg-deb --build resources/deb ./sourcegit_${version}-1_amd64.deb
+dpkg-deb --root-owner-group --build resources/deb ./sourcegit_${version}-1_amd64.deb
 
 # Redhat/CentOS/Fedora package
 rpmbuild -bb --target=x86_64 resources/rpm/SPECS/build.spec --define "_topdir `pwd`/resources/rpm" --define "_version ${version}"

--- a/build/build.linux.sh
+++ b/build/build.linux.sh
@@ -16,12 +16,13 @@ cd ../../
 
 # Debain/Ubuntu package
 mkdir -p resources/deb/opt/sourcegit/
+mkdir -p resources/deb/usr/bin
 mkdir -p resources/deb/usr/share/applications
 mkdir -p resources/deb/usr/share/icons
 cp -f SourceGit/* resources/deb/opt/sourcegit/
+ln -sf ../../opt/sourcegit/sourcegit resources/deb/usr/bin
 cp -r resources/_common/applications resources/deb/usr/share/
 cp -r resources/_common/icons resources/deb/usr/share/
-chmod +x -R resources/deb/opt/sourcegit
 sed -i "2s/.*/Version: ${version}/g" resources/deb/DEBIAN/control
 dpkg-deb --build resources/deb ./sourcegit_${version}-1_amd64.deb
 

--- a/build/ci/package.linux.sh
+++ b/build/ci/package.linux.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+
+set -e
+
+if [ -z "$VERSION" ]; then
+    echo "Provide the version as environment variable VERSION"
+    exit 1
+fi
+
+if [ -z "$RUNTIME" ]; then
+    echo "Provide the runtime as environment variable RUNTIME"
+    exit 1
+fi
+
+arch=
+appimage_arch=
+appimage_runtime=
+target=
+case "$RUNTIME" in
+    linux-x64)
+        arch=amd64
+        appimage_arch=x86_64
+        appimage_runtime=runtime-fuse2-x86_64
+        target=x86_64;;
+    linux-arm64)
+        arch=arm64
+        appimage_arch=arm_aarch64
+        appimage_runtime=runtime-fuse2-aarch64
+        target=aarch64;;
+    *)
+        echo "Unknown runtime $RUNTIME"
+        exit 1;;
+esac
+
+APPIMAGETOOL_URL=https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage
+APPIMAGE_RUNTIME_URL=https://github.com/AppImage/type2-runtime/releases/download/old/$appimage_runtime 
+
+cd build
+
+if [ ! -f "appimagetool" ]; then
+    curl -o appimagetool -L "$APPIMAGETOOL_URL"
+    chmod +x appimagetool
+fi
+
+if [ ! -f "appimage_runtime" ]; then
+    curl -o appimage_runtime -L "$APPIMAGE_RUNTIME_URL"
+fi
+
+rm -f SourceGit/*.dbg
+
+mkdir -p SourceGit.AppDir/opt
+mkdir -p SourceGit.AppDir/usr/share/metainfo
+mkdir -p SourceGit.AppDir/usr/share/applications
+
+cp -r SourceGit SourceGit.AppDir/opt/sourcegit
+desktop-file-install resources/_common/applications/sourcegit.desktop --dir SourceGit.AppDir/usr/share/applications \
+    --set-icon com.sourcegit_scm.SourceGit --set-key=Exec --set-value=AppRun
+mv SourceGit.AppDir/usr/share/applications/{sourcegit,com.sourcegit_scm.SourceGit}.desktop
+cp resources/appimage/sourcegit.png SourceGit.AppDir/com.sourcegit_scm.SourceGit.png
+ln -sf /opt/sourcegit/sourcegit SourceGit.AppDir/AppRun
+ln -rsf SourceGit.AppDir/usr/share/applications/com.sourcegit_scm.SourceGit.desktop SourceGit.AppDir
+cp resources/appimage/sourcegit.appdata.xml SourceGit.AppDir/usr/share/metainfo/com.sourcegit_scm.SourceGit.appdata.xml
+
+ARCH="$appimage_arch" ./appimagetool -v --runtime-file appimage_runtime SourceGit.AppDir "sourcegit-$VERSION.linux.$arch.AppImage"
+
+mkdir -p resources/deb/opt/sourcegit/
+mkdir -p resources/deb/usr/bin
+mkdir -p resources/deb/usr/share/applications
+mkdir -p resources/deb/usr/share/icons
+cp -f SourceGit/* resources/deb/opt/sourcegit
+ln -sf ../../opt/sourcegit/sourcegit resources/deb/usr/bin
+cp -r resources/_common/applications resources/deb/usr/share
+cp -r resources/_common/icons resources/deb/usr/share
+sed -i -e "s/^Version:.*/Version: $VERSION/" -e "s/^Architecture:.*/Architecture: $arch/" resources/deb/DEBIAN/control
+dpkg-deb --root-owner-group --build resources/deb "sourcegit_$VERSION-1_$arch.deb"
+
+rpmbuild -bb --target="$target" resources/rpm/SPECS/build.spec --define "_topdir $(pwd)/resources/rpm" --define "_version $VERSION"
+mv "resources/rpm/RPMS/$target/sourcegit-$VERSION-1.$target.rpm" ./

--- a/build/ci/package.linux.sh
+++ b/build/ci/package.linux.sh
@@ -14,18 +14,15 @@ fi
 
 arch=
 appimage_arch=
-appimage_runtime=
 target=
 case "$RUNTIME" in
     linux-x64)
         arch=amd64
         appimage_arch=x86_64
-        appimage_runtime=runtime-fuse2-x86_64
         target=x86_64;;
     linux-arm64)
         arch=arm64
         appimage_arch=arm_aarch64
-        appimage_runtime=runtime-fuse2-aarch64
         target=aarch64;;
     *)
         echo "Unknown runtime $RUNTIME"
@@ -33,17 +30,12 @@ case "$RUNTIME" in
 esac
 
 APPIMAGETOOL_URL=https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage
-APPIMAGE_RUNTIME_URL=https://github.com/AppImage/type2-runtime/releases/download/old/$appimage_runtime 
 
 cd build
 
 if [ ! -f "appimagetool" ]; then
     curl -o appimagetool -L "$APPIMAGETOOL_URL"
     chmod +x appimagetool
-fi
-
-if [ ! -f "appimage_runtime" ]; then
-    curl -o appimage_runtime -L "$APPIMAGE_RUNTIME_URL"
 fi
 
 rm -f SourceGit/*.dbg
@@ -61,7 +53,7 @@ ln -rsf SourceGit.AppDir/opt/sourcegit/sourcegit SourceGit.AppDir/AppRun
 ln -rsf SourceGit.AppDir/usr/share/applications/com.sourcegit_scm.SourceGit.desktop SourceGit.AppDir
 cp resources/appimage/sourcegit.appdata.xml SourceGit.AppDir/usr/share/metainfo/com.sourcegit_scm.SourceGit.appdata.xml
 
-ARCH="$appimage_arch" ./appimagetool -v --runtime-file appimage_runtime SourceGit.AppDir "sourcegit-$VERSION.linux.$arch.AppImage"
+ARCH="$appimage_arch" ./appimagetool -v SourceGit.AppDir "sourcegit-$VERSION.linux.$arch.AppImage"
 
 mkdir -p resources/deb/opt/sourcegit/
 mkdir -p resources/deb/usr/bin

--- a/build/ci/package.linux.sh
+++ b/build/ci/package.linux.sh
@@ -57,7 +57,7 @@ desktop-file-install resources/_common/applications/sourcegit.desktop --dir Sour
     --set-icon com.sourcegit_scm.SourceGit --set-key=Exec --set-value=AppRun
 mv SourceGit.AppDir/usr/share/applications/{sourcegit,com.sourcegit_scm.SourceGit}.desktop
 cp resources/appimage/sourcegit.png SourceGit.AppDir/com.sourcegit_scm.SourceGit.png
-ln -sf /opt/sourcegit/sourcegit SourceGit.AppDir/AppRun
+ln -rsf SourceGit.AppDir/opt/sourcegit/sourcegit SourceGit.AppDir/AppRun
 ln -rsf SourceGit.AppDir/usr/share/applications/com.sourcegit_scm.SourceGit.desktop SourceGit.AppDir
 cp resources/appimage/sourcegit.appdata.xml SourceGit.AppDir/usr/share/metainfo/com.sourcegit_scm.SourceGit.appdata.xml
 

--- a/build/ci/package.osx-app.sh
+++ b/build/ci/package.osx-app.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -e
+
+if [ -z "$VERSION" ]; then
+    echo "Provide the version as environment variable VERSION"
+    exit 1
+fi
+
+if [ -z "$RUNTIME" ]; then
+    echo "Provide the runtime as environment variable RUNTIME"
+    exit 1
+fi
+
+cd build
+
+mkdir -p SourceGit.app/Contents/Resources
+mv SourceGit SourceGit.app/Contents/MacOS
+cp resources/app/App.icns SourceGit.app/Contents/Resources/App.icns
+sed "s/SOURCE_GIT_VERSION/$VERSION/g" resources/app/App.plist > SourceGit.app/Contents/Info.plist
+
+zip "sourcegit_$VERSION.$RUNTIME.zip" -r SourceGit.app -x "*/*\.dsym/*"

--- a/build/ci/package.windows-portable.sh
+++ b/build/ci/package.windows-portable.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -e
+
+if [ -z "$VERSION" ]; then
+    echo "Provide the version as environment variable VERSION"
+    exit 1
+fi
+
+if [ -z "$RUNTIME" ]; then
+    echo "Provide the runtime as environment variable RUNTIME"
+    exit 1
+fi
+
+cd build
+
+rm -rf SourceGit/*.pdb
+
+zip "sourcegit_$VERSION.$RUNTIME.zip" -r SourceGit

--- a/build/resources/appimage/sourcegit.appdata.xml
+++ b/build/resources/appimage/sourcegit.appdata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop-application">
-	<id>com.sourcegit-scm.SourceGit</id>
+	<id>com.sourcegit_scm.SourceGit</id>
 	<metadata_license>MIT</metadata_license>
 	<project_license>MIT</project_license>
 	<name>SourceGit</name>
@@ -8,8 +8,9 @@
 	<description>
 		<p>Open-source GUI client for git users</p>
 	</description>
-	<launchable type="desktop-id">com.sourcegit-scm.SourceGit.desktop</launchable>
+  <url type="homepage">https://github.com/sourcegit-scm/sourcegit</url>
+	<launchable type="desktop-id">com.sourcegit_scm.SourceGit.desktop</launchable>
 	<provides>
-		<id>com.sourcegit-scm.SourceGit.desktop</id>
+		<id>com.sourcegit_scm.SourceGit.desktop</id>
 	</provides>
 </component>

--- a/build/resources/deb/DEBIAN/control
+++ b/build/resources/deb/DEBIAN/control
@@ -1,5 +1,5 @@
 Package: sourcegit
-Version: 8.18
+Version: 8.23
 Priority: optional
 Depends: libx11-6, libice6, libsm6
 Architecture: amd64

--- a/build/resources/deb/DEBIAN/postinst
+++ b/build/resources/deb/DEBIAN/postinst
@@ -1,5 +1,0 @@
-#!bin/sh
-
-echo 'Create link on /usr/bin'
-ln -s /opt/sourcegit/sourcegit /usr/bin/sourcegit
-exit 0

--- a/build/resources/deb/DEBIAN/postrm
+++ b/build/resources/deb/DEBIAN/postrm
@@ -1,4 +1,0 @@
-#!bin/sh
-
-rm -f /usr/bin/sourcegit
-exit 0

--- a/build/resources/rpm/SPECS/build.spec
+++ b/build/resources/rpm/SPECS/build.spec
@@ -14,24 +14,23 @@ Requires: libSM.so.6
 Open-source & Free Git Gui Client
 
 %install
-mkdir -p $RPM_BUILD_ROOT/opt/sourcegit
-mkdir -p $RPM_BUILD_ROOT/usr/share/applications
-mkdir -p $RPM_BUILD_ROOT/usr/share/icons
-cp -r ../../_common/applications $RPM_BUILD_ROOT/usr/share/
-cp -r ../../_common/icons $RPM_BUILD_ROOT/usr/share/
-cp -f ../../../SourceGit/* $RPM_BUILD_ROOT/opt/sourcegit/
-chmod 755 -R $RPM_BUILD_ROOT/opt/sourcegit
-chmod 755 $RPM_BUILD_ROOT/usr/share/applications/sourcegit.desktop
+mkdir -p %{buildroot}/opt/sourcegit
+mkdir -p %{buildroot}/%{_bindir}
+mkdir -p %{buildroot}/usr/share/applications
+mkdir -p %{buildroot}/usr/share/icons
+cp -f ../../../SourceGit/* %{buildroot}/opt/sourcegit/
+ln -sf ../../opt/sourcegit/sourcegit %{buildroot}/%{_bindir}
+cp -r ../../_common/applications %{buildroot}/%{_datadir}
+cp -r ../../_common/icons %{buildroot}/%{_datadir}
+chmod 755 -R %{buildroot}/opt/sourcegit
+chmod 755 %{buildroot}/%{_datadir}/applications/sourcegit.desktop
 
 %files
-/opt/sourcegit
-/usr/share
-
-%post
-ln -s /opt/sourcegit/sourcegit /usr/bin/sourcegit
-
-%postun
-rm -f /usr/bin/sourcegit
+%dir /opt/sourcegit/
+/opt/sourcegit/*
+/usr/share/applications/sourcegit.desktop
+/usr/share/icons/*
+%{_bindir}/sourcegit
 
 %changelog
 # skip


### PR DESCRIPTION
This will automate Source Git binary releases.
When the tag is pushed, a new release is created with all built packages attached.

Some minor changes include:
 * Embed symbolic links in Linux packages
 * Fix AppImage metadata warnings
 * Refactor ci.yml to use matrix

One of the considerations is how to handle version. Currently it gets the version from the tag (`v1.0.0` => `1.0.0`), but it could be changed to use the VERSION file from the project root.
By default, the release uses the message from the annotated tag or the latest commit message if the tag is liteweight, but this could be edited later.
