### PR TITLE
Use ArgumentList for commands instead of manual escaping

### DIFF
--- a/src/Commands/Add.cs
+++ b/src/Commands/Add.cs
@@ -12,19 +12,14 @@ namespace SourceGit.Commands
 
             if (changes == null || changes.Count == 0)
             {
-                Args = "add .";
+                Args = ["add", "."];
             }
             else
             {
-                var builder = new StringBuilder();
-                builder.Append("add --");
+                Args.AddRange(["add", "--"]);
+
                 foreach (var c in changes)
-                {
-                    builder.Append(" \"");
-                    builder.Append(c.Path);
-                    builder.Append("\"");
-                }
-                Args = builder.ToString();
+                    Args.Add(c.Path);
             }
         }
     }

--- a/src/Commands/Apply.cs
+++ b/src/Commands/Apply.cs
@@ -1,19 +1,20 @@
-﻿namespace SourceGit.Commands
+﻿using System.Collections.Generic;
+
+namespace SourceGit.Commands
 {
     public class Apply : Command
     {
-        public Apply(string repo, string file, bool ignoreWhitespace, string whitespaceMode, string extra)
+        public Apply(string repo, string file, bool ignoreWhitespace, string whitespaceMode, IEnumerable<string> extra)
         {
             WorkingDirectory = repo;
             Context = repo;
-            Args = "apply ";
+            Args = ["apply"];
             if (ignoreWhitespace)
-                Args += "--ignore-whitespace ";
+                Args.Add("--ignore-whitespace");
             else
-                Args += $"--whitespace={whitespaceMode} ";
-            if (!string.IsNullOrEmpty(extra))
-                Args += $"{extra} ";
-            Args += $"\"{file}\"";
+                Args.Add($"--whitespace={whitespaceMode}");
+            Args.AddRange(extra);
+            Args.Add(file);
         }
     }
 }

--- a/src/Commands/Archive.cs
+++ b/src/Commands/Archive.cs
@@ -8,7 +8,7 @@ namespace SourceGit.Commands
         {
             WorkingDirectory = repo;
             Context = repo;
-            Args = $"archive --format=zip --verbose --output=\"{saveTo}\" {revision}";
+            Args = ["archive", "--format=zip", "--verbose", "-o", saveTo, revision];
             TraitErrorAsOutput = true;
             _outputHandler = outputHandler;
         }

--- a/src/Commands/AssumeUnchanged.cs
+++ b/src/Commands/AssumeUnchanged.cs
@@ -13,7 +13,7 @@ namespace SourceGit.Commands
             public ViewCommand(string repo)
             {
                 WorkingDirectory = repo;
-                Args = "ls-files -v";
+                Args = ["ls-files", "-v"];
                 RaiseError = false;
             }
 
@@ -46,7 +46,7 @@ namespace SourceGit.Commands
 
                 WorkingDirectory = repo;
                 Context = repo;
-                Args = $"update-index {mode} -- \"{file}\"";
+                Args = ["update-index", mode, "--", file];
             }
         }
 

--- a/src/Commands/Blame.cs
+++ b/src/Commands/Blame.cs
@@ -13,7 +13,7 @@ namespace SourceGit.Commands
         {
             WorkingDirectory = repo;
             Context = repo;
-            Args = $"blame -t {revision} -- \"{file}\"";
+            Args = ["blame", "-t", revision, "--", file];
             RaiseError = false;
 
             _result.File = file;

--- a/src/Commands/Branch.cs
+++ b/src/Commands/Branch.cs
@@ -7,7 +7,7 @@
             var cmd = new Command();
             cmd.WorkingDirectory = repo;
             cmd.Context = repo;
-            cmd.Args = $"branch {name} {basedOn}";
+            cmd.Args = ["branch", name, basedOn];
             return cmd.Exec();
         }
 
@@ -16,7 +16,7 @@
             var cmd = new Command();
             cmd.WorkingDirectory = repo;
             cmd.Context = repo;
-            cmd.Args = $"branch -M {name} {to}";
+            cmd.Args = ["branch", "-M", name, to];
             return cmd.Exec();
         }
 
@@ -27,9 +27,9 @@
             cmd.Context = repo;
 
             if (string.IsNullOrEmpty(upstream))
-                cmd.Args = $"branch {name} --unset-upstream";
+                cmd.Args = ["branch", name, "--unset-upstream"];
             else
-                cmd.Args = $"branch {name} -u {upstream}";
+                cmd.Args = ["branch", name, "-u", upstream];
 
             return cmd.Exec();
         }
@@ -39,7 +39,7 @@
             var cmd = new Command();
             cmd.WorkingDirectory = repo;
             cmd.Context = repo;
-            cmd.Args = $"branch -D {name}";
+            cmd.Args = ["branch", "-D", name];
             return cmd.Exec();
         }
 
@@ -49,7 +49,7 @@
             cmd.WorkingDirectory = repo;
             cmd.Context = repo;
             cmd.SSHKey = new Config(repo).Get($"remote.{remote}.sshkey");
-            cmd.Args = $"push {remote} --delete {name}";
+            cmd.Args = ["push", remote, "--delete", name];
             return cmd.Exec();
         }
     }

--- a/src/Commands/Checkout.cs
+++ b/src/Commands/Checkout.cs
@@ -14,7 +14,7 @@ namespace SourceGit.Commands
 
         public bool Branch(string branch, Action<string> onProgress)
         {
-            Args = $"checkout --progress {branch}";
+            Args = ["checkout", "--progress", branch];
             TraitErrorAsOutput = true;
             _outputHandler = onProgress;
             return Exec();
@@ -22,7 +22,7 @@ namespace SourceGit.Commands
 
         public bool Branch(string branch, string basedOn, Action<string> onProgress)
         {
-            Args = $"checkout --progress -b {branch} {basedOn}";
+            Args = ["checkout", "--progress", "-b", branch, basedOn];
             TraitErrorAsOutput = true;
             _outputHandler = onProgress;
             return Exec();
@@ -30,41 +30,25 @@ namespace SourceGit.Commands
 
         public bool UseTheirs(List<string> files)
         {
-            StringBuilder builder = new StringBuilder();
-            builder.Append("checkout --theirs --");
-            foreach (var f in files)
-            {
-                builder.Append(" \"");
-                builder.Append(f);
-                builder.Append("\"");
-            }
-            Args = builder.ToString();
+            Args = ["checkout", "--theirs", "--", ..files];
             return Exec();
         }
 
         public bool UseMine(List<string> files)
         {
-            StringBuilder builder = new StringBuilder();
-            builder.Append("checkout --ours --");
-            foreach (var f in files)
-            {
-                builder.Append(" \"");
-                builder.Append(f);
-                builder.Append("\"");
-            }
-            Args = builder.ToString();
+            Args = ["checkout", "--ours", "--", ..files];
             return Exec();
         }
 
         public bool FileWithRevision(string file, string revision)
         {
-            Args = $"checkout --no-overlay {revision} -- \"{file}\"";
+            Args = ["checkout", "--no-overlay", revision, "--", file];
             return Exec();
         }
 
         public bool Commit(string commitId, Action<string> onProgress)
         {
-            Args = $"checkout --detach --progress {commitId}";
+            Args = ["checkout", "--detach", "--progress", commitId];
             TraitErrorAsOutput = true;
             _outputHandler = onProgress;
             return Exec();
@@ -72,15 +56,7 @@ namespace SourceGit.Commands
 
         public bool Files(List<string> files)
         {
-            StringBuilder builder = new StringBuilder();
-            builder.Append("checkout -f -q --");
-            foreach (var f in files)
-            {
-                builder.Append(" \"");
-                builder.Append(f);
-                builder.Append("\"");
-            }
-            Args = builder.ToString();
+            Args = ["checkout", "-f", "-q", "--", ..files];
             return Exec();
         }
 

--- a/src/Commands/CherryPick.cs
+++ b/src/Commands/CherryPick.cs
@@ -7,7 +7,7 @@
             var mode = noCommit ? "-n" : "--ff";
             WorkingDirectory = repo;
             Context = repo;
-            Args = $"cherry-pick {mode} {commits}";
+            Args = ["cherry-pick", mode, commits];
         }
     }
 }

