### PR TITLE
Fix aarch64 package dependencies

### DIFF
--- a/build/resources/rpm/SPECS/build.spec
+++ b/build/resources/rpm/SPECS/build.spec
@@ -5,6 +5,8 @@ Summary: Open-source & Free Git Gui Client
 License: MIT
 URL: https://sourcegit-scm.github.io/
 Source: https://github.com/sourcegit-scm/sourcegit/archive/refs/tags/v%_version.tar.gz
+Requires: libX11
+Requires: libSM
 
 %define _build_id_links none
 

--- a/build/resources/rpm/SPECS/build.spec
+++ b/build/resources/rpm/SPECS/build.spec
@@ -19,7 +19,7 @@ mkdir -p %{buildroot}/%{_bindir}
 mkdir -p %{buildroot}/usr/share/applications
 mkdir -p %{buildroot}/usr/share/icons
 cp -f ../../../SourceGit/* %{buildroot}/opt/sourcegit/
-ln -sf ../../opt/sourcegit/sourcegit %{buildroot}/%{_bindir}
+ln -rsf %{buildroot}/opt/sourcegit/sourcegit %{buildroot}/%{_bindir}
 cp -r ../../_common/applications %{buildroot}/%{_datadir}
 cp -r ../../_common/icons %{buildroot}/%{_datadir}
 chmod 755 -R %{buildroot}/opt/sourcegit

--- a/build/resources/rpm/SPECS/build.spec
+++ b/build/resources/rpm/SPECS/build.spec
@@ -5,8 +5,6 @@ Summary: Open-source & Free Git Gui Client
 License: MIT
 URL: https://sourcegit-scm.github.io/
 Source: https://github.com/sourcegit-scm/sourcegit/archive/refs/tags/v%_version.tar.gz
-Requires: libX11.so.6
-Requires: libSM.so.6
 
 %define _build_id_links none
 

--- a/build/scripts/package.linux.sh
+++ b/build/scripts/package.linux.sh
@@ -60,7 +60,7 @@ mkdir -p resources/deb/usr/bin
 mkdir -p resources/deb/usr/share/applications
 mkdir -p resources/deb/usr/share/icons
 cp -f SourceGit/* resources/deb/opt/sourcegit
-ln -sf ../../opt/sourcegit/sourcegit resources/deb/usr/bin
+ln -rsf resources/deb/opt/sourcegit/sourcegit resources/deb/usr/bin
 cp -r resources/_common/applications resources/deb/usr/share
 cp -r resources/_common/icons resources/deb/usr/share
 sed -i -e "s/^Version:.*/Version: $VERSION/" -e "s/^Architecture:.*/Architecture: $arch/" resources/deb/DEBIAN/control


### PR DESCRIPTION
When installing the aarch64 package on Fedora, there could be a problem when RPM couldn't figure out how to get `libX11.so.6`, due to the need for architecture specification on multi-arch systems.

This replaces libname dependencies with package name to fix the issue.
There's also a small adjustment to make the creation of relative links more explicit.
