### PR TITLE
File histories from commit view

### DIFF
--- a/src/ViewModels/CommitDetail.cs
+++ b/src/ViewModels/CommitDetail.cs
@@ -293,7 +293,7 @@ namespace SourceGit.ViewModels
             history.Icon = App.CreateMenuIcon("Icons.Histories");
             history.Click += (_, ev) =>
             {
-                var window = new Views.FileHistories() { DataContext = new FileHistories(_repo, change.Path) };
+                var window = new Views.FileHistories() { DataContext = new FileHistories(_repo, change.Path, _commit.SHA) };
                 window.Show();
                 ev.Handled = true;
             };
@@ -434,7 +434,7 @@ namespace SourceGit.ViewModels
             history.Icon = App.CreateMenuIcon("Icons.Histories");
             history.Click += (_, ev) =>
             {
-                var window = new Views.FileHistories() { DataContext = new FileHistories(_repo, file.Path) };
+                var window = new Views.FileHistories() { DataContext = new FileHistories(_repo, file.Path, _commit.SHA) };
                 window.Show();
                 ev.Handled = true;
             };

--- a/src/ViewModels/FileHistories.cs
+++ b/src/ViewModels/FileHistories.cs
@@ -57,14 +57,14 @@ namespace SourceGit.ViewModels
             private set => SetProperty(ref _viewContent, value);
         }
 
-        public FileHistories(Repository repo, string file)
+        public FileHistories(Repository repo, string file, string commit = null)
         {
             _repo = repo;
             _file = file;
 
             Task.Run(() =>
             {
-                var commits = new Commands.QueryCommits(_repo.FullPath, $"-n 10000 -- \"{file}\"", false).Result();
+                var commits = new Commands.QueryCommits(_repo.FullPath, $"-n 10000 {commit} -- \"{file}\"", false).Result();
                 Dispatcher.UIThread.Invoke(() =>
                 {
                     IsLoading = false;


### PR DESCRIPTION
Currently when the file history is requested,  `git log` runs against the current branch.  Thus if file history is requested for a file from a commit from another visible branch,  the selected commit does not show up in the history.  When the file was added in another branch and was not yet seen in the current branch,  the history view is just empty.

This PR makes the log run against the selected commit,  which makes most sense to me.

Another approach would probably be to find a first parent reference containing current commit and run log against that,  though to me it would be a bit counter-intuitive.