--- a/src/Commands/Clean.cs
+++ b/src/Commands/Clean.cs
@@ -9,23 +9,15 @@ namespace SourceGit.Commands
         {
             WorkingDirectory = repo;
             Context = repo;
-            Args = "clean -qfd";
+            Args = ["clean", "-qfd"];
         }
 
         public Clean(string repo, List<string> files)
         {
-            StringBuilder builder = new StringBuilder();
-            builder.Append("clean -qfd --");
-            foreach (var f in files)
-            {
-                builder.Append(" \"");
-                builder.Append(f);
-                builder.Append("\"");
-            }
+            Args = ["clean", "-qfd", "--", ..files];
 
             WorkingDirectory = repo;
             Context = repo;
-            Args = builder.ToString();
         }
     }
 }

--- a/src/Commands/Clone.cs
+++ b/src/Commands/Clone.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 
 namespace SourceGit.Commands
 {
@@ -6,21 +7,20 @@ namespace SourceGit.Commands
     {
         private readonly Action<string> _notifyProgress;
 
-        public Clone(string ctx, string path, string url, string localName, string sshKey, string extraArgs, Action<string> ouputHandler)
+        public Clone(string ctx, string path, string url, string localName, string sshKey, IEnumerable<string> extraArgs, Action<string> ouputHandler)
         {
             Context = ctx;
             WorkingDirectory = path;
             TraitErrorAsOutput = true;
             SSHKey = sshKey;
-            Args = "clone --progress --verbose --recurse-submodules ";
+            Args = ["clone", "--progress", "--verbose", "--recurse-submodules"];
 
-            if (!string.IsNullOrEmpty(extraArgs))
-                Args += $"{extraArgs} ";
+            Args.AddRange(extraArgs);
 
-            Args += $"{url} ";
+            Args.Add(url);
 
             if (!string.IsNullOrEmpty(localName))
-                Args += localName;
+                Args.Add(localName);
 
             _notifyProgress = ouputHandler;
         }

--- a/src/Commands/Commit.cs
+++ b/src/Commands/Commit.cs
@@ -12,11 +12,11 @@ namespace SourceGit.Commands
             WorkingDirectory = repo;
             Context = repo;
             TraitErrorAsOutput = true;
-            Args = $"commit --file=\"{file}\"";
+            Args = ["commit", $"--file={file}"];
             if (amend)
-                Args += " --amend --no-edit";
+                Args.AddRange(["--amend", "--no-edit"]);
             if (allowEmpty)
-                Args += " --allow-empty";
+                Args.Add("--allow-empty");
         }
     }
 }

--- a/src/Commands/CompareRevisions.cs
+++ b/src/Commands/CompareRevisions.cs
@@ -15,7 +15,7 @@ namespace SourceGit.Commands
             Context = repo;
 
             var based = string.IsNullOrEmpty(start) ? "-R" : start;
-            Args = $"diff --name-status {based} {end}";
+            Args = ["diff", "--name-status", based, end];
         }
 
         public List<Models.Change> Result()

--- a/src/Commands/Config.cs
+++ b/src/Commands/Config.cs
@@ -15,9 +15,9 @@ namespace SourceGit.Commands
         public Dictionary<string, string> ListAll()
         {
             if (string.IsNullOrEmpty(WorkingDirectory))
-                Args = "config --global -l";
+                Args = ["config", "--global", "-l"];
             else
-                Args = "config -l";
+                Args = ["config", "-l"];
 
             var output = ReadToEnd();
             var rs = new Dictionary<string, string>();
@@ -41,7 +41,7 @@ namespace SourceGit.Commands
 
         public string Get(string key)
         {
-            Args = $"config {key}";
+            Args = ["config", key];
             return ReadToEnd().StdOut.Trim();
         }
 
@@ -50,16 +50,16 @@ namespace SourceGit.Commands
             if (!allowEmpty && string.IsNullOrWhiteSpace(value))
             {
                 if (string.IsNullOrEmpty(WorkingDirectory))
-                    Args = $"config --global --unset {key}";
+                    Args = ["config", "--global", "--unset", key];
                 else
-                    Args = $"config --unset {key}";
+                    Args = ["config", "--unset", key];
             }
             else
             {
                 if (string.IsNullOrWhiteSpace(WorkingDirectory))
-                    Args = $"config --global {key} \"{value}\"";
+                    Args = ["config", "--global", key, value];
                 else
-                    Args = $"config {key} \"{value}\"";
+                    Args = ["config", key, value];
             }
 
             return Exec();

--- a/src/Commands/CountLocalChangesWithoutUntracked.cs
+++ b/src/Commands/CountLocalChangesWithoutUntracked.cs
@@ -8,7 +8,7 @@ namespace SourceGit.Commands
         {
             WorkingDirectory = repo;
             Context = repo;
-            Args = "status -uno --ignore-submodules=dirty --porcelain";
+            Args = ["status", "-uno", "--ignore-submodules=dirty", "--porcelain"];
         }
 
         public int Result()

--- a/src/Commands/Diff.cs
+++ b/src/Commands/Diff.cs
@@ -22,7 +22,7 @@ namespace SourceGit.Commands
 
             WorkingDirectory = repo;
             Context = repo;
-            Args = $"diff --ignore-cr-at-eol --unified={unified} {opt}";
+            Args = ["diff", "--ignore-cr-at-eol", $"--unified={unified}", ..opt.ToArgs()];
         }
 
         public Models.DiffResult Result()

--- a/src/Commands/Discard.cs
+++ b/src/Commands/Discard.cs
@@ -33,7 +33,7 @@ namespace SourceGit.Commands
             for (int i = 0; i < needCheckout.Count; i += 10)
             {
                 var count = Math.Min(10, needCheckout.Count - i);
-                new Restore(repo, needCheckout.GetRange(i, count), "--worktree --recurse-submodules").Exec();
+                new Restore(repo, needCheckout.GetRange(i, count), ["--worktree", "--recurse-submodules"]).Exec();
             }
         }
     }

--- a/src/Commands/Fetch.cs
+++ b/src/Commands/Fetch.cs
@@ -11,17 +11,17 @@ namespace SourceGit.Commands
             Context = repo;
             TraitErrorAsOutput = true;
             SSHKey = new Config(repo).Get($"remote.{remote}.sshkey");
-            Args = "fetch --progress --verbose ";
+            Args = ["fetch", "--progress", "--verbose"];
 
             if (prune)
-                Args += "--prune ";
+                Args.Add("--prune");
 
             if (noTags)
-                Args += "--no-tags ";
+                Args.Add("--no-tags");
             else
-                Args += "--force ";
+                Args.Add("--force");
 
-            Args += remote;
+            Args.Add(remote);
 
             Models.AutoFetchManager.Instance.MarkFetched(repo);
         }
@@ -33,7 +33,7 @@ namespace SourceGit.Commands
             Context = repo;
             TraitErrorAsOutput = true;
             SSHKey = new Config(repo).Get($"remote.{remote}.sshkey");
-            Args = $"fetch --progress --verbose {remote} {remoteBranch}:{localBranch}";
+            Args = ["fetch", "--progress", "--verbose", remote, $"{remoteBranch}:{localBranch}"];
         }
 
         protected override void OnReadline(string line)

--- a/src/Commands/FormatPatch.cs
+++ b/src/Commands/FormatPatch.cs
@@ -6,7 +6,7 @@
         {
             WorkingDirectory = repo;
             Context = repo;
-            Args = $"format-patch {commit} -1 -o \"{saveTo}\"";
+            Args = ["format-patch", commit, "-1", "-o", saveTo];
         }
     }
 }

