### PR TITLE
feature/autofocus password input field

### DIFF
--- a/src/Views/Askpass.axaml
+++ b/src/Views/Askpass.axaml
@@ -39,9 +39,11 @@
         <TextBlock Text="{Binding Description}" TextWrapping="Wrap"/>
       </Border>
       
-      <TextBox Margin="16"
+      <TextBox Name="PassphraseTextBox"
+               Margin="16"
                MinWidth="300" 
                Height="32" 
+               Focusable="True"
                Text="{Binding Passphrase, Mode=TwoWay}" 
                PasswordChar="*"
                RevealPassword="{Binding ShowPassword, Mode=OneWay}"

--- a/src/Views/Askpass.axaml.cs
+++ b/src/Views/Askpass.axaml.cs
@@ -52,5 +52,11 @@ namespace SourceGit.Views
             Console.Out.Write($"{Passphrase}\n");
             App.Quit(0);
         }
+
+        protected override void OnOpened(EventArgs e)
+        {
+            PassphraseTextBox.Focus();
+            base.OnOpened(e);
+        }
     }
 }


### PR DESCRIPTION
### Description
This change will bring the SSH password field into focus immediately after opening the window and avoid unnecessary mouse movements

### Before
![image](https://github.com/user-attachments/assets/1ada5485-3170-4464-b11d-321cd2a6d239)

### After
![image](https://github.com/user-attachments/assets/f962280d-9503-453c-90d6-0e135a9f8f44)

