### PR TITLE
fix: Make RPM builds compatible with OpenSUSE (libX11)

### DIFF
--- a/build/resources/rpm/SPECS/build.spec
+++ b/build/resources/rpm/SPECS/build.spec
@@ -5,7 +5,7 @@ Summary: Open-source & Free Git Gui Client
 License: MIT
 URL: https://sourcegit-scm.github.io/
 Source: https://github.com/sourcegit-scm/sourcegit/archive/refs/tags/v%_version.tar.gz
-Requires: libX11
+Requires: (libX11 or libX11-6)
 Requires: (libSM or libSM6)
 
 %define _build_id_links none


### PR DESCRIPTION
Similar to #622 this allows an alternative name for `libX11`, some distributions use `libX11-6`.

I did not notice it because [dpkg.org](https://pkgs.org/download/libx11-6) does not show this correctly.
Sorry for the noise.