### PR TITLE
fix(histories): handle commits with breaking changes

### DIFF
--- a/src/Views/Histories.axaml.cs
+++ b/src/Views/Histories.axaml.cs
@@ -308,7 +308,7 @@ namespace SourceGit.Views
         [GeneratedRegex(@"^\[[\w\s]+\]")]
         private static partial Regex REG_KEYWORD_FORMAT1();
 
-        [GeneratedRegex(@"^\w+([\<\(][\w\s_\-\*,]+[\>\)])?\s?:\s")]
+        [GeneratedRegex(@"^\w+([\<\(][\w\s_\-\*,]+[\>\)])?\!?\s?:\s")]
         private static partial Regex REG_KEYWORD_FORMAT2();
 
         private List<Models.Hyperlink> _matches = null;


### PR DESCRIPTION
Update regex to handle conventional commits with breaking changes (!). [doc](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with--to-draw-attention-to-breaking-change)

![image](https://github.com/user-attachments/assets/edeef249-d3fb-446b-9c7a-38609525ad59)
