### PR TITLE
Small fixes to support opening terminal in flatpak

### DIFF
--- a/src/Native/Linux.cs
+++ b/src/Native/Linux.cs
@@ -78,7 +78,8 @@ namespace SourceGit.Native
             }
 
             var startInfo = new ProcessStartInfo();
-            startInfo.WorkingDirectory = string.IsNullOrEmpty(workdir) ? "~" : workdir;
+            var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+            startInfo.WorkingDirectory = string.IsNullOrEmpty(workdir) ? home : workdir;
             startInfo.FileName = OS.ShellOrTerminal;
             Process.Start(startInfo);
         }

--- a/src/Native/OS.cs
+++ b/src/Native/OS.cs
@@ -95,7 +95,7 @@ namespace SourceGit.Native
         public static void OpenTerminal(string workdir)
         {
             if (string.IsNullOrEmpty(ShellOrTerminal))
-                App.RaiseException(workdir, $"Can not found terminal! Please confirm that the correct shell/terminal has been configured.");
+                App.RaiseException(workdir, $"Terminal is not specified! Please confirm that the correct shell/terminal has been configured.");
             else
                 _backend.OpenTerminal(workdir);
         }

--- a/src/Native/Windows.cs
+++ b/src/Native/Windows.cs
@@ -160,7 +160,7 @@ namespace SourceGit.Native
         {
             if (string.IsNullOrEmpty(OS.ShellOrTerminal) || !File.Exists(OS.ShellOrTerminal))
             {
-                App.RaiseException(workdir, $"Can not found terminal! Please confirm that the correct shell/terminal has been configured.");
+                App.RaiseException(workdir, $"Terminal is not specified! Please confirm that the correct shell/terminal has been configured.");
                 return;
             }
 


### PR DESCRIPTION
This also includes a small error message correction, a fix for crash when opening terminal on the Welcome page on Linux, and finally will add support for spawning host's terminal form flatpak.
There's no support to use host's merge tools, as changes will collide with #473 and I still need some time to implement it properly but it is on the way