### PR TITLE
fix: prevent crash in Custom Action when executable path is missing

### DIFF
--- a/src/Commands/ExecuteCustomAction.cs
+++ b/src/Commands/ExecuteCustomAction.cs
@@ -45,6 +45,9 @@ namespace SourceGit.Commands
             try
             {
                 proc.Start();
+                proc.BeginOutputReadLine();
+                proc.BeginErrorReadLine();
+                proc.WaitForExit();
             }
             catch (Exception e)
             {
@@ -54,9 +57,6 @@ namespace SourceGit.Commands
                 });
             }
 
-            proc.BeginOutputReadLine();
-            proc.BeginErrorReadLine();
-            proc.WaitForExit();
             proc.Close();
         }
     }


### PR DESCRIPTION
This pull request addresses an issue in Custom Action that caused the application to crash if the executable path was not specified. Although it's unlikely anyone would forget, this is just to be safe :joy:

## Before

https://github.com/user-attachments/assets/54114c29-1629-4bab-a247-69da3d7e4956

## After

https://github.com/user-attachments/assets/def980e3-5362-4917-8dfc-7f6b48c0180c

## Note

This is just a simple solution, so I didn’t address the issue where a pop-up panel may briefly flash on the screen.

![popup](https://github.com/user-attachments/assets/480964f5-6b53-45e5-86e6-4fdf7175b5e9)