### PR TITLE
Add option to set different push URL

### DIFF
--- a/src/Commands/QueryRemotes.cs
+++ b/src/Commands/QueryRemotes.cs
@@ -30,10 +30,16 @@ namespace SourceGit.Commands
             var remote = new Models.Remote()
             {
                 Name = match.Groups[1].Value,
-                URL = match.Groups[2].Value,
+                URL = match.Groups[0].Value.Contains("fetch") ? match.Groups[2].Value : "",
+                PushURL = match.Groups[0].Value.Contains("push") ? match.Groups[2].Value : "",
             };
+            var alreadyFound = _loaded.Find(x => x.Name == remote.Name);
+            if (alreadyFound != null && !string.IsNullOrEmpty(remote.PushURL))
+            {
+                alreadyFound.PushURL = alreadyFound.URL != remote.PushURL ? remote.PushURL : "";
+            }
 
-            if (_loaded.Find(x => x.Name == remote.Name) != null)
+            if (alreadyFound != null)
                 return;
             _loaded.Add(remote);
         }

--- a/src/Commands/Remote.cs
+++ b/src/Commands/Remote.cs
@@ -35,6 +35,24 @@
         public bool SetURL(string name, string url)
         {
             Args = $"remote set-url {name} {url}";
+            var first = Exec();
+            Args = $"remote set-url {name} {url} --push";
+            return Exec() && first;
+        }
+
+        public bool SetPushURL(string name, string oldUrl, string newUrl)
+        {
+            if (oldUrl == newUrl)
+                return true;
+
+            if (string.IsNullOrEmpty(newUrl) && !string.IsNullOrEmpty(oldUrl))
+            {
+                Args = $"remote set-url --push --delete {name} {oldUrl}";
+            }
+            else
+            {
+                Args = $"remote set-url --push {name} {newUrl}";
+            }
             return Exec();
         }
     }

--- a/src/Models/Remote.cs
+++ b/src/Models/Remote.cs
@@ -23,6 +23,7 @@ namespace SourceGit.Models
 
         public string Name { get; set; }
         public string URL { get; set; }
+        public string PushURL { get; set; }
 
         public static bool IsSSH(string url)
         {

--- a/src/Resources/Locales/en_US.axaml
+++ b/src/Resources/Locales/en_US.axaml
@@ -477,7 +477,9 @@
   <x:String x:Key="Text.Remote.Name" xml:space="preserve">Name:</x:String>
   <x:String x:Key="Text.Remote.Name.Placeholder" xml:space="preserve">Remote name</x:String>
   <x:String x:Key="Text.Remote.URL" xml:space="preserve">Repository URL:</x:String>
+  <x:String x:Key="Text.Remote.PushURL" xml:space="preserve">Push URL:</x:String>
   <x:String x:Key="Text.Remote.URL.Placeholder" xml:space="preserve">Remote git repository URL</x:String>
+  <x:String x:Key="Text.Remote.PushURL.Placeholder" xml:space="preserve">Leave empty if same as URL</x:String>
   <x:String x:Key="Text.RemoteCM.CopyURL" xml:space="preserve">Copy URL</x:String>
   <x:String x:Key="Text.RemoteCM.Delete" xml:space="preserve">Delete...</x:String>
   <x:String x:Key="Text.RemoteCM.Edit" xml:space="preserve">Edit...</x:String>

--- a/src/Views/EditRemote.axaml
+++ b/src/Views/EditRemote.axaml
@@ -35,13 +35,24 @@
                CornerRadius="2"
                Watermark="{DynamicResource Text.Remote.URL.Placeholder}"
                Text="{Binding Url, Mode=TwoWay}"/>
-
+      
       <TextBlock Grid.Row="2" Grid.Column="0"
+                 HorizontalAlignment="Right" VerticalAlignment="Center"
+                 Margin="0,0,8,0"
+                 Text="{DynamicResource Text.Remote.PushURL}"/>
+      <TextBox Grid.Row="2" Grid.Column="1"
+               Height="26"
+               VerticalAlignment="Center"
+               CornerRadius="2"
+               Watermark="{DynamicResource Text.Remote.PushURL.Placeholder}"
+               Text="{Binding PushUrl, Mode=TwoWay}"/>
+
+      <TextBlock Grid.Row="3" Grid.Column="0"
                  HorizontalAlignment="Right" VerticalAlignment="Center"
                  Margin="0,0,8,0"
                  Text="{DynamicResource Text.SSHKey}"
                  IsVisible="{Binding UseSSH}"/>
-      <TextBox Grid.Row="2" Grid.Column="1"
+      <TextBox Grid.Row="3" Grid.Column="1"
                x:Name="TxtSshKey"
                Height="26"
                CornerRadius="3"


### PR DESCRIPTION
I was confused after a separate push URL was set in one of my repos and sourcegit was not able to change the url for the push. 
Even worse, you can't see it at all. 
This PR adds an additional option to the remote edit dialog. If the push URL is set to empty or the same URL AS the fetch URL, the push URL is deleted, so that the remote set-url git command set both URL with the same value. 
I think this is not completed, because of SSH options.
