### PR TITLE
Reset file to parent revision - improvements

### DIFF
--- a/src/Commands/Checkout.cs
+++ b/src/Commands/Checkout.cs
@@ -58,7 +58,7 @@ namespace SourceGit.Commands
 
         public bool FileWithRevision(string file, string revision)
         {
-            Args = $"checkout {revision} -- \"{file}\"";
+            Args = $"checkout --no-overlay {revision} -- \"{file}\"";
             return Exec();
         }
 


### PR DESCRIPTION
* support reset to parent revision for Added files too
* support reset to parent revision in Files tab
* support reset to parent revision in Changes - now supports Renamings too

now it behaves more like git-extensions