### PR TITLE
fix: invalidate counter visual (#338)

### DIFF
--- a/src/Views/Repository.axaml.cs
+++ b/src/Views/Repository.axaml.cs
@@ -98,6 +98,7 @@ namespace SourceGit.Views
                 _label = null;
             }
 
+            InvalidateVisual();
             return _label != null ? new Size(_label.Width + 18, 18) : new Size(0, 0);
         }
 

--- a/src/Views/Repository.axaml.cs
+++ b/src/Views/Repository.axaml.cs
@@ -63,11 +63,6 @@ namespace SourceGit.Views
                 FontFamilyProperty,
                 ForegroundProperty,
                 CountProperty);
-
-            AffectsRender<CounterPresenter>(
-                ForegroundProperty,
-                BackgroundProperty,
-                CountProperty);
         }
 
         public override void Render(DrawingContext context)


### PR DESCRIPTION
Keep the same implementation as `CommitRefsPresenter` to avoid displaying the number of the previous `DataContext`