### PR TITLE
github action to publish to homebrew

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,25 @@
+name: Publish
+on:
+  release:
+    types: [published]
+jobs:
+  osx-app:
+    name: Publish OSX app to Homebrew
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        runtime: [osx-x64, osx-arm64]
+    steps:
+      - name: Release to Homebrew Private Tap
+        env:
+          VERSION: ${{ github.event.release.tag_name }}
+          RUNTIME: ${{ matrix.runtime }}
+        id: homebrew-releaser
+        # env:
+        #   # TODO: use a secret if needed because this push to the other repo
+        #   HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.GH_TOKEN }}
+
+        # TODO: replace "ChiahongHong/sourcegit" with "sourcegit-scm/sourcegit" in two places
+        run: |
+          brew tap ChiahongHong/sourcegit
+          brew bump-cask-pr --dry-run --no-fork --version $VERSION --no-browse --message "Update SourceGit to version $VERSION" --no-pull-request sourcegit --tap ChiahongHong/sourcegit


### PR DESCRIPTION
relates to issue #426 

1. this is the workflow
2. @love-linger you need to create a clone (not fork) same repo like in the example in the issue
3. @love-linger you need to create a token that can be used to create a PR from this repo to the new repo
4. integrate the token in the placeholder I left

it should be triggered when a release is created
1. it goes to the new repo
2. grabs a link of the published app based on version and arch
3. download
4. modify the ruby file in the new repo
5. calculate sha
6. create a PR in the new repo

then you need to merge the PR - and it's published :)
I guess you can automate the merge if you like (if specific user creates a PR - auto-merge it)

then you just add the new install via homebrew to Readme :)