### PR TITLE
fix: SourceGit misspelled as "Source Git"

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -3,7 +3,7 @@ on:
   workflow_call:
     inputs:
       version:
-        description: Source Git package version
+        description: SourceGit package version
         required: true
         type: string
 jobs:

--- a/build/resources/_common/applications/sourcegit.desktop
+++ b/build/resources/_common/applications/sourcegit.desktop
@@ -1,5 +1,5 @@
 [Desktop Entry]
-Name=Source Git
+Name=SourceGit
 Comment=Open-source & Free Git GUI Client
 Exec=/opt/sourcegit/sourcegit
 Icon=/usr/share/icons/sourcegit.png


### PR DESCRIPTION
SourceGit is misspelled in the `.desktop` file, and this inconsistent spelling is really annoying when you use application starters like KRunner or dmenu :grin: