### PR TITLE
Add DE keys for new OpenAI commit message generation

### DIFF
--- a/src/Resources/Locales/de_DE.axaml
+++ b/src/Resources/Locales/de_DE.axaml
@@ -20,6 +20,8 @@
   <x:String x:Key="Text.AddWorktree.Name.Placeholder" xml:space="preserve">Optional. Standard ist der Zielordnername.</x:String>
   <x:String x:Key="Text.AddWorktree.Tracking" xml:space="preserve">Branch verfolgen:</x:String>
   <x:String x:Key="Text.AddWorktree.Tracking.Toggle" xml:space="preserve">Remote-Branch verfolgen</x:String>
+  <x:String x:Key="Text.AIAssistant" xml:space="preserve">OpenAI Assistent</x:String>
+  <x:String x:Key="Text.AIAssistant.Tip" xml:space="preserve">Verwende OpenAI, um Commit-Nachrichten zu generieren</x:String>
   <x:String x:Key="Text.Apply" xml:space="preserve">Patch</x:String>
   <x:String x:Key="Text.Apply.Error" xml:space="preserve">Fehler</x:String>
   <x:String x:Key="Text.Apply.Error.Desc" xml:space="preserve">Fehler werfen und anwenden des Patches verweigern</x:String>
@@ -385,6 +387,10 @@
   <x:String x:Key="Text.Period.LastYear" xml:space="preserve">Leztes Jahr</x:String>
   <x:String x:Key="Text.Period.YearsAgo" xml:space="preserve">Vor {0} Jahren</x:String>
   <x:String x:Key="Text.Preference" xml:space="preserve">Einstellungen</x:String>
+  <x:String x:Key="Text.Preference.AI" xml:space="preserve">OPEN AI</x:String>
+  <x:String x:Key="Text.Preference.AI.Server" xml:space="preserve">Server</x:String>
+  <x:String x:Key="Text.Preference.AI.ApiKey" xml:space="preserve">API Schlüssel</x:String>
+  <x:String x:Key="Text.Preference.AI.Model" xml:space="preserve">Modell</x:String>
   <x:String x:Key="Text.Preference.Appearance" xml:space="preserve">DARSTELLUNG</x:String>
   <x:String x:Key="Text.Preference.Appearance.DefaultFont" xml:space="preserve">Standardschriftart</x:String>
   <x:String x:Key="Text.Preference.Appearance.DefaultFontSize" xml:space="preserve">Standardschriftgröße</x:String>


### PR DESCRIPTION
Added the German translations again.

## Thoughts
- Could have left "API Key" since this term is quite common but "Schlüssel" is the actual translation. Works either way