### PR TITLE
Few terminal fixes

### DIFF
--- a/src/Models/ShellOrTerminal.cs
+++ b/src/Models/ShellOrTerminal.cs
@@ -54,6 +54,7 @@ namespace SourceGit.Models
                     new ShellOrTerminal("deepin-terminal", "Deepin Terminal", "deepin-terminal"),
                     new ShellOrTerminal("mate-terminal", "MATE Terminal", "mate-terminal"),
                     new ShellOrTerminal("foot", "Foot", "foot"),
+                    new ShellOrTerminal("custom", "Custom", ""),
                 };
             }
         }

--- a/src/Native/Linux.cs
+++ b/src/Native/Linux.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using System.Linq.Expressions;
 using System.Runtime.Versioning;
 
 using Avalonia;
@@ -27,6 +26,11 @@ namespace SourceGit.Native
 
         public string FindTerminal(Models.ShellOrTerminal shell)
         {
+            if (string.IsNullOrEmpty(shell.Exec))
+            {
+                return string.Empty;
+            }
+
             var pathVariable = Environment.GetEnvironmentVariable("PATH") ?? string.Empty;
             var pathes = pathVariable.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries);
             foreach (var path in pathes)

--- a/src/Native/Linux.cs
+++ b/src/Native/Linux.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Linq.Expressions;
 using System.Runtime.Versioning;
 
 using Avalonia;
@@ -71,9 +72,9 @@ namespace SourceGit.Native
 
         public void OpenTerminal(string workdir)
         {
-            if (string.IsNullOrEmpty(OS.ShellOrTerminal) || !File.Exists(OS.ShellOrTerminal))
+            if (string.IsNullOrEmpty(OS.ShellOrTerminal))
             {
-                App.RaiseException(workdir, $"Can not found terminal! Please confirm that the correct shell/terminal has been configured.");
+                App.RaiseException(workdir, $"Terminal is not specified! Please confirm that the correct shell/terminal has been configured.");
                 return;
             }
 
@@ -81,7 +82,14 @@ namespace SourceGit.Native
             var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
             startInfo.WorkingDirectory = string.IsNullOrEmpty(workdir) ? home : workdir;
             startInfo.FileName = OS.ShellOrTerminal;
-            Process.Start(startInfo);
+            try
+            {
+                Process.Start(startInfo);
+            }
+            catch (Exception e)
+            {
+                App.RaiseException(workdir, e.Message);
+            }
         }
 
         public void OpenWithDefaultEditor(string file)

--- a/src/Native/Linux.cs
+++ b/src/Native/Linux.cs
@@ -78,7 +78,8 @@ namespace SourceGit.Native
             }
 
             var startInfo = new ProcessStartInfo();
-            startInfo.WorkingDirectory = string.IsNullOrEmpty(workdir) ? "~" : workdir;
+            var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+            startInfo.WorkingDirectory = string.IsNullOrEmpty(workdir) ? home : workdir;
             startInfo.FileName = OS.ShellOrTerminal;
             Process.Start(startInfo);
         }

--- a/src/Native/OS.cs
+++ b/src/Native/OS.cs
@@ -95,7 +95,7 @@ namespace SourceGit.Native
         public static void OpenTerminal(string workdir)
         {
             if (string.IsNullOrEmpty(ShellOrTerminal))
-                App.RaiseException(workdir, $"Can not found terminal! Please confirm that the correct shell/terminal has been configured.");
+                App.RaiseException(workdir, $"Terminal is not specified! Please confirm that the correct shell/terminal has been configured.");
             else
                 _backend.OpenTerminal(workdir);
         }

--- a/src/Native/Windows.cs
+++ b/src/Native/Windows.cs
@@ -160,7 +160,7 @@ namespace SourceGit.Native
         {
             if (string.IsNullOrEmpty(OS.ShellOrTerminal) || !File.Exists(OS.ShellOrTerminal))
             {
-                App.RaiseException(workdir, $"Can not found terminal! Please confirm that the correct shell/terminal has been configured.");
+                App.RaiseException(workdir, $"Terminal is not specified! Please confirm that the correct shell/terminal has been configured.");
                 return;
             }
 

--- a/src/ViewModels/Preference.cs
+++ b/src/ViewModels/Preference.cs
@@ -41,6 +41,22 @@ namespace SourceGit.ViewModels
                 if (!_instance.IsGitConfigured())
                     _instance.GitInstallPath = Native.OS.FindGitExecutable();
 
+                if (!_instance.IsTerminalConfigured())
+                {
+                    for (var i = 0; i < Models.ShellOrTerminal.Supported.Count; i++)
+                    {
+                        _instance.ShellOrTerminal = i;
+                        if (string.IsNullOrEmpty(_instance.ShellOrTerminalPath))
+                        {
+                            _instance.ShellOrTerminal = -1;
+                        }
+                        else
+                        {
+                            break;
+                        }
+                    }
+                }
+
                 if (_instance.Workspaces.Count == 0)
                     _instance.Workspaces.Add(new Workspace() { Name = "Default", Color = 4278221015 });
 
@@ -378,6 +394,11 @@ namespace SourceGit.ViewModels
         {
             var path = GitInstallPath;
             return !string.IsNullOrEmpty(path) && File.Exists(path);
+        }
+
+        public bool IsTerminalConfigured()
+        {
+            return ShellOrTerminal != -1;
         }
 
         public bool ShouldCheck4UpdateOnStartup()


### PR DESCRIPTION
* Fix crash on Welcome screen
* Allow custom terminal and non-absolute executable names for terminals (useful when setting a custom terminal)
* Catch errors thrown by `Process.Start` when terminal configuration is invalid on Linux