### PR TITLE
Adding hotkeys for creating branch, pushing and pulling

### DIFF
--- a/src/Resources/Locales/en_US.axaml
+++ b/src/Resources/Locales/en_US.axaml
@@ -370,6 +370,9 @@
   <x:String x:Key="Text.Hotkeys.Repo.ViewChanges" xml:space="preserve">Switch to 'Changes'</x:String>
   <x:String x:Key="Text.Hotkeys.Repo.ViewHistories" xml:space="preserve">Switch to 'Histories'</x:String>
   <x:String x:Key="Text.Hotkeys.Repo.ViewStashes" xml:space="preserve">Switch to 'Stashes'</x:String>
+  <x:String x:Key="Text.Hotkeys.Repo.Pull" xml:space="preserve">Pull, starts directly</x:String>
+  <x:String x:Key="Text.Hotkeys.Repo.Push" xml:space="preserve">Push, starts directly</x:String>
+  <x:String x:Key="Text.Hotkeys.Repo.CreateBranchOnCommit" xml:space="preserve">Creates a new branch based on selected commit</x:String>
   <x:String x:Key="Text.Hotkeys.TextEditor" xml:space="preserve">TEXT EDITOR</x:String>
   <x:String x:Key="Text.Hotkeys.TextEditor.CloseSearch" xml:space="preserve">Close search panel</x:String>
   <x:String x:Key="Text.Hotkeys.TextEditor.GotoNextMatch" xml:space="preserve">Find next match</x:String>

--- a/src/ViewModels/Histories.cs
+++ b/src/ViewModels/Histories.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Text;
 
 using Avalonia.Controls;
+using Avalonia.Input;
 using Avalonia.Platform.Storage;
 
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -544,6 +545,7 @@ namespace SourceGit.ViewModels
             var createBranch = new MenuItem();
             createBranch.Icon = App.CreateMenuIcon("Icons.Branch.Add");
             createBranch.Header = App.Text("CreateBranch");
