### PR TITLE
FIX: int out of bounds for branch names with long number

### DIFF
--- a/src/Models/NumericSort.cs
+++ b/src/Models/NumericSort.cs
@@ -51,9 +51,16 @@
                 int result;
                 if (isDigit1 && isDigit2)
                 {
-                    int num1 = int.Parse(sub1);
-                    int num2 = int.Parse(sub2);
-                    result = num1 - num2;
+                    // compare numeric values
+                    if (sub1.Length == sub2.Length)
+                    {
+                        // if length is the same, lexicographical comparison is good also for numbers
+                        result = string.CompareOrdinal(sub1, sub2);
+                    }
+                    else
+                    {
+                        result = sub1.Length.CompareTo(sub2.Length);
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
see screenshot with error:

![image](https://github.com/user-attachments/assets/ae6aedc2-d7f8-48ff-aaa2-dc719ba2b85d)

input to reproduce:

![image](https://github.com/user-attachments/assets/389a850f-542f-4d88-989c-a09e2b5e9abf)


these branches are auto-generated by snaky which is a very popular tool

anyway the code below remove the Parse function completely so no error should occue