### PR TITLE
fix: avoid NRE in ContextMenuExtension

### DIFF
--- a/src/Views/ContextMenuExtension.cs
+++ b/src/Views/ContextMenuExtension.cs
@@ -1,6 +1,5 @@
 ﻿using System.ComponentModel;
 using Avalonia.Controls;
-using Avalonia.Threading;
 
 namespace SourceGit.Views
 {
@@ -15,10 +14,7 @@ namespace SourceGit.Views
             menu.Closing += OnContextMenuClosing; // Clear context menu because it is dynamic.
 
             control.ContextMenu = menu;
-            Dispatcher.UIThread.InvokeAsync(() =>
-            {
-                control.ContextMenu?.Open();
-            });
+            control.ContextMenu?.Open();
         }
 
         private static void OnContextMenuClosing(object sender, CancelEventArgs e)

--- a/src/Views/ContextMenuExtension.cs
+++ b/src/Views/ContextMenuExtension.cs
@@ -1,6 +1,6 @@
 ﻿using System.ComponentModel;
-
 using Avalonia.Controls;
+using Avalonia.Threading;
 
 namespace SourceGit.Views
 {
@@ -15,7 +15,10 @@ namespace SourceGit.Views
             menu.Closing += OnContextMenuClosing; // Clear context menu because it is dynamic.
 
             control.ContextMenu = menu;
-            control.ContextMenu.Open();
+            Dispatcher.UIThread.InvokeAsync(() =>
+            {
+                control.ContextMenu?.Open();
+            });
         }
 
         private static void OnContextMenuClosing(object sender, CancelEventArgs e)


### PR DESCRIPTION
Sometimes the context menu may be set to `null` before opening. For example, the `Avalonia` repository has many branches. If you right-click multiple times before the context menu of the branch is opened, NRE will appear.