### PR TITLE
enhance: depend on SO in rpm package 

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -293,6 +293,10 @@ end_of_line = lf
 [*.{cmd,bat}]
 end_of_line = crlf
 
+# Package manifests
+[{*.spec,control}]
+end_of_line = lf
+
 # YAML files
 [*.{yml,yaml}]
 indent_size = 2

--- a/.gitattributes
+++ b/.gitattributes
@@ -3,6 +3,8 @@
 *.png      binary
 *.ico      binary
 *.sh       text eol=lf
+*.spec     text eol=lf
+control    text eol=lf
 *.bat      text eol=crlf
 *.cmd      text eol=crlf
 *.ps1      text eol=crlf

--- a/build/resources/rpm/SPECS/build.spec
+++ b/build/resources/rpm/SPECS/build.spec
@@ -5,8 +5,8 @@ Summary: Open-source & Free Git Gui Client
 License: MIT
 URL: https://sourcegit-scm.github.io/
 Source: https://github.com/sourcegit-scm/sourcegit/archive/refs/tags/v%_version.tar.gz
-Requires: (libX11 or libX11-6)
-Requires: (libSM or libSM6)
+Requires: libX11.so.6()(%{__isa_bits}bit)
+Requires: libSM.so.6()(%{__isa_bits}bit)
 
 %define _build_id_links none
 

--- a/build/scripts/package.linux.sh
+++ b/build/scripts/package.linux.sh
@@ -5,16 +5,6 @@ set -o
 set -u
 set pipefail
 
-if [[ -z "$VERSION" ]]; then
-    echo "Provide the version as environment variable VERSION"
-    exit 1
-fi
-
-if [[ -z "$RUNTIME" ]]; then
-    echo "Provide the runtime as environment variable RUNTIME"
-    exit 1
-fi
-
 arch=
 appimage_arch=
 target=

--- a/build/scripts/package.osx-app.sh
+++ b/build/scripts/package.osx-app.sh
@@ -5,16 +5,6 @@ set -o
 set -u
 set pipefail
 
-if [[ -z "$VERSION" ]]; then
-    echo "Provide the version as environment variable VERSION"
-    exit 1
-fi
-
-if [[ -z "$RUNTIME" ]]; then
-    echo "Provide the runtime as environment variable RUNTIME"
-    exit 1
-fi
-
 cd build
 
 mkdir -p SourceGit.app/Contents/Resources

--- a/build/scripts/package.windows-portable.sh
+++ b/build/scripts/package.windows-portable.sh
@@ -5,16 +5,6 @@ set -o
 set -u
 set pipefail
 
-if [[ -z "$VERSION" ]]; then
-    echo "Provide the version as environment variable VERSION"
-    exit 1
-fi
-
-if [[ -z "$RUNTIME" ]]; then
-    echo "Provide the runtime as environment variable RUNTIME"
-    exit 1
-fi
-
 cd build
 
 rm -rf SourceGit/*.pdb


### PR DESCRIPTION
Refactor rpm's `Requires:` to depend on SO instead of package

Add `*.spec` and `control` to `.gitattributes` and `.editorconfig` (without it vscode will change EOL to CRLF every time file is touched, a bit inconvenient when testing locally)

Remove redundant `VERSION` and `RUNTIME` variable checks in CI build scripts as `set -u` was introduced in #498

Tested with Fedora 41 (x86_64 and arm64), openSUSE 15.6 (x86_64 and arm64)

Closes #686