--- a/src/Commands/GC.cs
+++ b/src/Commands/GC.cs
@@ -10,7 +10,7 @@ namespace SourceGit.Commands
             WorkingDirectory = repo;
             Context = repo;
             TraitErrorAsOutput = true;
-            Args = "gc --prune";
+            Args = ["gc", "--prune"];
         }
 
         protected override void OnReadline(string line)

--- a/src/Commands/GenerateCommitMessage.cs
+++ b/src/Commands/GenerateCommitMessage.cs
@@ -16,7 +16,7 @@ namespace SourceGit.Commands
             {
                 WorkingDirectory = repo;
                 Context = repo;
-                Args = $"diff --diff-algorithm=minimal {opt}";
+                Args = ["diff", "--diff-algorithm=minimal", ..opt.ToArgs()];
             }
         }
 

--- a/src/Commands/GitFlow.cs
+++ b/src/Commands/GitFlow.cs
@@ -60,7 +60,7 @@ namespace SourceGit.Commands
             var init = new Command();
             init.WorkingDirectory = repo;
             init.Context = repo;
-            init.Args = "flow init -d";
+            init.Args = ["flow", "init", "-d"];
             return init.Exec();
         }
 
@@ -128,7 +128,7 @@ namespace SourceGit.Commands
             var start = new Command();
             start.WorkingDirectory = repo;
             start.Context = repo;
-            start.Args = $"flow {type} start {name}";
+            start.Args = ["flow", type, "start", name];
             return start.Exec();
         }
 
@@ -148,7 +148,7 @@ namespace SourceGit.Commands
             var finish = new Command();
             finish.WorkingDirectory = repo;
             finish.Context = repo;
-            finish.Args = $"flow {type} finish {option} {name}";
+            finish.Args = ["flow", type, "finish", option, name];
             return finish.Exec();
         }
 

--- a/src/Commands/Init.cs
+++ b/src/Commands/Init.cs
@@ -6,7 +6,7 @@
         {
             Context = ctx;
             WorkingDirectory = dir;
-            Args = "init -q";
+            Args = ["init", "-q"];
         }
     }
 }

--- a/src/Commands/IsBinary.cs
+++ b/src/Commands/IsBinary.cs
@@ -11,7 +11,7 @@ namespace SourceGit.Commands
         {
             WorkingDirectory = repo;
             Context = repo;
-            Args = $"diff 4b825dc642cb6eb9a060e54bf8d69288fbee4904 {commit} --numstat -- \"{path}\"";
+            Args = ["diff", "4b825dc642cb6eb9a060e54bf8d69288fbee4904", commit, "--numstat", "--", path];
             RaiseError = false;
         }
 

--- a/src/Commands/IsConflictResolved.cs
+++ b/src/Commands/IsConflictResolved.cs
@@ -8,7 +8,7 @@
 
             WorkingDirectory = repo;
             Context = repo;
-            Args = $"diff -a --ignore-cr-at-eol --check {opt}";
+            Args = ["diff", "-a", "--ignore-cr-at-eol", "--check", ..opt.ToArgs()];
         }
     }
 }

--- a/src/Commands/IsLFSFiltered.cs
+++ b/src/Commands/IsLFSFiltered.cs
@@ -6,7 +6,7 @@
         {
             WorkingDirectory = repo;
             Context = repo;
-            Args = $"check-attr -z filter \"{path}\"";
+            Args = ["check-attr", "-z", "filter", path];
             RaiseError = false;
         }
 
@@ -14,7 +14,7 @@
         {
             WorkingDirectory = repo;
             Context = repo;
-            Args = $"check-attr --source {sha} -z filter \"{path}\"";
+            Args = ["check-attr", "--source", sha, "-z", "filter", path];
             RaiseError = false;
         }
 

--- a/src/Commands/Merge.cs
+++ b/src/Commands/Merge.cs
@@ -10,7 +10,7 @@ namespace SourceGit.Commands
             WorkingDirectory = repo;
             Context = repo;
             TraitErrorAsOutput = true;
-            Args = $"merge --progress {source} {mode}";
+            Args = ["merge", "--progress", source, mode];
         }
 
         protected override void OnReadline(string line)

--- a/src/Commands/MergeTool.cs
+++ b/src/Commands/MergeTool.cs
@@ -15,7 +15,7 @@ namespace SourceGit.Commands
 
             if (toolType == 0)
             {
-                cmd.Args = $"mergetool \"{file}\"";
+                cmd.Args = ["mergetool", file];
                 return cmd.Exec();
             }
 
@@ -32,7 +32,13 @@ namespace SourceGit.Commands
                 return false;
             }
 
-            cmd.Args = $"-c mergetool.sourcegit.cmd=\"\\\"{toolPath}\\\" {supported.Cmd}\" -c mergetool.writeToTemp=true -c mergetool.keepBackup=false -c mergetool.trustExitCode=true mergetool --tool=sourcegit \"{file}\"";
+            cmd.Args = [
+                "-c", $"mergetool.sourcegit.cmd=\"{toolPath}\" {supported.Cmd}",
+                "-c", "mergetool.writeToTemp=true",
+                "-c", "mergetool.keepBackup=false",
+                "-c", "mergetool.trustExitCode=true",
+                "mergetool", "--tool=sourcegit", file
+            ];
             return cmd.Exec();
         }
 
@@ -45,7 +51,7 @@ namespace SourceGit.Commands
 
             if (toolType == 0)
             {
-                cmd.Args = $"difftool -g --no-prompt {option}";
+                cmd.Args = ["difftool", "-g", "--no-prompt", ..option.ToArgs()];
                 return cmd.Exec();
             }
 
@@ -62,7 +68,11 @@ namespace SourceGit.Commands
                 return false;
             }
 
-            cmd.Args = $"-c difftool.sourcegit.cmd=\"\\\"{toolPath}\\\" {supported.DiffCmd}\" difftool --tool=sourcegit --no-prompt {option}";
+            cmd.Args = [
+                "-c", $"difftool.sourcegit.cmd=\"{toolPath}\" {supported.DiffCmd}",
+                "difftool", "--tool=sourcegit", "--no-prompt"
+            ];
+            cmd.Args.AddRange(option.ToArgs());
             return cmd.Exec();
         }
     }

--- a/src/Commands/Pull.cs
+++ b/src/Commands/Pull.cs
@@ -11,14 +11,14 @@ namespace SourceGit.Commands
             Context = repo;
             TraitErrorAsOutput = true;
             SSHKey = new Config(repo).Get($"remote.{remote}.sshkey");
-            Args = "pull --verbose --progress --tags ";
+            Args = ["pull", "--verbose", "--progress", "--tags"];
 
             if (useRebase)
-                Args += "--rebase ";
+                Args.Add("--rebase");
             if (noTags)
-                Args += "--no-tags ";
+                Args.Add("--no-tags");
 
-            Args += $"{remote} {branch}";
+            Args.AddRange([remote, branch]);
         }
 
         protected override void OnReadline(string line)

--- a/src/Commands/Push.cs
+++ b/src/Commands/Push.cs
@@ -12,18 +12,18 @@ namespace SourceGit.Commands
             Context = repo;
             TraitErrorAsOutput = true;
             SSHKey = new Config(repo).Get($"remote.{remote}.sshkey");
-            Args = "push --progress --verbose ";
+            Args = ["push", "--progress", "--verbose"];
 
             if (withTags)
-                Args += "--tags ";
+                Args.Add("--tags");
             if (checkSubmodules)
-                Args += "--recurse-submodules=check ";
+                Args.Add("--recurse-submodules=check");
             if (track)
-                Args += "-u ";
+                Args.Add("-u");
             if (force)
-                Args += "--force-with-lease ";
+                Args.Add("--force-with-lease");
 
-            Args += $"{remote} {local}:{remoteBranch}";
+            Args.AddRange([remote, $"{local}:{remoteBranch}"]);
         }
 
         public Push(string repo, string remote, string tag, bool isDelete)
