### PR TITLE
Allow to disable native AOT deployment

### DIFF
--- a/src/SourceGit.csproj
+++ b/src/SourceGit.csproj
@@ -20,7 +20,7 @@
     <RepositoryType>Public</RepositoryType>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)' == 'Release'">
+  <PropertyGroup Condition="'$(Configuration)' == 'Release' and '$(SourceGitNoAot)' != 'true'">
     <PublishAot>true</PublishAot>
     <PublishTrimmed>true</PublishTrimmed>
     <TrimMode>link</TrimMode>


### PR DESCRIPTION
This will introduce `SourceGitNoAot` variable, which can be set to `true` to disable native AOT deployment.
While AOT could improve application's speed, bundling the dotnet runtime will also increase its size.

The change is useful for Flatpak with the dotnet runtime included, or for a Linux package that will depend on the `dotnet-runtime` package. This is the more idiomatic way for Linux, and will also minimize the amount of disk space used if the system already has the dotnet runtime installed.

This variable is intended to be used by package maintainers, current Linux CI builds should be left as they are.
