### PR TITLE
fix: Make RPM builds compatible with OpenSUSE

### DIFF
--- a/build/resources/rpm/SPECS/build.spec
+++ b/build/resources/rpm/SPECS/build.spec
@@ -6,7 +6,7 @@ License: MIT
 URL: https://sourcegit-scm.github.io/
 Source: https://github.com/sourcegit-scm/sourcegit/archive/refs/tags/v%_version.tar.gz
 Requires: libX11
-Requires: libSM
+Requires: (libSM or libSM6)
 
 %define _build_id_links none
 


### PR DESCRIPTION
While most RPM based distributions use `libSM` as a name for this library OpenSUSE uses `libSM6`.
This leads to unfulfilled dependencies when the RPM package is installed on OpenSUSE `Tumbleweed` for example.

I think it is save to require either `libSM` or `libSM6`, because it is very unlikely a distribution would package the library under both names at the same time. And even if they did the package manager would be responsible to resolve this gracefully.