@@ -31,12 +31,12 @@ namespace SourceGit.Commands
             WorkingDirectory = repo;
             Context = repo;
             SSHKey = new Config(repo).Get($"remote.{remote}.sshkey");
-            Args = "push ";
+            Args = ["push"];
 
             if (isDelete)
-                Args += "--delete ";
+                Args.Add("--delete");
 
-            Args += $"{remote} refs/tags/{tag}";
+            Args.AddRange([remote, $"refs/tags/{tag}"]);
         }
 
         protected override void OnReadline(string line)

--- a/src/Commands/QueryBranches.cs
+++ b/src/Commands/QueryBranches.cs
@@ -14,7 +14,10 @@ namespace SourceGit.Commands
         {
             WorkingDirectory = repo;
             Context = repo;
-            Args = "branch -l --all -v --format=\"%(refname)$%(objectname)$%(HEAD)$%(upstream)$%(upstream:trackshort)\"";
+            Args = [
+                "branch", "-l", "--all", "-v",
+                "--format=%(refname)$%(objectname)$%(HEAD)$%(upstream)$%(upstream:trackshort)"
+            ];
         }
 
         public List<Models.Branch> Result()

--- a/src/Commands/QueryCommitFullMessage.cs
+++ b/src/Commands/QueryCommitFullMessage.cs
@@ -6,7 +6,7 @@ namespace SourceGit.Commands
         {
             WorkingDirectory = repo;
             Context = repo;
-            Args = $"show --no-show-signature --pretty=format:%B -s {sha}";
+            Args = ["show", "--no-show-signature", "--pretty=format:%B", "-s", sha];
         }
 
         public string Result()

--- a/src/Commands/QueryCommitsWithFullMessage.cs
+++ b/src/Commands/QueryCommitsWithFullMessage.cs
@@ -5,13 +5,17 @@ namespace SourceGit.Commands
 {
     public class QueryCommitsWithFullMessage : Command
     {
-        public QueryCommitsWithFullMessage(string repo, string args)
+        public QueryCommitsWithFullMessage(string repo, IEnumerable<string> args)
         {
             _boundary = $"----- BOUNDARY OF COMMIT {Guid.NewGuid()} -----";
 
             WorkingDirectory = repo;
             Context = repo;
-            Args = $"log --date-order --no-show-signature --decorate=full --pretty=format:\"%H%n%P%n%D%n%aN±%aE%n%at%n%cN±%cE%n%ct%n%B%n{_boundary}\" {args}";
+            Args = [
+                "log", "--date-order", "--no-show-signature", "--decorate=full",
+                $"--pretty=format:\"%H%n%P%n%D%n%aN±%aE%n%at%n%cN±%cE%n%ct%n%B%n{_boundary}",
+                ..args
+            ];
         }
 
         public List<Models.CommitWithMessage> Result()

--- a/src/Commands/QueryCurrentRevisionFiles.cs
+++ b/src/Commands/QueryCurrentRevisionFiles.cs
@@ -6,7 +6,7 @@
         {
             WorkingDirectory = repo;
             Context = repo;
-            Args = "ls-tree -r --name-only HEAD";
+            Args = ["ls-tree", "-r", "--name-only", "HEAD"];
         }
 
         public string[] Result()

--- a/src/Commands/QueryFileContent.cs
+++ b/src/Commands/QueryFileContent.cs
@@ -8,10 +8,8 @@ namespace SourceGit.Commands
     {
         public static Stream Run(string repo, string revision, string file)
         {
-            var starter = new ProcessStartInfo();
+            var starter = new ProcessStartInfo(Native.OS.GitExecutable, ["show", $"{revision}:{file}"]);
             starter.WorkingDirectory = repo;
-            starter.FileName = Native.OS.GitExecutable;
-            starter.Arguments = $"show {revision}:\"{file}\"";
             starter.UseShellExecute = false;
             starter.CreateNoWindow = true;
             starter.WindowStyle = ProcessWindowStyle.Hidden;

--- a/src/Commands/QueryFileSize.cs
+++ b/src/Commands/QueryFileSize.cs
@@ -11,7 +11,7 @@ namespace SourceGit.Commands
         {
             WorkingDirectory = repo;
             Context = repo;
-            Args = $"ls-tree {revision} -l -- {file}";
+            Args = ["ls-tree", revision, "-l", "--", file];
         }
 
         public long Result()

--- a/src/Commands/QueryGitDir.cs
+++ b/src/Commands/QueryGitDir.cs
@@ -7,7 +7,7 @@ namespace SourceGit.Commands
         public QueryGitDir(string workDir)
         {
             WorkingDirectory = workDir;
-            Args = "rev-parse --git-dir";
+            Args = ["rev-parse", "--git-dir"];
             RaiseError = false;
         }
 

--- a/src/Commands/QueryLocalChanges.cs
+++ b/src/Commands/QueryLocalChanges.cs
@@ -14,7 +14,7 @@ namespace SourceGit.Commands
         {
             WorkingDirectory = repo;
             Context = repo;
-            Args = $"status -u{UNTRACKED[includeUntracked ? 1 : 0]} --ignore-submodules=dirty --porcelain";
+            Args = ["status", $"-u{UNTRACKED[includeUntracked ? 1 : 0]}", "--ignore-submodules=dirty", "--porcelain"];
         }
 
         public List<Models.Change> Result()

--- a/src/Commands/QueryRefsContainsCommit.cs
+++ b/src/Commands/QueryRefsContainsCommit.cs
@@ -9,7 +9,7 @@ namespace SourceGit.Commands
         {
             WorkingDirectory = repo;
             RaiseError = false;
-            Args = $"for-each-ref --format=\"%(refname)\" --contains {commit}";
+            Args = ["for-each-ref", "--format=%(refname)", "--contains", commit];
         }
 
         public List<Models.Decorator> Result()

--- a/src/Commands/QueryRemotes.cs
+++ b/src/Commands/QueryRemotes.cs
@@ -12,7 +12,7 @@ namespace SourceGit.Commands
         {
             WorkingDirectory = repo;
             Context = repo;
-            Args = "remote -v";
+            Args = ["remote", "-v"];
         }
 
         public List<Models.Remote> Result()

--- a/src/Commands/QueryRepositoryRootPath.cs
+++ b/src/Commands/QueryRepositoryRootPath.cs
@@ -5,7 +5,7 @@
         public QueryRepositoryRootPath(string path)
         {
             WorkingDirectory = path;
-            Args = "rev-parse --show-toplevel";
+            Args = ["rev-parse", "--show-toplevel"];
         }
     }
 }

--- a/src/Commands/QueryRevisionObjects.cs
+++ b/src/Commands/QueryRevisionObjects.cs
@@ -12,10 +12,10 @@ namespace SourceGit.Commands
         {
             WorkingDirectory = repo;
             Context = repo;
-            Args = $"ls-tree {sha}";
+            Args = ["ls-tree", sha];
 
             if (!string.IsNullOrEmpty(parentFolder))
-                Args += $" -- \"{parentFolder}\"";
+                Args.AddRange(["--", parentFolder]);
         }
 
         public List<Models.Object> Result()

--- a/src/Commands/QuerySingleCommit.cs
+++ b/src/Commands/QuerySingleCommit.cs
@@ -8,7 +8,11 @@ namespace SourceGit.Commands
         {
             WorkingDirectory = repo;
             Context = repo;
-            Args = $"show --no-show-signature --decorate=full --pretty=format:%H%n%P%n%D%n%aN±%aE%n%at%n%cN±%cE%n%ct%n%s -s {sha}";
+            Args = [
+                "show", "--no-show-signature", "--decorate=full",
+                "--pretty=format:%H%n%P%n%D%n%aN±%aE%n%at%n%cN±%cE%n%ct%n%s",
+                "-s", sha
+            ];
         }
 
         public Models.Commit Result()

--- a/src/Commands/QueryStagedChangesWithAmend.cs
+++ b/src/Commands/QueryStagedChangesWithAmend.cs
@@ -15,7 +15,7 @@ namespace SourceGit.Commands
         {
             WorkingDirectory = repo;
             Context = repo;
-            Args = "diff-index --cached -M HEAD^";
+            Args = ["diff-index", "--cached", "-M", "HEAD^"];
         }
 
         public List<Models.Change> Result()

--- a/src/Commands/QueryStagedFileBlobGuid.cs
+++ b/src/Commands/QueryStagedFileBlobGuid.cs
@@ -11,7 +11,7 @@ namespace SourceGit.Commands
         {
             WorkingDirectory = repo;
             Context = repo;
-            Args = $"ls-files -s -- \"{file}\"";
+            Args = ["ls-files", "-s", "--", file];
         }
 
         public string Result()

--- a/src/Commands/QueryStashChanges.cs
+++ b/src/Commands/QueryStashChanges.cs
@@ -12,7 +12,7 @@ namespace SourceGit.Commands
         {
             WorkingDirectory = repo;
             Context = repo;
-            Args = $"diff --name-status --pretty=format: {sha}^ {sha}";
+            Args = ["diff", "--name-status", "--pretty=format:", $"{sha}^", sha];
         }
 
         public List<Models.Change> Result()

--- a/src/Commands/QueryStashes.cs
+++ b/src/Commands/QueryStashes.cs
@@ -8,7 +8,7 @@ namespace SourceGit.Commands
         {
             WorkingDirectory = repo;
             Context = repo;
-            Args = "stash list --pretty=format:%H%n%ct%n%gd%n%s";
+            Args = ["stash", "list", "--pretty=format:%H%n%ct%n%gd%n%s"];
         }
 
         public List<Models.Stash> Result()

--- a/src/Commands/QuerySubmodules.cs
+++ b/src/Commands/QuerySubmodules.cs
@@ -17,7 +17,7 @@ namespace SourceGit.Commands
         {
             WorkingDirectory = repo;
             Context = repo;
-            Args = "submodule status";
+            Args = ["submodule", "status"];
         }
 
         public List<Models.Submodule> Result()
@@ -27,7 +27,7 @@ namespace SourceGit.Commands
             if (!rs.IsSuccess)
                 return submodules;
 
-            var builder = new StringBuilder();
+            var extra = new List<string>();
             var lines = rs.StdOut.Split('\n', System.StringSplitOptions.RemoveEmptyEntries);
             foreach (var line in lines)
             {
@@ -35,7 +35,7 @@ namespace SourceGit.Commands
                 if (match.Success)
                 {
                     var path = match.Groups[1].Value;
-                    builder.Append($"\"{path}\" ");
+                    extra.Add(path);
                     submodules.Add(new Models.Submodule() { Path = path });
                     continue;
                 }
@@ -44,14 +44,14 @@ namespace SourceGit.Commands
                 if (match.Success)
                 {
                     var path = match.Groups[1].Value;
-                    builder.Append($"\"{path}\" ");
+                    extra.Add(path);
                     submodules.Add(new Models.Submodule() { Path = path });
                 }
             }
 
             if (submodules.Count > 0)
             {
-                Args = $"status -uno --porcelain -- {builder}";
+                Args = ["status", "-uno", "--porcelain", "--", ..extra];
                 rs = ReadToEnd();
                 if (!rs.IsSuccess)
                     return submodules;

--- a/src/Commands/QueryTags.cs
+++ b/src/Commands/QueryTags.cs
@@ -9,7 +9,7 @@ namespace SourceGit.Commands
         {
             Context = repo;
             WorkingDirectory = repo;
-            Args = "tag -l --sort=-creatordate --format=\"$%(refname)$%(objectname)$%(*objectname)\"";
+            Args = ["tag", "-l", "--sort=-creatordate", "--format=$%(refname)$%(objectname)$%(*objectname)"];
         }
 
         public List<Models.Tag> Result()

--- a/src/Commands/QueryTrackStatus.cs
+++ b/src/Commands/QueryTrackStatus.cs
@@ -8,7 +8,7 @@ namespace SourceGit.Commands
         {
             WorkingDirectory = repo;
             Context = repo;
-            Args = $"rev-list --left-right {local}...{upstream}";
+            Args = ["rev-list", "--left-right", $"{local}...{upstream}"];
         }
 
         public Models.BranchTrackStatus Result()

--- a/src/Commands/Rebase.cs
+++ b/src/Commands/Rebase.cs
@@ -6,10 +6,10 @@
         {
             WorkingDirectory = repo;
             Context = repo;
-            Args = "rebase ";
+            Args = ["rebase"];
             if (autoStash)
-                Args += "--autostash ";
-            Args += basedOn;
+                Args.Add("--autostash");
+            Args.Add(basedOn);
         }
     }
 
@@ -20,7 +20,7 @@
             WorkingDirectory = repo;
             Context = repo;
             Editor = EditorType.RebaseEditor;
-            Args = $"rebase -i --autosquash {basedOn}";
+            Args = ["rebase", "-i", "--autosquash", basedOn];
         }
     }
 }

