### PR TITLE
feat: delete orphan remote tracking branches

### DIFF
--- a/src/Commands/Branch.cs
+++ b/src/Commands/Branch.cs
@@ -52,5 +52,27 @@
             cmd.Args = $"push {remote} --delete {name}";
             return cmd.Exec();
         }
+
+        public static bool DeleteRemoteTracking(string repo, string name)
+        {
+            var cmd = new Command();
+            cmd.WorkingDirectory = repo;
+            cmd.Context = repo;
+            cmd.Args = $"branch -D -r {name}";
+            return cmd.Exec();
+        }
+
+        public static bool HasRemote(string repo, string remote, string name)
+        {
+            var cmd = new Command();
+            cmd.WorkingDirectory = repo;
+            cmd.Context = repo;
+            cmd.SSHKey = new Config(repo).Get($"remote.{remote}.sshkey");
+            cmd.Args = $"ls-remote {remote} {name}";
+            
+            var rs = cmd.ReadToEnd();
+            
+            return rs.StdOut.Length > 0;
+        }
     }
 }

--- a/src/ViewModels/DeleteBranch.cs
+++ b/src/ViewModels/DeleteBranch.cs
@@ -57,8 +57,22 @@ namespace SourceGit.ViewModels
 
                     if (_alsoDeleteTrackingRemote && TrackingRemoteBranch != null)
                     {
-                        SetProgressDescription("Deleting remote-tracking branch...");
-                        Commands.Branch.DeleteRemote(_repo.FullPath, TrackingRemoteBranch.Remote, TrackingRemoteBranch.Name);
+
+                        if (Commands.Branch.HasRemote(_repo.FullPath, TrackingRemoteBranch.Remote, TrackingRemoteBranch.Name))
+                        {
+                            SetProgressDescription("Deleting remote-tracking branch and remote branch...");
+
+                            Commands.Branch.DeleteRemote(_repo.FullPath, TrackingRemoteBranch.Remote, TrackingRemoteBranch.Name);
+                        } 
+                        else
+                        {
+                            SetProgressDescription("Deleting remote-tracking branch...");
+
+                            var remoteTrackingBranch = $"{TrackingRemoteBranch.Remote}/{TrackingRemoteBranch.Name}";
+
+                            Commands.Branch.DeleteRemoteTracking(_repo.FullPath, remoteTrackingBranch);
+                        }
+
                     }
                 }
                 else if(!Commands.Branch.HasRemote(_repo.FullPath, Target.Remote, Target.Name))

--- a/src/ViewModels/DeleteBranch.cs
+++ b/src/ViewModels/DeleteBranch.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 
 namespace SourceGit.ViewModels
 {
@@ -56,12 +57,20 @@ namespace SourceGit.ViewModels
 
                     if (_alsoDeleteTrackingRemote && TrackingRemoteBranch != null)
                     {
-                        SetProgressDescription("Deleting tracking remote branch...");
+                        SetProgressDescription("Deleting remote-tracking branch...");
                         Commands.Branch.DeleteRemote(_repo.FullPath, TrackingRemoteBranch.Remote, TrackingRemoteBranch.Name);
                     }
                 }
-                else
+                else if(!Commands.Branch.HasRemote(_repo.FullPath, Target.Remote, Target.Name))
                 {
+                    SetProgressDescription("Remote branch not found. Deleting remote-tracking branch...");
+                    var remoteTrackingBranch = $"{Target.Remote}/{Target.Name}";
+
+                    Commands.Branch.DeleteRemoteTracking(_repo.FullPath, remoteTrackingBranch);
+                }
+                else 
+                {
+                    SetProgressDescription("Deleting remote-tracking branch...");
                     Commands.Branch.DeleteRemote(_repo.FullPath, Target.Remote, Target.Name);
                 }
 


### PR DESCRIPTION
### Goal
- Allow users to remove local remote-tracking branches without remotes (ie. remote was removed on merge request).

**Displayed error**
![image](https://github.com/user-attachments/assets/594d15c7-d386-4a03-addc-05368017788a)
![image](https://github.com/user-attachments/assets/05292b80-03b8-433b-a803-ff4361fa1573)

### Changes
- Included 'DeleteRemoteTracking' and 'HasRemote' util methods to handle this case.
- We have local and remote-tracking but not a remote branch. We need to remove both or only the tracking based on the checkbox and on the 'hasRemote' condition
