### PR TITLE
Fix foreground color in tooltip on primary button

### DIFF
--- a/src/Resources/Styles.axaml
+++ b/src/Resources/Styles.axaml
@@ -514,7 +514,7 @@
   <Style Selector="Button.flat.primary:pointerover /template/ ContentPresenter#PART_ContentPresenter">
     <Setter Property="Background" Value="Transparent"/>
   </Style>
-  <Style Selector="Button.flat.primary TextBlock">
+  <Style Selector="Button.flat.primary > TextBlock">
     <Setter Property="Foreground" Value="{DynamicResource AccentButtonForeground}"/>
   </Style>
 


### PR DESCRIPTION
This pull request fixes the issue with the foreground color in the tooltip for the primary button. The problem was caused by an incorrect selector, which resulted in the tooltip text being displayed in the wrong color.

- ux: foreground for primary button https://github.com/sourcegit-scm/sourcegit/commit/45b93a117e0add3131d5aadd986d434b06275156)

Before:

![bug](https://github.com/user-attachments/assets/932138cd-d4a9-486d-910b-2de85c967106)

After:

![fixed](https://github.com/user-attachments/assets/21d1a081-5416-40d3-956d-26b5aef37d77)

<br>

I think this issue can be resolved simply by using the child combinator `>`. However, because I'm not familiar with Avalonia UI, I hope this solution does not introduce any unintended side effects.