--- a/src/Commands/Remote.cs
+++ b/src/Commands/Remote.cs
@@ -10,31 +10,31 @@
 
         public bool Add(string name, string url)
         {
-            Args = $"remote add {name} {url}";
+            Args = ["remote", "add", name, url];
             return Exec();
         }
 
         public bool Delete(string name)
         {
-            Args = $"remote remove {name}";
+            Args = ["remote", "remove", name];
             return Exec();
         }
 
         public bool Rename(string name, string to)
         {
-            Args = $"remote rename {name} {to}";
+            Args = ["remote", "rename", name, to];
             return Exec();
         }
 
         public bool Prune(string name)
         {
-            Args = $"remote prune {name}";
+            Args = ["remote", "prune", name];
             return Exec();
         }
 
         public bool SetURL(string name, string url)
         {
-            Args = $"remote set-url {name} {url}";
+            Args = ["remote", "set-url", name, url];
             return Exec();
         }
     }

--- a/src/Commands/Reset.cs
+++ b/src/Commands/Reset.cs
@@ -9,7 +9,7 @@ namespace SourceGit.Commands
         {
             WorkingDirectory = repo;
             Context = repo;
-            Args = "reset";
+            Args = ["reset"];
         }
 
         public Reset(string repo, List<Models.Change> changes)
@@ -17,22 +17,18 @@ namespace SourceGit.Commands
             WorkingDirectory = repo;
             Context = repo;
 
-            var builder = new StringBuilder();
-            builder.Append("reset --");
+            Args = ["reset", "--"];
             foreach (var c in changes)
             {
-                builder.Append(" \"");
-                builder.Append(c.Path);
-                builder.Append("\"");
+                Args.Add(c.Path);
             }
-            Args = builder.ToString();
         }
 
         public Reset(string repo, string revision, string mode)
         {
             WorkingDirectory = repo;
             Context = repo;
-            Args = $"reset {mode} {revision}";
+            Args = ["reset", mode, revision];
         }
     }
 }

--- a/src/Commands/Restore.cs
+++ b/src/Commands/Restore.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Text;
 
 namespace SourceGit.Commands
 {
@@ -9,22 +8,15 @@ namespace SourceGit.Commands
         {
             WorkingDirectory = repo;
             Context = repo;
-            Args = "restore . --source=HEAD --staged --worktree --recurse-submodules";
+            Args = ["restore", ".", "--source=HEAD", "--staged", "--worktree", "--recurse-submodules"];
         }
 
-        public Restore(string repo, List<string> files, string extra)
+        public Restore(string repo, IEnumerable<string> files, IEnumerable<string> extra)
         {
             WorkingDirectory = repo;
             Context = repo;
 
-            StringBuilder builder = new StringBuilder();
-            builder.Append("restore ");
-            if (!string.IsNullOrEmpty(extra))
-                builder.Append(extra).Append(" ");
-            builder.Append("--");
-            foreach (var f in files)
-                builder.Append(' ').Append('"').Append(f).Append('"');
-            Args = builder.ToString();
+            Args = ["restore", ..extra, "--", ..files];
         }
     }
 }

