### PR TITLE
feature: add support for Visual Studio as external tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ This app supports open repository in external tools listed in the table below.
 | JetBrains Fleet               | YES     | YES   | YES   | FLEET                          |
 | Sublime Text                  | YES     | YES   | YES   | SUBLIME_TEXT                   |
 | Zed                           | NO      | YES   | YES   | ZED                            |
+| Visual Studio                 | YES     | YES   | YES   | VISUALSTUDIO                   |
 
 > [!NOTE]
 > This app will try to find those tools based on some pre-defined or expected locations automatically. If you are using one portable version of these tools, it will not be detected by this app.

--- a/src/Models/ExternalTool.cs
+++ b/src/Models/ExternalTool.cs
@@ -154,6 +154,11 @@ namespace SourceGit.Models
             TryAdd("Zed", "zed", "\"{0}\"", "ZED", platformFinder);
         }
 
+        public void VisualStudio(Func<string> platformFinder)
+        {
+            TryAdd("Visual Studio", "vs", "\"{0}\"", "VISUALSTUDIO", platformFinder);
+        }
+
         public void FindJetBrainsFromToolbox(Func<string> platformFinder)
         {
             var exclude = new List<string> { "fleet", "dotmemory", "dottrace", "resharper-u", "androidstudio" };

--- a/src/Native/Windows.cs
+++ b/src/Native/Windows.cs
@@ -134,6 +134,7 @@ namespace SourceGit.Native
             finder.Fleet(() => $"{Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData)}\\Programs\\Fleet\\Fleet.exe");
             finder.FindJetBrainsFromToolbox(() => $"{Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData)}\\JetBrains\\Toolbox");
             finder.SublimeText(FindSublimeText);
+            finder.VisualStudio(FindVisualStudio);
             return finder.Founded;
         }
 
@@ -309,6 +310,25 @@ namespace SourceGit.Native
             {
                 var icon = sublime3.GetValue("DisplayIcon") as string;
                 return Path.Combine(Path.GetDirectoryName(icon)!, "subl.exe");
+            }
+
+            return string.Empty;
+        }
+
+        private string FindVisualStudio()
+        {
+            var localMachine = Microsoft.Win32.RegistryKey.OpenBaseKey(
+                    Microsoft.Win32.RegistryHive.LocalMachine,
+                    Microsoft.Win32.RegistryView.Registry64);
+
+            // Get default class for VisualStudio.Launcher.sln - the handler for *.sln files
+            if (localMachine.OpenSubKey(@"SOFTWARE\Classes\VisualStudio.Launcher.sln\CLSID") is Microsoft.Win32.RegistryKey launcher)
+            {
+                // Get actual path to the executable
+                if (launcher.GetValue(string.Empty) is string CLSID && localMachine.OpenSubKey(@$"SOFTWARE\Classes\CLSID\{CLSID}\LocalServer32") is Microsoft.Win32.RegistryKey devenv && devenv.GetValue(string.Empty) is string localServer32)
+                {
+                    return localServer32!.Trim('\"');
+                }
             }
 
             return string.Empty;


### PR DESCRIPTION
This allows using Visual Studio as an external tool for opening the repo in.

Current limitations:
* Visual Studio for Mac is not supported.
* It only relies on registry for Visual Studio location (reportedly Visual Studio can be installed without modifying the registry;  other discovery mechanisms may be used).
* SourceGit tries to open the whole repo as a directory.  From my experience,  when you actually need Visual Studio  (as opposed to Visual Studio Code),  you normally want to open a solution file instead.  One may expect a prompt asking how to open a project and allowing to select a solution file interactively.  Instead, the implementation tries to locate a solution file and to open it directly,  falling back to repo directory only in case of failure.

The solution finding bit is more objectionable,  and the implementation is messier,  so it is split out into its own commit.

Basically,  I've implemented specifically what _I_ need to make use of the external tools functionality.