+            createBranch.HotKey = new KeyGesture(Key.B, KeyModifiers.Control);
             createBranch.Click += (_, e) =>
             {
                 if (PopupHost.CanCreatePopup())

--- a/src/Views/Histories.axaml.cs
+++ b/src/Views/Histories.axaml.cs
@@ -12,6 +12,7 @@ using Avalonia.Interactivity;
 using Avalonia.Media;
 using Avalonia.Threading;
 using Avalonia.VisualTree;
+using SourceGit.ViewModels;
 
 namespace SourceGit.Views
 {
@@ -722,19 +723,38 @@ namespace SourceGit.Views
 
         private void OnCommitListKeyDown(object sender, KeyEventArgs e)
         {
+            // These shortcuts are not mentioned in the Shortcut Reference window. Is this expected?
             if (sender is ListBox { SelectedItems: { Count: > 0 } selected } &&
-                e.Key == Key.C &&
                 e.KeyModifiers.HasFlag(KeyModifiers.Control))
             {
-                var builder = new StringBuilder();
-                foreach (var item in selected)
+                // CTRL + C -> Copy selected commit SHA and subject.
+                if (e.Key == Key.C)
                 {
-                    if (item is Models.Commit commit)
-                        builder.AppendLine($"{commit.SHA.Substring(0, 10)} - {commit.Subject}");
+                    var builder = new StringBuilder();
+                    foreach (var item in selected)
+                    {
+                        if (item is Models.Commit commit)
+                            builder.AppendLine($"{commit.SHA.Substring(0, 10)} - {commit.Subject}");
+                    }
+
+                    App.CopyText(builder.ToString());
+                    e.Handled = true;
+                    return;
                 }
 
-                App.CopyText(builder.ToString());
-                e.Handled = true;
+                // CTRL + B -> shows Create Branch pop-up at selected commit.
+                if (e.Key == Key.B)
+                {
+                    if (selected.Count == 1 &&
+                        selected[0] is Models.Commit commit &&
+                        DataContext is ViewModels.Histories histories &&
+                        PopupHost.CanCreatePopup())
+                    {
+                        PopupHost.ShowPopup(new ViewModels.CreateBranch(histories.Repo, commit));
+                        e.Handled = true;
+
+                    }
+                }
             }
         }
 

--- a/src/Views/Hotkeys.axaml
+++ b/src/Views/Hotkeys.axaml
@@ -71,7 +71,7 @@
                    FontSize="{Binding Source={x:Static vm:Preference.Instance}, Path=DefaultFontSize, Converter={x:Static c:DoubleConverters.Increase}}"
                    Margin="0,8"/>
 
-        <Grid RowDefinitions="20,20,20,20,20,20,20,20,20,20,20" ColumnDefinitions="150,*">
+        <Grid RowDefinitions="20,20,20,20,20,20,20,20,20,20,20,20,20,20" ColumnDefinitions="150,*">
           <TextBlock Grid.Row="0" Grid.Column="0" Classes="primary bold" Text="{OnPlatform Ctrl+Shift+H, macOS=⌘+⇧+H}"/>
           <TextBlock Grid.Row="0" Grid.Column="1" Margin="16,0,0,0" Text="{DynamicResource Text.Hotkeys.Repo.GoHome}" />
           
@@ -102,8 +102,17 @@
           <TextBlock Grid.Row="9" Grid.Column="0" Classes="primary bold" Text="{OnPlatform Alt+Enter, macOS=⌥+Enter}"/>
           <TextBlock Grid.Row="9" Grid.Column="1" Margin="16,0,0,0" Text="{DynamicResource Text.Hotkeys.Repo.CommitAndPush}" />
 
-          <TextBlock Grid.Row="10" Grid.Column="0" Classes="primary bold" Text="F5"/>
-          <TextBlock Grid.Row="10" Grid.Column="1" Margin="16,0,0,0" Text="{DynamicResource Text.Hotkeys.Repo.Refresh}" />
+          <TextBlock Grid.Row="10" Grid.Column="0" Classes="primary bold" Text="{OnPlatform Ctrl+Shift+Down, macOS=⌘+Shift+Down}"/>
+          <TextBlock Grid.Row="10" Grid.Column="1" Margin="16,0,0,0" Text="{DynamicResource Text.Hotkeys.Repo.Pull}" />
+
+          <TextBlock Grid.Row="11" Grid.Column="0" Classes="primary bold" Text="{OnPlatform Ctrl+Shift+Up, macOS=⌘+Shift+Up}"/>
+          <TextBlock Grid.Row="11" Grid.Column="1" Margin="16,0,0,0" Text="{DynamicResource Text.Hotkeys.Repo.Push}" />
+
+          <TextBlock Grid.Row="12" Grid.Column="0" Classes="primary bold" Text="{OnPlatform Ctrl+B, macOS=⌘+B}"/>
+          <TextBlock Grid.Row="12" Grid.Column="1" Margin="16,0,0,0" Text="{DynamicResource Text.Hotkeys.Repo.CreateBranchOnCommit}" />
+
+          <TextBlock Grid.Row="13" Grid.Column="0" Classes="primary bold" Text="F5"/>
+          <TextBlock Grid.Row="13" Grid.Column="1" Margin="16,0,0,0" Text="{DynamicResource Text.Hotkeys.Repo.Refresh}" />
         </Grid>
 
         <TextBlock Text="{DynamicResource Text.Hotkeys.TextEditor}"

--- a/src/Views/RepositoryToolbar.axaml
+++ b/src/Views/RepositoryToolbar.axaml
@@ -42,7 +42,7 @@
           <Path Width="14" Height="14" Data="{StaticResource Icons.Fetch}"/>
         </Button>
 
-        <Button Classes="icon_button" Width="32" Margin="16,0,0,0" Click="Pull">
+        <Button Classes="icon_button" Width="32" Margin="16,0,0,0" Click="Pull" HotKey="{OnPlatform Ctrl+Shift+Down, macOS=⌘+Shift+Down}">
           <ToolTip.Tip>
             <StackPanel Orientation="Vertical">
               <TextBlock Text="{DynamicResource Text.Pull}"/>
@@ -53,7 +53,7 @@
           <Path Width="14" Height="14" Data="{StaticResource Icons.Pull}"/>
         </Button>
 
-        <Button Classes="icon_button" Width="32" Margin="16,0,0,0" Click="Push">
+        <Button Classes="icon_button" Width="32" Margin="16,0,0,0" Click="Push" HotKey="{OnPlatform Ctrl+Shift+Up, macOS=⌘+Shift+Up}">
           <ToolTip.Tip>
             <StackPanel Orientation="Vertical">
               <TextBlock Text="{DynamicResource Text.Push}"/>
@@ -85,6 +85,7 @@
                    Fill="{DynamicResource Brush.Border2}"/>
 
         <Button Classes="icon_button" Width="32" Margin="16,0,0,0" Command="{Binding CreateNewBranch}" ToolTip.Tip="{DynamicResource Text.Repository.NewBranch}">
+
           <Path Width="14" Height="14" Data="{StaticResource Icons.Branch.Add}"/>
         </Button>
 


### PR DESCRIPTION
### Summary
Nothing big, just adding keyboard shortcuts for:
- **Pull** (starts directly)
- **Push** (starts directly)
- **Create Branch** (based on selected commit)

### Motivation
Those are some of the operations I do most often, it's nice to have shortcuts. I also added those to the `Hotkeys` window.

### Implementation
For creating branch, I didn't use the `HotKey=""` property of Avalonia XML, as I needed the selected commit. I implemented it on the already existing `OnCommitListKeyDown` event.

Not sure how to handle localization, I've only added the new strings to `en_US`.