### PR TITLE
Prevent executing an executable file with the same name as the directory

### DIFF
--- a/src/Native/Windows.cs
+++ b/src/Native/Windows.cs
@@ -183,6 +183,7 @@ namespace SourceGit.Native
             else
             {
                 fullpath = new DirectoryInfo(path!).FullName;
+                fullpath += Path.DirectorySeparatorChar;
             }
 
             if (select)

--- a/src/Native/Windows.cs
+++ b/src/Native/Windows.cs
@@ -203,7 +203,7 @@ namespace SourceGit.Native
         public void OpenWithDefaultEditor(string file)
         {
             var info = new FileInfo(file);
-            var start = new ProcessStartInfo("cmd", $"/c start {info.FullName}");
+            var start = new ProcessStartInfo("cmd", $"/c start \"\" \"{info.FullName}\"");
             start.CreateNoWindow = true;
             Process.Start(start);
         }


### PR DESCRIPTION
This pull request addresses a security issue where an executable file with the same name as a directory could be executed instead of opening the directory.

In scenarios where a directory and an executable file share the same name and are located in the same directory, the existing implementation could mistakenly execute the file instead of opening the intended directory. For example:

```
.
├── danger/
│   ├── .git/
│   └── ...
└── danger.exe
```

When attempting to open the `danger` directory, the program might execute `danger.exe` (calculator in the following demo) instead, which poses a security risk.

https://github.com/user-attachments/assets/303690fd-78b1-4d92-a7db-c419138c427c

To prevent this, I modified the code to ensure that when a directory is intended to be opened, a directory separator character is appended to the path. This change ensures that the path is recognized as a directory, preventing the accidental execution of an executable file.

---

This PR also fixes issues with paths containing spaces. If there are spaces in the directory names, it could potentially lead to the aforementioned security risk.

```
.
├── danger white space/
│   ├── .git/
│   └── test.txt
└── danger.exe
```

https://github.com/user-attachments/assets/beb3281f-085d-4ca0-9028-de86d67274b6

Additionally, if the file names contained spaces, the original implementation would result in an error, causing the file to be unable to be opened correctly.

```
white space.txt
```

https://github.com/user-attachments/assets/cdd66de6-0044-4232-ada2-bbf865d8185f

