### PR TITLE
localization: update zh_TW.axaml

### DIFF
--- a/src/Resources/Locales/zh_TW.axaml
+++ b/src/Resources/Locales/zh_TW.axaml
@@ -146,7 +146,7 @@
   <x:String x:Key="Text.Configure.Git.AutoFetch" xml:space="preserve">啟用定時自動提取 (fetch) 遠端更新</x:String>
   <x:String x:Key="Text.Configure.Git.AutoFetchIntervalSuffix" xml:space="preserve">分鐘</x:String>
   <x:String x:Key="Text.Configure.Git.DefaultRemote" xml:space="preserve">預設遠端存放庫</x:String>
-  <x:String x:Key="Text.Configure.Git.EnableSignOff" xml:space="preserve">提交資訊追加署名 (--signoff)</x:String>
+  <x:String x:Key="Text.Configure.Git.EnableSignOff" xml:space="preserve">提交訊息追加署名 (--signoff)</x:String>
   <x:String x:Key="Text.Configure.IssueTracker" xml:space="preserve">Issue 追蹤</x:String>
   <x:String x:Key="Text.Configure.IssueTracker.AddSampleGithub" xml:space="preserve">新增符合 GitHub Issue 規則</x:String>
   <x:String x:Key="Text.Configure.IssueTracker.AddSampleJira" xml:space="preserve">新增符合 Jira 規則</x:String>
@@ -404,11 +404,13 @@
   <x:String x:Key="Text.Period.LastYear" xml:space="preserve">一年前</x:String>
   <x:String x:Key="Text.Period.YearsAgo" xml:space="preserve">{0} 年前</x:String>
   <x:String x:Key="Text.Preference" xml:space="preserve">偏好設定</x:String>
-  <x:String x:Key="Text.Preference.Advanced" xml:space="preserve">進階選項</x:String>
+  <x:String x:Key="Text.Preference.Advanced" xml:space="preserve">進階設定</x:String>
   <x:String x:Key="Text.Preference.AI" xml:space="preserve">OpenAI</x:String>
   <x:String x:Key="Text.Preference.AI.Server" xml:space="preserve">伺服器</x:String>
   <x:String x:Key="Text.Preference.AI.ApiKey" xml:space="preserve">API 金鑰</x:String>
   <x:String x:Key="Text.Preference.AI.Model" xml:space="preserve">模型</x:String>
+  <x:String x:Key="Text.Preference.AI.AnalyzeDiffPrompt" xml:space="preserve">分析變更差異提示詞</x:String>
+  <x:String x:Key="Text.Preference.AI.GenerateSubjectPrompt" xml:space="preserve">產生提交訊息提示詞</x:String>
   <x:String x:Key="Text.Preference.Appearance" xml:space="preserve">外觀設定</x:String>
   <x:String x:Key="Text.Preference.Appearance.DefaultFont" xml:space="preserve">預設字型</x:String>
   <x:String x:Key="Text.Preference.Appearance.DefaultFontSize" xml:space="preserve">預設字型大小</x:String>
@@ -642,7 +644,7 @@
   <x:String x:Key="Text.WorkingCopy.CommitMessageHelper" xml:space="preserve">歷史輸入/範本</x:String>
   <x:String x:Key="Text.WorkingCopy.CommitTip" xml:space="preserve">觸發點擊事件</x:String>
   <x:String x:Key="Text.WorkingCopy.CommitWithAutoStage" xml:space="preserve">自動暫存全部變更並提交</x:String>
-  <x:String x:Key="Text.WorkingCopy.ConfirmCommitWithoutFiles" xml:space="preserve">提交未包含變更檔案！是否繼續(--allow-empty)？</x:String>
+  <x:String x:Key="Text.WorkingCopy.ConfirmCommitWithoutFiles" xml:space="preserve">未包含任何檔案變更! 您是否仍要提交 (--allow-empty)?</x:String>
   <x:String x:Key="Text.WorkingCopy.Conflicts" xml:space="preserve">檢測到衝突</x:String>
   <x:String x:Key="Text.WorkingCopy.Conflicts.Resolved" xml:space="preserve">檔案衝突已解決</x:String>
   <x:String x:Key="Text.WorkingCopy.IncludeUntracked" xml:space="preserve">顯示未追蹤檔案</x:String>


### PR DESCRIPTION
Made slight adjustments to the Traditional Chinese translations for the strings added over the past week.

> [!NOTE]
> I would include the following tables in each PR updating the Traditional Chinese translation, so that future contributors to the Traditional Chinese translation could use it as a reference or make corrections.

| Original        | Translation     |
| ----------- | -------- |
| Fetch       | 提取     |
| Pull        | 拉取     |
| Push        | 推送     |
| Rebase      | 重定基底 |
| Cherry-pick | 揀選     |
| Checkout    | 簽出     |
| Amend     | 修補    |
| Blame       | 逐行溯源 |
| Archive     | 封存     |
| Patch       | 修補檔   |
| Stash       | 擱置變更 |
| Track       | 追蹤     |
| Local       | 本機     |
| Repository  | 存放庫   |
| Sign         | 簽章 |
| Discard | 捨棄 |
| Terminal | 終端機 |
| Conventional commit | 約定式提交 |
| Clone | *複製 |

- `clone` does not have a corresponding translation in Taiwan, **_nor_** is it transliterated as `克隆`. The translation `複製` is adopted following [Microsoft Terminology](https://msit.powerbi.com/view?r=eyJrIjoiODJmYjU4Y2YtM2M0ZC00YzYxLWE1YTktNzFjYmYxNTAxNjQ0IiwidCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsImMiOjV9).
- Punctuation style follows the [Chinese (Traditional) Localization Style Guide](https://download.microsoft.com/download/2/9/3/293e6d41-ba40-451b-a41e-94bdb6242ae3/zho-twn-StyleGuide.pdf)

| Half-width | Full-width |
| ---------- | ---------- |
| `:`        | `，`       |
| `;`        | `。`       |
| `!`        | `、`       |
| `?`        | `《》`     |
| `( )`      | `＜＞`     |
| `[ ]`      |            |