### PR TITLE
fix: commit histories double click error

### DIFF
--- a/src/ViewModels/Histories.cs
+++ b/src/ViewModels/Histories.cs
@@ -150,8 +150,11 @@ namespace SourceGit.ViewModels
             {
                 _repo.SearchResultSelectedCommit = null;
                 DetailContext = null;
+
+                return;
             }
-            else if (commits.Count == 1)
+            
+            if (commits.Count == 1)
             {
                 var commit = (commits[0] as Models.Commit)!;
                 if (_repo.SearchResultSelectedCommit == null || _repo.SearchResultSelectedCommit.SHA != commit.SHA)
@@ -170,20 +173,23 @@ namespace SourceGit.ViewModels
                     commitDetail.Commit = commit;
                     DetailContext = commitDetail;
                 }
+
+                return;
             }
-            else if (commits.Count == 2)
+            
+            if (commits.Count == 2)
             {
                 _repo.SearchResultSelectedCommit = null;
 
                 var end = commits[0] as Models.Commit;
                 var start = commits[1] as Models.Commit;
                 DetailContext = new RevisionCompare(_repo.FullPath, start, end);
+
+                return;
             }
-            else
-            {
-                _repo.SearchResultSelectedCommit = null;
-                DetailContext = commits.Count;
-            }
+
+            _repo.SearchResultSelectedCommit = null;
+            DetailContext = commits.Count;
         }
 
         public void DoubleTapped(Models.Commit commit)

--- a/src/Views/Histories.axaml.cs
+++ b/src/Views/Histories.axaml.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Reflection;
 
 using Avalonia;
 using Avalonia.Collections;
@@ -730,7 +731,16 @@ namespace SourceGit.Views
 
         private void OnCommitListDoubleTapped(object sender, TappedEventArgs e)
         {
-            if (DataContext is ViewModels.Histories histories && sender is ListBox { SelectedItems: { Count: 1 } selected })
+            // Retrieve the PropertyInfo for the "Name" property
+            var nameProperty = e.Source.GetType().GetProperty("Name");
+
+            // Get the value of the "Name" property, or null if it doesn't exist
+            string nameValue = nameProperty?.GetValue(e.Source) as string;
+
+            // Check if has clicked the Background of the ListBox
+            bool isInvalidUiPressed = nameValue == "PART_ContentPresenter";
+
+            if (DataContext is ViewModels.Histories histories && !isInvalidUiPressed && sender is ListBox { SelectedItems: { Count: 1 } selected })
             {
                 histories.DoubleTapped(selected[0] as Models.Commit);
             }


### PR DESCRIPTION
**Error**
When a commit was selected (single click without checkout) and the user double tapped in an empty part of the histories ListBox
![image](https://github.com/user-attachments/assets/62f3b27c-ed8b-4398-9dc2-35061503fa06)

The Checkout message was displayed for the last selected commit. 
![image](https://github.com/user-attachments/assets/ea446430-fea3-4a2c-8d2d-4a27c3498389)

**Fix**
It shouldn't execute that action unless the user double tap on a commit. I validated the name of the pressed UI element and ignore the empty part of the checkbox.