--- a/src/Commands/Revert.cs
+++ b/src/Commands/Revert.cs
@@ -6,9 +6,9 @@
         {
             WorkingDirectory = repo;
             Context = repo;
-            Args = $"revert -m 1 {commit} --no-edit";
+            Args = ["revert", "-m", "1", commit, "--no-edit"];
             if (!autoCommit)
-                Args += " --no-commit";
+                Args.Add("--no-commit");
         }
     }
 }

--- a/src/Commands/SaveChangesAsPatch.cs
+++ b/src/Commands/SaveChangesAsPatch.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-
 using Avalonia.Threading;
 
 namespace SourceGit.Commands
@@ -25,10 +24,11 @@ namespace SourceGit.Commands
 
         private static bool ProcessSingleChange(string repo, Models.DiffOption opt, FileStream writer)
         {
-            var starter = new ProcessStartInfo();
+            var starter = new ProcessStartInfo(
+                Native.OS.GitExecutable,
+                ["diff", "--ignore-cr-at-eol", "--unified=4", ..opt.ToArgs()]
+            );
             starter.WorkingDirectory = repo;
-            starter.FileName = Native.OS.GitExecutable;
-            starter.Arguments = $"diff --ignore-cr-at-eol --unified=4 {opt}";
             starter.UseShellExecute = false;
             starter.CreateNoWindow = true;
             starter.WindowStyle = ProcessWindowStyle.Hidden;

--- a/src/Commands/SaveRevisionFile.cs
+++ b/src/Commands/SaveRevisionFile.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 
@@ -14,24 +15,22 @@ namespace SourceGit.Commands
             if (isLFSFiltered)
             {
                 var tmpFile = saveTo + ".tmp";
-                if (ExecCmd(repo, $"show {revision}:\"{file}\"", tmpFile))
+                if (ExecCmd(repo, ["show", $"{revision}:{file}"], tmpFile))
                 {
-                    ExecCmd(repo, $"lfs smudge", saveTo, tmpFile);
+                    ExecCmd(repo, ["lfs", "smudge"], saveTo, tmpFile);
                 }
                 File.Delete(tmpFile);
             }
             else
             {
-                ExecCmd(repo, $"show {revision}:\"{file}\"", saveTo);
+                ExecCmd(repo, ["show", $"{revision}:{file}"], saveTo);
             }
         }
 
-        private static bool ExecCmd(string repo, string args, string outputFile, string inputFile = null)
+        private static bool ExecCmd(string repo, IEnumerable<string> args, string outputFile, string inputFile = null)
         {
-            var starter = new ProcessStartInfo();
+            var starter = new ProcessStartInfo(Native.OS.GitExecutable, args);
             starter.WorkingDirectory = repo;
-            starter.FileName = Native.OS.GitExecutable;
-            starter.Arguments = args;
             starter.UseShellExecute = false;
             starter.CreateNoWindow = true;
             starter.WindowStyle = ProcessWindowStyle.Hidden;

--- a/src/Commands/Stash.cs
+++ b/src/Commands/Stash.cs
@@ -13,17 +13,17 @@ namespace SourceGit.Commands
 
         public bool Push(string message)
         {
-            Args = $"stash push -m \"{message}\"";
+            Args = ["stash", "push", "-m", message];
             return Exec();
         }
 
         public bool Push(List<Models.Change> changes, string message)
         {
-            var pathsBuilder = new StringBuilder();
+            Args = ["stash", "push", "-m", message, "--"];
             var needAdd = new List<Models.Change>();
             foreach (var c in changes)
             {
-                pathsBuilder.Append($"\"{c.Path}\" ");
+                Args.Add(c.Path);
 
                 if (c.WorkTree == Models.ChangeState.Added || c.WorkTree == Models.ChangeState.Untracked)
                 {
@@ -41,32 +41,30 @@ namespace SourceGit.Commands
                 needAdd.Clear();
             }
 
-            var paths = pathsBuilder.ToString();
-            Args = $"stash push -m \"{message}\" -- {paths}";
             return Exec();
         }
 
         public bool Apply(string name)
         {
-            Args = $"stash apply -q {name}";
+            Args = ["stash", "apply", "-q", name];
             return Exec();
         }
 
         public bool Pop(string name)
         {
-            Args = $"stash pop -q {name}";
+            Args = ["stash", "pop", "-q", name];
             return Exec();
         }
 
         public bool Drop(string name)
         {
-            Args = $"stash drop -q {name}";
+            Args = ["stash", "drop", "-q", name];
             return Exec();
         }
 
         public bool Clear()
         {
-            Args = "stash clear";
+            Args = ["stash", "clear"];
             return Exec();
         }
     }

--- a/src/Commands/Statistics.cs
+++ b/src/Commands/Statistics.cs
@@ -10,7 +10,10 @@ namespace SourceGit.Commands
 
             WorkingDirectory = repo;
             Context = repo;
-            Args = $"log --date-order --branches --remotes --since=\"{_statistics.Since()}\" --pretty=format:\"%ct$%an\"";
+            Args = [
+                "log", "--date-order", "--branches", "--remotes",
+                $"--since={_statistics.Since()}", "--pretty=format:%ct$%an"
+            ];
         }
 
         public Models.Statistics Result()

