### PR TITLE
Fix untracked files being staged when hidden

### DIFF
--- a/src/Commands/QueryHasUntrackedFiles.cs
+++ b/src/Commands/QueryHasUntrackedFiles.cs
@@ -1,0 +1,24 @@
+namespace SourceGit.Commands
+{
+    public partial class QueryHasUntrackedFiles : Command
+    {
+        private bool _hasUntracked = false;
+
+        public QueryHasUntrackedFiles(string repo) {
+            WorkingDirectory = repo;
+            Context = repo;
+            Args = "ls-files --others --exclude-standard";
+        }
+
+        public bool Result()
+        {
+            Exec();
+            return _hasUntracked;
+        }
+
+        protected override void OnReadline(string line)
+        {
+            _hasUntracked = true;
+        }
+    }
+}

--- a/src/ViewModels/WorkingCopy.cs
+++ b/src/ViewModels/WorkingCopy.cs
@@ -343,7 +343,18 @@ namespace SourceGit.ViewModels
 
             IsStaging = true;
             _repo.SetWatcherEnabled(false);
-            if (changes.Count == _unstaged.Count)
+
+            var canAddAll = changes.Count == _unstaged.Count;
+            if (canAddAll && !IncludeUntracked) {
+                // If the user chose to hide untracked files, we have to make sure to not
+                // add those by mistake when performing `git add <repo path>`, otherwise those
+                // untracked files will be added as well
+                var hasUntracked = new Commands.QueryHasUntrackedFiles(_repo.FullPath).Exec();
+
+                canAddAll = !hasUntracked;
+            }
+
+            if (canAddAll)
             {
                 await Task.Run(() => new Commands.Add(_repo.FullPath).Exec());
             }


### PR DESCRIPTION
Current version of SourceGit contains an optimization to perform a `git add <repo path>` operation when the number of files being staged equals the number of changes. While this optimization makes perfect sense, it fails to accommodate for untracked files, if those are marked **hidden** in the UI ("Include Untracked Files" is disabled)

Before staging: 
<img width="1136" alt="image" src="https://github.com/user-attachments/assets/b6dd1e9a-2206-486c-9c3f-be79c70b3f3d">

After staging:
<img width="1136" alt="image" src="https://github.com/user-attachments/assets/67555045-6d9f-421d-9ef7-db44caa2d3b6">

This PR includes a fix to check and make sure there are no untracked files present in the repo before performing this operation in order to avoid adding those unwanted files.