### PR TITLE
Add Enter as keybinding for staging/unstaging

### DIFF
--- a/src/Views/WorkingCopy.axaml.cs
+++ b/src/Views/WorkingCopy.axaml.cs
@@ -62,7 +62,7 @@ namespace SourceGit.Views
 
         private void OnUnstagedKeyDown(object _, KeyEventArgs e)
         {
-            if (DataContext is ViewModels.WorkingCopy vm && e.Key == Key.Space)
+            if (DataContext is ViewModels.WorkingCopy vm && e.Key is Key.Space or Key.Enter)
             {
                 vm.StageSelected();
                 e.Handled = true;
@@ -71,7 +71,7 @@ namespace SourceGit.Views
 
         private void OnStagedKeyDown(object _, KeyEventArgs e)
         {
-            if (DataContext is ViewModels.WorkingCopy vm && e.Key == Key.Space)
+            if (DataContext is ViewModels.WorkingCopy vm && e.Key is Key.Space or Key.Enter)
             {
                 vm.UnstageSelected();
                 e.Handled = true;


### PR DESCRIPTION
This is probably a rather subjective change (and more of a proposal). Feel free to reject it if this does not make sense to you.
It's just that using the Enter key to stage/unstage changes feels more intuitive to me (or I'm just used to it).