--- a/src/Commands/Submodule.cs
+++ b/src/Commands/Submodule.cs
@@ -13,34 +13,34 @@ namespace SourceGit.Commands
         public bool Add(string url, string relativePath, bool recursive, Action<string> outputHandler)
         {
             _outputHandler = outputHandler;
-            Args = $"submodule add {url} \"{relativePath}\"";
+            Args = ["submodule", "add", url, relativePath];
             if (!Exec())
                 return false;
 
             if (recursive)
             {
-                Args = $"submodule update --init --recursive -- \"{relativePath}\"";
+                Args = ["submodule", "update", "--init", "--recursive", "--", relativePath];
                 return Exec();
             }
             else
             {
-                Args = $"submodule update --init -- \"{relativePath}\"";
+                Args = ["submodule", "update", "--init", "--", relativePath];
                 return true;
             }
         }
 
         public bool Update(string module, bool init, bool recursive, bool useRemote, Action<string> outputHandler)
         {
-            Args = "submodule update";
+            Args = ["submodule", "update"];
 
             if (init)
-                Args += " --init";
+                Args.Add("--init");
             if (recursive)
-                Args += " --recursive";
+                Args.Add("--recursive");
             if (useRemote)
-                Args += " --remote";
+                Args.Add("--remote");
             if (!string.IsNullOrEmpty(module))
-                Args += $" -- \"{module}\"";
+                Args.AddRange(["--", module]);
 
             _outputHandler = outputHandler;
             return Exec();
@@ -48,11 +48,11 @@ namespace SourceGit.Commands
 
         public bool Delete(string relativePath)
         {
-            Args = $"submodule deinit -f \"{relativePath}\"";
+            Args = ["submodule", "deinit", "-f", relativePath];
             if (!Exec())
                 return false;
 
-            Args = $"rm -rf \"{relativePath}\"";
+            Args = ["rm", "-rf", relativePath];
             return Exec();
         }
 

--- a/src/Commands/Tag.cs
+++ b/src/Commands/Tag.cs
@@ -10,27 +10,27 @@ namespace SourceGit.Commands
             var cmd = new Command();
             cmd.WorkingDirectory = repo;
             cmd.Context = repo;
-            cmd.Args = $"tag {name} {basedOn}";
+            cmd.Args = ["tag", name, basedOn];
             return cmd.Exec();
         }
 
         public static bool Add(string repo, string name, string basedOn, string message, bool sign)
         {
-            var param = sign ? "-s -a" : "-a";
+            IEnumerable<string> param = sign ? ["-s", "-a"] : ["-a"];
             var cmd = new Command();
             cmd.WorkingDirectory = repo;
             cmd.Context = repo;
-            cmd.Args = $"tag {param} {name} {basedOn} ";
+            cmd.Args = ["tag", ..param, name, basedOn];
 
             if (!string.IsNullOrEmpty(message))
             {
                 string tmp = Path.GetTempFileName();
                 File.WriteAllText(tmp, message);
-                cmd.Args += $"-F \"{tmp}\"";
+                cmd.Args.AddRange(["-F", tmp]);
             }
             else
             {
-                cmd.Args += $"-m {name}";
+                cmd.Args.AddRange(["-m", name]);
             }
 
             return cmd.Exec();
@@ -41,7 +41,7 @@ namespace SourceGit.Commands
             var cmd = new Command();
             cmd.WorkingDirectory = repo;
             cmd.Context = repo;
-            cmd.Args = $"tag --delete {name}";
+            cmd.Args = ["tag", "--delete", name];
             if (!cmd.Exec())
                 return false;
 

--- a/src/Commands/UnstageChangesForAmend.cs
+++ b/src/Commands/UnstageChangesForAmend.cs
@@ -53,10 +53,11 @@ namespace SourceGit.Commands
 
         public bool Exec()
         {
-            var starter = new ProcessStartInfo();
+            var starter = new ProcessStartInfo(
+                Native.OS.GitExecutable,
+                ["-c", "core.editor=true", "update-index", "--index-info"]
+            );
             starter.WorkingDirectory = _repo;
-            starter.FileName = Native.OS.GitExecutable;
-            starter.Arguments = "-c core.editor=true update-index --index-info";
             starter.UseShellExecute = false;
             starter.CreateNoWindow = true;
             starter.WindowStyle = ProcessWindowStyle.Hidden;

--- a/src/Commands/Version.cs
+++ b/src/Commands/Version.cs
@@ -4,7 +4,7 @@
     {
         public Version()
         {
-            Args = "--version";
+            Args = ["--version"];
             RaiseError = false;
         }
 

--- a/src/Commands/Worktree.cs
+++ b/src/Commands/Worktree.cs
@@ -13,7 +13,7 @@ namespace SourceGit.Commands
 
         public List<Models.Worktree> List()
         {
-            Args = "worktree list --porcelain";
+            Args = ["worktree", "list", "--porcelain"];
 
             var rs = ReadToEnd();
             var worktrees = new List<Models.Worktree>();
@@ -56,23 +56,23 @@ namespace SourceGit.Commands
 
         public bool Add(string fullpath, string name, bool createNew, string tracking, Action<string> outputHandler)
         {
-            Args = "worktree add ";
+            Args = ["worktree", "add"];
 
             if (!string.IsNullOrEmpty(tracking))
-                Args += "--track ";
+                Args.Add("--track");
 
             if (!string.IsNullOrEmpty(name))
             {
                 if (createNew)
-                    Args += $"-b {name} ";
+                    Args.AddRange(["-b", name]);
                 else
-                    Args += $"-B {name} ";
+                    Args.AddRange(["-B", name]);
             }
 
-            Args += $"\"{fullpath}\" ";
+            Args.Add(fullpath);
 
             if (!string.IsNullOrEmpty(tracking))
-                Args += tracking;
+                Args.Add(tracking);
 
             _outputHandler = outputHandler;
             return Exec();
@@ -80,29 +80,29 @@ namespace SourceGit.Commands
 
         public bool Prune(Action<string> outputHandler)
         {
-            Args = "worktree prune -v";
+            Args = ["worktree", "prune", "-v"];
             _outputHandler = outputHandler;
             return Exec();
         }
 
         public bool Lock(string fullpath)
         {
-            Args = $"worktree lock \"{fullpath}\"";
+            Args = ["worktree", "lock", fullpath];
             return Exec();
         }
 
         public bool Unlock(string fullpath)
         {
-            Args = $"worktree unlock \"{fullpath}\"";
+            Args = ["worktree", "unlock", fullpath];
             return Exec();
         }
 
         public bool Remove(string fullpath, bool force, Action<string> outputHandler)
         {
             if (force)
-                Args = $"worktree remove -f \"{fullpath}\"";
+                Args = ["worktree", "remove", "-f", fullpath];
             else
-                Args = $"worktree remove \"{fullpath}\"";
+                Args = ["worktree", "remove", fullpath];
 
             _outputHandler = outputHandler;
             return Exec();

--- a/src/Models/DiffOption.cs
+++ b/src/Models/DiffOption.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Text;
 
 namespace SourceGit.Models
 {
@@ -27,7 +26,7 @@ namespace SourceGit.Models
                 {
                     case ChangeState.Added:
                     case ChangeState.Untracked:
-                        _extra = "--no-index";
+                        _extra = ["--no-index"];
                         _path = change.Path;
                         _orgPath = "/dev/null";
                         break;
@@ -40,9 +39,9 @@ namespace SourceGit.Models
             else
             {
                 if (change.DataForAmend != null)
-                    _extra = "--cached HEAD^";
+                    _extra = ["--cached", "HEAD^"];
                 else
-                    _extra = "--cached";
+                    _extra = ["--cached"];
 
                 _path = change.Path;
                 _orgPath = change.OriginalPath;
@@ -94,27 +93,25 @@ namespace SourceGit.Models
         ///     Converts to diff command arguments.
         /// </summary>
         /// <returns></returns>
-        public override string ToString()
+        public List<string> ToArgs()
         {
-            var builder = new StringBuilder();
-            if (!string.IsNullOrEmpty(_extra))
-                builder.Append($"{_extra} ");
-            foreach (var r in _revisions)
-                builder.Append($"{r} ");
+            var args = new List<string>();
+            args.AddRange(_extra);
+            args.AddRange(_revisions);
 
-            builder.Append("-- ");
+            args.Add("--");
             if (!string.IsNullOrEmpty(_orgPath))
-                builder.Append($"\"{_orgPath}\" ");
-            builder.Append($"\"{_path}\"");
+                args.Add(_orgPath);
+            args.Add(_path);
 
-            return builder.ToString();
+            return args;
         }
 
         private readonly Change _workingCopyChange = null;
         private readonly bool _isUnstaged = false;
         private readonly string _path;
         private readonly string _orgPath = string.Empty;
-        private readonly string _extra = string.Empty;
+        private readonly IEnumerable<string> _extra = [];
         private readonly List<string> _revisions = new List<string>();
     }
 }

--- a/src/Native/Linux.cs
+++ b/src/Native/Linux.cs
@@ -52,20 +52,20 @@ namespace SourceGit.Native
 
         public void OpenBrowser(string url)
         {
-            Process.Start("xdg-open", $"\"{url}\"");
+            Process.Start("xdg-open", [url]);
         }
 
         public void OpenInFileManager(string path, bool select)
         {
             if (Directory.Exists(path))
             {
-                Process.Start("xdg-open", $"\"{path}\"");
+                Process.Start("xdg-open", [path]);
             }
             else
             {
                 var dir = Path.GetDirectoryName(path);
                 if (Directory.Exists(dir))
-                    Process.Start("xdg-open", $"\"{dir}\"");
+                    Process.Start("xdg-open", [dir]);
             }
         }
 
@@ -85,7 +85,7 @@ namespace SourceGit.Native
 
         public void OpenWithDefaultEditor(string file)
         {
-            var proc = Process.Start("xdg-open", $"\"{file}\"");
+            var proc = Process.Start("xdg-open", [file]);
             if (proc != null)
             {
                 proc.WaitForExit();

--- a/src/Native/MacOS.cs
+++ b/src/Native/MacOS.cs
@@ -51,27 +51,27 @@ namespace SourceGit.Native
 
         public void OpenBrowser(string url)
         {
-            Process.Start("open", url);
+            Process.Start("open", [url]);
         }
 
         public void OpenInFileManager(string path, bool select)
         {
             if (Directory.Exists(path))
-                Process.Start("open", $"\"{path}\"");
+                Process.Start("open", [path]);
             else if (File.Exists(path))
-                Process.Start("open", $"\"{path}\" -R");
+                Process.Start("open", [path]);
         }
 
         public void OpenTerminal(string workdir)
         {
             var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
             var dir = string.IsNullOrEmpty(workdir) ? home : workdir;
-            Process.Start("open", $"-a {OS.ShellOrTerminal} \"{dir}\"");
+            Process.Start("open", ["-a", OS.ShellOrTerminal, dir]);
         }
 
         public void OpenWithDefaultEditor(string file)
         {
-            Process.Start("open", $"\"{file}\"");
+            Process.Start("open", [file]);
         }
     }
 }

--- a/src/Native/Windows.cs
+++ b/src/Native/Windows.cs
@@ -151,7 +151,7 @@ namespace SourceGit.Native
 
         public void OpenBrowser(string url)
         {
-            var info = new ProcessStartInfo("cmd", $"/c start {url}");
+            var info = new ProcessStartInfo("cmd", ["/c", "start", url]);
             info.CreateNoWindow = true;
             Process.Start(info);
         }
@@ -201,7 +201,7 @@ namespace SourceGit.Native
         public void OpenWithDefaultEditor(string file)
         {
             var info = new FileInfo(file);
-            var start = new ProcessStartInfo("cmd", $"/c start \"\" \"{info.FullName}\"");
+            var start = new ProcessStartInfo("cmd", ["/c", "start", "", info.FullName]);
             start.CreateNoWindow = true;
             Process.Start(start);
         }

--- a/src/ViewModels/Clone.cs
+++ b/src/ViewModels/Clone.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.IO;
 using System.Threading.Tasks;
@@ -47,7 +48,7 @@ namespace SourceGit.ViewModels
             set => SetProperty(ref _local, value);
         }
 
-        public string ExtraArgs
+        public IEnumerable<string> ExtraArgs
         {
             get => _extraArgs;
             set => SetProperty(ref _extraArgs, value);
@@ -154,6 +155,6 @@ namespace SourceGit.ViewModels
         private string _sshKey = string.Empty;
         private string _parentFolder = Preference.Instance.GitDefaultCloneDir;
         private string _local = string.Empty;
-        private string _extraArgs = string.Empty;
+        private IEnumerable<string> _extraArgs = [];
     }
 }

--- a/src/ViewModels/FileHistories.cs
+++ b/src/ViewModels/FileHistories.cs
@@ -63,7 +63,7 @@ namespace SourceGit.ViewModels
 
             Task.Run(() =>
             {
-                var commits = new Commands.QueryCommits(_repo.FullPath, $"-n 10000 -- \"{file}\"", false).Result();
+                var commits = new Commands.QueryCommits(_repo.FullPath, ["-n", "10000", "--", file], false).Result();
                 Dispatcher.UIThread.Invoke(() =>
                 {
                     IsLoading = false;

--- a/src/ViewModels/InProgressContexts.cs
+++ b/src/ViewModels/InProgressContexts.cs
@@ -28,7 +28,7 @@ namespace SourceGit.ViewModels
             {
                 WorkingDirectory = Repository,
                 Context = Repository,
-                Args = $"{Cmd} --abort",
+                Args = [Cmd, "--abort"],
             }.Exec();
         }
 
@@ -39,7 +39,7 @@ namespace SourceGit.ViewModels
                 WorkingDirectory = Repository,
                 Context = Repository,
                 Editor = Commands.Command.EditorType.None,
-                Args = $"{Cmd} --continue",
+                Args = [Cmd, "--continue"],
             }.Exec();
         }
     }
@@ -63,7 +63,7 @@ namespace SourceGit.ViewModels
                 WorkingDirectory = Repository,
                 Context = Repository,
                 Editor = Commands.Command.EditorType.RebaseEditor,
-                Args = $"rebase --continue",
+                Args = ["rebase", "--continue"],
             }.Exec();
 
             if (succ)

--- a/src/ViewModels/InteractiveRebase.cs
+++ b/src/ViewModels/InteractiveRebase.cs
@@ -118,7 +118,7 @@ namespace SourceGit.ViewModels
 
             Task.Run(() =>
             {
-                var commits = new Commands.QueryCommitsWithFullMessage(repoPath, $"{on.SHA}...HEAD").Result();
+                var commits = new Commands.QueryCommitsWithFullMessage(repoPath, [$"{on.SHA}...HEAD"]).Result();
                 var list = new List<InteractiveRebaseItem>();
 
                 foreach (var c in commits)

--- a/src/ViewModels/Repository.cs
+++ b/src/ViewModels/Repository.cs
@@ -765,9 +765,9 @@ namespace SourceGit.ViewModels
         {
             Dispatcher.UIThread.Invoke(() => _histories.IsLoading = true);
 
-            var limits = $"-{Preference.Instance.MaxHistoryCommits} ";
+            List<string> limits = [$"-{Preference.Instance.MaxHistoryCommits}"];
             if (_enableFirstParentInHistories)
-                limits += "--first-parent ";
+                limits.Add("--first-parent");
 
             var validFilters = new List<string>();
             foreach (var filter in _settings.Filters)
@@ -786,7 +786,7 @@ namespace SourceGit.ViewModels
 
             if (validFilters.Count > 0)
             {
-                limits += string.Join(" ", validFilters);
+                limits.AddRange(validFilters);
 
                 if (_settings.Filters.Count != validFilters.Count)
                 {
@@ -799,7 +799,7 @@ namespace SourceGit.ViewModels
             }
             else
             {
-                limits += "--exclude=refs/stash --all";
+                limits.AddRange(["--exclude=refs/stash", "-all"]);
             }
 
             var commits = new Commands.QueryCommits(_fullpath, limits).Result();

--- a/src/Views/TextDiffView.axaml.cs
+++ b/src/Views/TextDiffView.axaml.cs
@@ -1211,7 +1211,7 @@ namespace SourceGit.Views
                     diff.GeneratePatchFromSelectionSingleSide(change, treeGuid, selection, false, chunk.IsOldSide, tmpFile);
                 }
 
-                new Commands.Apply(diff.Repo, tmpFile, true, "nowarn", "--cache --index").Exec();
+                new Commands.Apply(diff.Repo, tmpFile, true, "nowarn", ["--cache", "--index"]).Exec();
                 File.Delete(tmpFile);
             }
 
@@ -1265,7 +1265,7 @@ namespace SourceGit.Views
                 else
                     diff.GeneratePatchFromSelectionSingleSide(change, treeGuid, selection, true, chunk.IsOldSide, tmpFile);
 
-                new Commands.Apply(diff.Repo, tmpFile, true, "nowarn", "--cache --index --reverse").Exec();
+                new Commands.Apply(diff.Repo, tmpFile, true, "nowarn", ["--cache", "--index", "--reverse"]).Exec();
                 File.Delete(tmpFile);
             }
 
@@ -1323,7 +1323,7 @@ namespace SourceGit.Views
                     diff.GeneratePatchFromSelectionSingleSide(change, treeGuid, selection, true, chunk.IsOldSide, tmpFile);
                 }
 
-                new Commands.Apply(diff.Repo, tmpFile, true, "nowarn", "--reverse").Exec();
+                new Commands.Apply(diff.Repo, tmpFile, true, "nowarn", ["--reverse"]).Exec();
                 File.Delete(tmpFile);
             }
 


### PR DESCRIPTION
This will refactor command arguments from a single string to an argument array

Argument arrays are easier to work with, and you don't have to worry about escaping arguments. They are also easier to work with because you can split them into multiple lines

I've tested all the features I use, but an extra pair of eyes is really needed :grin: