### PR TITLE
Show the list of children in the commit details

### DIFF
--- a/src/Commands/QueryCommitChildren.cs
+++ b/src/Commands/QueryCommitChildren.cs
@@ -5,12 +5,14 @@ namespace SourceGit.Commands
 {
     public class QueryCommitChildren : Command
     {
-        public QueryCommitChildren(string repo, string commit)
+        public QueryCommitChildren(string repo, string commit, string filters)
         {
             WorkingDirectory = repo;
             Context = repo;
             _commit = commit;
-            Args = $"rev-list --parents --all ^{commit}";
+            if (string.IsNullOrEmpty(filters))
+                filters = "--all";
+            Args = $"rev-list --parents {filters} ^{commit}";
         }
 
         public IEnumerable<string> Result()

--- a/src/Commands/QueryCommitChildren.cs
+++ b/src/Commands/QueryCommitChildren.cs
@@ -15,19 +15,19 @@ namespace SourceGit.Commands
             Args = $"rev-list --parents {filters} ^{commit}";
         }
 
+        protected override void OnReadline(string line)
+        {
+            if (line.Contains(_commit))
+                _lines.Add(line);
+        }
+
         public IEnumerable<string> Result()
         {
-            var rs = ReadToEnd();
-            if (!rs.IsSuccess)
-                yield break;
-
-            foreach (string s in rs.StdOut.Split('\n', StringSplitOptions.None))
-            {
-                if (s.Contains(_commit))
-                    yield return s.Substring(0, 40);
-            }
+            Exec();
+            return _lines;
         }
 
         private string _commit;
+        private List<string> _lines = new List<string>();
     }
 }

--- a/src/Commands/QueryCommitChildren.cs
+++ b/src/Commands/QueryCommitChildren.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using SourceGit.ViewModels;
 
 namespace SourceGit.Commands
 {
@@ -12,7 +13,7 @@ namespace SourceGit.Commands
             _commit = commit;
             if (string.IsNullOrEmpty(filters))
                 filters = "--all";
-            Args = $"rev-list --parents {filters} ^{commit}";
+            Args = $"rev-list -{Preference.Instance.MaxHistoryCommits}  --parents {filters} ^{commit}";
         }
 
         protected override void OnReadline(string line)

--- a/src/Commands/QueryCommitChildren.cs
+++ b/src/Commands/QueryCommitChildren.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace SourceGit.Commands
+{
+    public class QueryCommitChildren : Command
+    {
+        public QueryCommitChildren(string repo, string commit)
+        {
+            WorkingDirectory = repo;
+            Context = repo;
+            _commit = commit;
+            Args = $"rev-list --parents --all ^{commit}";
+        }
+
+        public IEnumerable<string> Result()
+        {
+            var rs = ReadToEnd();
+            if (!rs.IsSuccess)
+                yield break;
+
+            foreach (string s in rs.StdOut.Split('\n', StringSplitOptions.None))
+            {
+                if (s.Contains(_commit))
+                    yield return s.Substring(0, 40);
+            }
+        }
+
+        private string _commit;
+    }
+}

--- a/src/Commands/QueryCommitChildren.cs
+++ b/src/Commands/QueryCommitChildren.cs
@@ -19,7 +19,7 @@ namespace SourceGit.Commands
         protected override void OnReadline(string line)
         {
             if (line.Contains(_commit))
-                _lines.Add(line);
+                _lines.Add(line.Substring(0, 40));
         }
 
         public IEnumerable<string> Result()

--- a/src/Resources/Locales/en_US.axaml
+++ b/src/Resources/Locales/en_US.axaml
@@ -452,6 +452,7 @@
   <x:String x:Key="Text.Preference.General.Locale" xml:space="preserve">Language</x:String>
   <x:String x:Key="Text.Preference.General.MaxHistoryCommits" xml:space="preserve">History Commits</x:String>
   <x:String x:Key="Text.Preference.General.ShowAuthorTime" xml:space="preserve">Show author time intead of commit time in graph</x:String>
+  <x:String x:Key="Text.Preference.General.ShowChildren" xml:space="preserve">Show children in the comment details</x:String>
   <x:String x:Key="Text.Preference.General.SubjectGuideLength" xml:space="preserve">Subject Guide Length</x:String>
   <x:String x:Key="Text.Preference.Git" xml:space="preserve">GIT</x:String>
   <x:String x:Key="Text.Preference.Git.CRLF" xml:space="preserve">Enable Auto CRLF</x:String>

--- a/src/Resources/Locales/en_US.axaml
+++ b/src/Resources/Locales/en_US.axaml
@@ -125,6 +125,7 @@
   <x:String x:Key="Text.CommitDetail.Info" xml:space="preserve">INFORMATION</x:String>
   <x:String x:Key="Text.CommitDetail.Info.Author" xml:space="preserve">AUTHOR</x:String>
   <x:String x:Key="Text.CommitDetail.Info.Changed" xml:space="preserve">CHANGED</x:String>
+  <x:String x:Key="Text.CommitDetail.Info.Children" xml:space="preserve">CHILDREN</x:String>
   <x:String x:Key="Text.CommitDetail.Info.Committer" xml:space="preserve">COMMITTER</x:String>
   <x:String x:Key="Text.CommitDetail.Info.ContainsIn" xml:space="preserve">Check refs that contains this commit</x:String>
   <x:String x:Key="Text.CommitDetail.Info.ContainsIn.Title" xml:space="preserve">COMMIT IS CONTAINED BY</x:String>

--- a/src/Resources/Locales/fr_FR.axaml
+++ b/src/Resources/Locales/fr_FR.axaml
@@ -126,6 +126,7 @@
   <x:String x:Key="Text.CommitDetail.Info" xml:space="preserve">INFORMATIONS</x:String>
   <x:String x:Key="Text.CommitDetail.Info.Author" xml:space="preserve">AUTEUR</x:String>
   <x:String x:Key="Text.CommitDetail.Info.Changed" xml:space="preserve">CHANGÉ</x:String>
+  <x:String x:Key="Text.CommitDetail.Info.Children" xml:space="preserve">ENFANTS</x:String>
   <x:String x:Key="Text.CommitDetail.Info.Committer" xml:space="preserve">COMMITTER</x:String>
   <x:String x:Key="Text.CommitDetail.Info.ContainsIn" xml:space="preserve">Vérifier les références contenant ce commit</x:String>
   <x:String x:Key="Text.CommitDetail.Info.ContainsIn.Title" xml:space="preserve">LE COMMIT EST CONTENU PAR</x:String>

--- a/src/ViewModels/CommitDetail.cs
+++ b/src/ViewModels/CommitDetail.cs
@@ -78,6 +78,12 @@ namespace SourceGit.ViewModels
             }
         }
 
+        public AvaloniaList<string> Children
+        {
+            get;
+            private set;
+        } = new AvaloniaList<string>();
+
         public string SearchChangeFilter
         {
             get => _searchChangeFilter;
@@ -515,6 +521,7 @@ namespace SourceGit.ViewModels
             VisibleChanges = null;
             SelectedChanges = null;
             ViewRevisionFileContent = null;
+            Children.Clear();
 
             if (_commit == null)
                 return;
@@ -529,6 +536,12 @@ namespace SourceGit.ViewModels
             {
                 var signInfo = new Commands.QueryCommitSignInfo(_repo.FullPath, _commit.SHA, !_repo.HasAllowedSignersFile).Result();
                 Dispatcher.UIThread.Invoke(() => SignInfo = signInfo);
+            });
+
+            Task.Run(() =>
+            {
+                var children = new Commands.QueryCommitChildren(_repo.FullPath, _commit.SHA).Result();
+                Dispatcher.UIThread.Invoke(() => Children.AddRange(children));
             });
 
             if (_cancelToken != null)

--- a/src/ViewModels/CommitDetail.cs
+++ b/src/ViewModels/CommitDetail.cs
@@ -538,16 +538,19 @@ namespace SourceGit.ViewModels
                 Dispatcher.UIThread.Invoke(() => SignInfo = signInfo);
             });
 
-            Task.Run(() =>
-            {
-                var children = new Commands.QueryCommitChildren(_repo.FullPath, _commit.SHA, _repo.Settings.BuildHistoriesFilter()).Result();
-                Dispatcher.UIThread.Invoke(() => Children.AddRange(children));
-            });
-
             if (_cancelToken != null)
                 _cancelToken.Requested = true;
 
             _cancelToken = new Commands.Command.CancelToken();
+
+            Task.Run(() =>
+            {
+                var cmdChildren = new Commands.QueryCommitChildren(_repo.FullPath, _commit.SHA, _repo.Settings.BuildHistoriesFilter()) { Cancel = _cancelToken };
+                var children = cmdChildren.Result();
+                if (!cmdChildren.Cancel.Requested)
+                    Dispatcher.UIThread.Post(() => Children.AddRange(children));
+            });
+
             Task.Run(() =>
             {
                 var parent = _commit.Parents.Count == 0 ? "4b825dc642cb6eb9a060e54bf8d69288fbee4904" : _commit.Parents[0];

--- a/src/ViewModels/CommitDetail.cs
+++ b/src/ViewModels/CommitDetail.cs
@@ -540,7 +540,7 @@ namespace SourceGit.ViewModels
 
             Task.Run(() =>
             {
-                var children = new Commands.QueryCommitChildren(_repo.FullPath, _commit.SHA).Result();
+                var children = new Commands.QueryCommitChildren(_repo.FullPath, _commit.SHA, _repo.Settings.BuildHistoriesFilter()).Result();
                 Dispatcher.UIThread.Invoke(() => Children.AddRange(children));
             });
 

--- a/src/ViewModels/CommitDetail.cs
+++ b/src/ViewModels/CommitDetail.cs
@@ -543,13 +543,16 @@ namespace SourceGit.ViewModels
 
             _cancelToken = new Commands.Command.CancelToken();
 
-            Task.Run(() =>
+            if (Preference.Instance.ShowChildren)
             {
-                var cmdChildren = new Commands.QueryCommitChildren(_repo.FullPath, _commit.SHA, _repo.Settings.BuildHistoriesFilter()) { Cancel = _cancelToken };
-                var children = cmdChildren.Result();
-                if (!cmdChildren.Cancel.Requested)
-                    Dispatcher.UIThread.Post(() => Children.AddRange(children));
-            });
+                Task.Run(() =>
+                {
+                    var cmdChildren = new Commands.QueryCommitChildren(_repo.FullPath, _commit.SHA, _repo.Settings.BuildHistoriesFilter()) { Cancel = _cancelToken };
+                    var children = cmdChildren.Result();
+                    if (!cmdChildren.Cancel.Requested)
+                        Dispatcher.UIThread.Post(() => Children.AddRange(children));
+                });
+            }
 
             Task.Run(() =>
             {

--- a/src/ViewModels/Preference.cs
+++ b/src/ViewModels/Preference.cs
@@ -294,6 +294,12 @@ namespace SourceGit.ViewModels
             set => SetProperty(ref _statisticsSampleColor, value);
         }
 
+        public bool ShowChildren
+        {
+            get => _showChildren;
+            set => SetProperty(ref _showChildren, value);
+        }
+
         public List<RepositoryNode> RepositoryNodes
         {
             get;
@@ -617,5 +623,7 @@ namespace SourceGit.ViewModels
         private string _externalMergeToolPath = string.Empty;
 
         private uint _statisticsSampleColor = 0xFF00FF00;
+
+        private bool _showChildren = false;
     }
 }

--- a/src/Views/CommitBaseInfo.axaml
+++ b/src/Views/CommitBaseInfo.axaml
@@ -51,7 +51,7 @@
         <Rectangle Height=".65" Margin="8" Fill="{DynamicResource Brush.Border2}" VerticalAlignment="Center"/>
 
         <!-- Base Information -->
-        <Grid RowDefinitions="24,Auto,Auto,Auto" ColumnDefinitions="96,*">
+        <Grid RowDefinitions="24,Auto,Auto,Auto,Auto" ColumnDefinitions="96,*">
           <!-- SHA -->
           <TextBlock Grid.Row="0" Grid.Column="0" Classes="info_label" Text="{DynamicResource Text.CommitDetail.Info.SHA}" />
           <StackPanel Grid.Row="0" Grid.Column="1" Orientation="Horizontal">
@@ -143,9 +143,52 @@
             </ItemsControl.ItemTemplate>
           </ItemsControl>
 
+          <!-- CHILDREN -->
+          <TextBlock Grid.Row="2" Grid.Column="0" Classes="info_label" Text="{DynamicResource Text.CommitDetail.Info.Children}" IsVisible="{Binding #ThisControl.Children.Count, Converter={x:Static c:IntConverters.IsGreaterThanZero}}"/>
+          <ItemsControl Grid.Row="2" Grid.Column="1" Height="24" Margin="12,0,0,0" ItemsSource="{Binding #ThisControl.Children}" IsVisible="{Binding #ThisControl.Children.Count, Converter={x:Static c:IntConverters.IsGreaterThanZero}}">
+            <ItemsControl.ItemsPanel>
+              <ItemsPanelTemplate>
+                <StackPanel Orientation="Horizontal" VerticalAlignment="Center"/>
+              </ItemsPanelTemplate>
+            </ItemsControl.ItemsPanel>
+
+            <ItemsControl.ItemTemplate>
+              <DataTemplate>
+                <TextBlock Classes="primary"
+                           Text="{Binding Converter={x:Static c:StringConverters.ToShortSHA}}"
+                           Foreground="DarkOrange"
+                           TextDecorations="Underline"
+                           Cursor="Hand"
+                           Margin="0,0,16,0"
+                           PointerEntered="OnSHAPointerEntered"
+                           PointerPressed="OnSHAPressed">
+                  <TextBlock.Styles>
+                    <Style Selector="ToolTip">
+                      <Setter Property="MaxWidth" Value="600"/>
+                    </Style>
+                  </TextBlock.Styles>
+
+                  <TextBlock.DataTemplates>
+                    <DataTemplate DataType="m:Commit">
+                      <StackPanel MinWidth="400" Orientation="Vertical">
+                        <Grid ColumnDefinitions="Auto,*,Auto">
+                          <v:Avatar Grid.Column="0" Width="16" Height="16" VerticalAlignment="Center" IsHitTestVisible="False" User="{Binding Author}"/>
+                          <TextBlock Grid.Column="1" Classes="primary" Text="{Binding Author.Name}" Margin="8,0,0,0"/>
+                          <TextBlock Grid.Column="2" Classes="primary" Text="{Binding CommitterTimeStr}" Foreground="{DynamicResource Brush.FG2}" Margin="8,0,0,0"/>
+                        </Grid>
+
+                        <TextBlock Classes="primary" Margin="0,8,0,0" Text="{Binding Subject}" TextWrapping="Wrap"/>
+                      </StackPanel>
+                    </DataTemplate>
+                  </TextBlock.DataTemplates>
+                </TextBlock>
+              </DataTemplate>
+            </ItemsControl.ItemTemplate>
+          </ItemsControl>
+
           <!-- REFS -->
-          <TextBlock Grid.Row="2" Grid.Column="0" Classes="info_label" Text="{DynamicResource Text.CommitDetail.Info.Refs}" IsVisible="{Binding HasDecorators}"/>
-          <Border Grid.Row="2" Grid.Column="1" Margin="12,0,0,0" Height="24" IsVisible="{Binding HasDecorators}">
+          <TextBlock Grid.Row="3" Grid.Column="0" Classes="info_label" Text="{DynamicResource Text.CommitDetail.Info.Refs}" IsVisible="{Binding HasDecorators}"/>
+          <Border Grid.Row="3" Grid.Column="1" Margin="12,0,0,0" Height="24" IsVisible="{Binding HasDecorators}">
             <v:CommitRefsPresenter TagBackground="{DynamicResource Brush.DecoratorTag}"
                                    Foreground="{DynamicResource Brush.FG1}"
                                    FontFamily="{DynamicResource Fonts.Primary}"
@@ -155,8 +198,8 @@
           </Border>
 
           <!-- Messages -->
-          <TextBlock Grid.Row="3" Grid.Column="0" Classes="info_label" Text="{DynamicResource Text.CommitDetail.Info.Message}" VerticalAlignment="Top" Margin="0,4,0,0" />
-          <v:CommitMessagePresenter Grid.Row="4" Grid.Column="1" 
+          <TextBlock Grid.Row="4" Grid.Column="0" Classes="info_label" Text="{DynamicResource Text.CommitDetail.Info.Message}" VerticalAlignment="Top" Margin="0,4,0,0" />
+          <v:CommitMessagePresenter Grid.Row="5" Grid.Column="1" 
                                     Margin="12,5,8,0" 
                                     Classes="primary" 
                                     Message="{Binding #ThisControl.Message}"

--- a/src/Views/CommitBaseInfo.axaml
+++ b/src/Views/CommitBaseInfo.axaml
@@ -102,89 +102,93 @@
 
           <!-- PARENTS -->
           <TextBlock Grid.Row="1" Grid.Column="0" Classes="info_label" Text="{DynamicResource Text.CommitDetail.Info.Parents}" IsVisible="{Binding Parents.Count, Converter={x:Static c:IntConverters.IsGreaterThanZero}}"/>
-          <ItemsControl Grid.Row="1" Grid.Column="1" Height="24" Margin="12,0,0,0" ItemsSource="{Binding Parents}" IsVisible="{Binding Parents.Count, Converter={x:Static c:IntConverters.IsGreaterThanZero}}">
-            <ItemsControl.ItemsPanel>
-              <ItemsPanelTemplate>
-                <StackPanel Orientation="Horizontal" VerticalAlignment="Center"/>
-              </ItemsPanelTemplate>
-            </ItemsControl.ItemsPanel>
+          <ScrollViewer Grid.Row="1" Grid.Column="1" HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Hidden" AllowAutoHide="True">
+            <ItemsControl Height="24" Margin="12,0,0,0" ItemsSource="{Binding Parents}" IsVisible="{Binding Parents.Count, Converter={x:Static c:IntConverters.IsGreaterThanZero}}">
+              <ItemsControl.ItemsPanel>
+                <ItemsPanelTemplate>
+                  <StackPanel Orientation="Horizontal" VerticalAlignment="Center"/>
+                </ItemsPanelTemplate>
+              </ItemsControl.ItemsPanel>
 
-            <ItemsControl.ItemTemplate>
-              <DataTemplate>
-                <TextBlock Classes="primary"
-                           Text="{Binding Converter={x:Static c:StringConverters.ToShortSHA}}"
-                           Foreground="DarkOrange"
-                           TextDecorations="Underline"
-                           Cursor="Hand"
-                           Margin="0,0,16,0"
-                           PointerEntered="OnSHAPointerEntered"
-                           PointerPressed="OnSHAPressed">
-                  <TextBlock.Styles>
-                    <Style Selector="ToolTip">
-                      <Setter Property="MaxWidth" Value="600"/>
-                    </Style>
-                  </TextBlock.Styles>
+              <ItemsControl.ItemTemplate>
+                <DataTemplate>
+                  <TextBlock Classes="primary"
+                             Text="{Binding Converter={x:Static c:StringConverters.ToShortSHA}}"
+                             Foreground="DarkOrange"
+                             TextDecorations="Underline"
+                             Cursor="Hand"
+                             Margin="0,0,16,0"
+                             PointerEntered="OnSHAPointerEntered"
+                             PointerPressed="OnSHAPressed">
+                    <TextBlock.Styles>
+                      <Style Selector="ToolTip">
+                        <Setter Property="MaxWidth" Value="600"/>
+                      </Style>
+                    </TextBlock.Styles>
 
-                  <TextBlock.DataTemplates>
-                    <DataTemplate DataType="m:Commit">
-                      <StackPanel MinWidth="400" Orientation="Vertical">
-                        <Grid ColumnDefinitions="Auto,*,Auto">
-                          <v:Avatar Grid.Column="0" Width="16" Height="16" VerticalAlignment="Center" IsHitTestVisible="False" User="{Binding Author}"/>
-                          <TextBlock Grid.Column="1" Classes="primary" Text="{Binding Author.Name}" Margin="8,0,0,0"/>
-                          <TextBlock Grid.Column="2" Classes="primary" Text="{Binding CommitterTimeStr}" Foreground="{DynamicResource Brush.FG2}" Margin="8,0,0,0"/>
-                        </Grid>
+                    <TextBlock.DataTemplates>
+                      <DataTemplate DataType="m:Commit">
+                        <StackPanel MinWidth="400" Orientation="Vertical">
+                          <Grid ColumnDefinitions="Auto,*,Auto">
+                            <v:Avatar Grid.Column="0" Width="16" Height="16" VerticalAlignment="Center" IsHitTestVisible="False" User="{Binding Author}"/>
+                            <TextBlock Grid.Column="1" Classes="primary" Text="{Binding Author.Name}" Margin="8,0,0,0"/>
+                            <TextBlock Grid.Column="2" Classes="primary" Text="{Binding CommitterTimeStr}" Foreground="{DynamicResource Brush.FG2}" Margin="8,0,0,0"/>
+                          </Grid>
 
-                        <TextBlock Classes="primary" Margin="0,8,0,0" Text="{Binding Subject}" TextWrapping="Wrap"/>
-                      </StackPanel>
-                    </DataTemplate>
-                  </TextBlock.DataTemplates>
-                 </TextBlock>
-              </DataTemplate>
-            </ItemsControl.ItemTemplate>
-          </ItemsControl>
+                          <TextBlock Classes="primary" Margin="0,8,0,0" Text="{Binding Subject}" TextWrapping="Wrap"/>
+                        </StackPanel>
+                      </DataTemplate>
+                    </TextBlock.DataTemplates>
+                  </TextBlock>
+                </DataTemplate>
+              </ItemsControl.ItemTemplate>
+            </ItemsControl>
+          </ScrollViewer>
 
           <!-- CHILDREN -->
           <TextBlock Grid.Row="2" Grid.Column="0" Classes="info_label" Text="{DynamicResource Text.CommitDetail.Info.Children}" IsVisible="{Binding #ThisControl.Children.Count, Converter={x:Static c:IntConverters.IsGreaterThanZero}}"/>
-          <ItemsControl Grid.Row="2" Grid.Column="1" Height="24" Margin="12,0,0,0" ItemsSource="{Binding #ThisControl.Children}" IsVisible="{Binding #ThisControl.Children.Count, Converter={x:Static c:IntConverters.IsGreaterThanZero}}">
-            <ItemsControl.ItemsPanel>
-              <ItemsPanelTemplate>
-                <StackPanel Orientation="Horizontal" VerticalAlignment="Center"/>
-              </ItemsPanelTemplate>
-            </ItemsControl.ItemsPanel>
+          <ScrollViewer Grid.Row="2" Grid.Column="1" HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Hidden" AllowAutoHide="True">
+            <ItemsControl Height="24" Margin="12,0,0,0" ItemsSource="{Binding #ThisControl.Children}" IsVisible="{Binding #ThisControl.Children.Count, Converter={x:Static c:IntConverters.IsGreaterThanZero}}">
+              <ItemsControl.ItemsPanel>
+                <ItemsPanelTemplate>
+                  <StackPanel Orientation="Horizontal" VerticalAlignment="Center"/>
+                </ItemsPanelTemplate>
+              </ItemsControl.ItemsPanel>
 
-            <ItemsControl.ItemTemplate>
-              <DataTemplate>
-                <TextBlock Classes="primary"
-                           Text="{Binding Converter={x:Static c:StringConverters.ToShortSHA}}"
-                           Foreground="DarkOrange"
-                           TextDecorations="Underline"
-                           Cursor="Hand"
-                           Margin="0,0,16,0"
-                           PointerEntered="OnSHAPointerEntered"
-                           PointerPressed="OnSHAPressed">
-                  <TextBlock.Styles>
-                    <Style Selector="ToolTip">
-                      <Setter Property="MaxWidth" Value="600"/>
-                    </Style>
-                  </TextBlock.Styles>
+              <ItemsControl.ItemTemplate>
+                <DataTemplate>
+                  <TextBlock Classes="primary"
+                             Text="{Binding Converter={x:Static c:StringConverters.ToShortSHA}}"
+                             Foreground="DarkOrange"
+                             TextDecorations="Underline"
+                             Cursor="Hand"
+                             Margin="0,0,16,0"
+                             PointerEntered="OnSHAPointerEntered"
+                             PointerPressed="OnSHAPressed">
+                    <TextBlock.Styles>
+                      <Style Selector="ToolTip">
+                        <Setter Property="MaxWidth" Value="600"/>
+                      </Style>
+                    </TextBlock.Styles>
 
-                  <TextBlock.DataTemplates>
-                    <DataTemplate DataType="m:Commit">
-                      <StackPanel MinWidth="400" Orientation="Vertical">
-                        <Grid ColumnDefinitions="Auto,*,Auto">
-                          <v:Avatar Grid.Column="0" Width="16" Height="16" VerticalAlignment="Center" IsHitTestVisible="False" User="{Binding Author}"/>
-                          <TextBlock Grid.Column="1" Classes="primary" Text="{Binding Author.Name}" Margin="8,0,0,0"/>
-                          <TextBlock Grid.Column="2" Classes="primary" Text="{Binding CommitterTimeStr}" Foreground="{DynamicResource Brush.FG2}" Margin="8,0,0,0"/>
-                        </Grid>
+                    <TextBlock.DataTemplates>
+                      <DataTemplate DataType="m:Commit">
+                        <StackPanel MinWidth="400" Orientation="Vertical">
+                          <Grid ColumnDefinitions="Auto,*,Auto">
+                            <v:Avatar Grid.Column="0" Width="16" Height="16" VerticalAlignment="Center" IsHitTestVisible="False" User="{Binding Author}"/>
+                            <TextBlock Grid.Column="1" Classes="primary" Text="{Binding Author.Name}" Margin="8,0,0,0"/>
+                            <TextBlock Grid.Column="2" Classes="primary" Text="{Binding CommitterTimeStr}" Foreground="{DynamicResource Brush.FG2}" Margin="8,0,0,0"/>
+                          </Grid>
 
-                        <TextBlock Classes="primary" Margin="0,8,0,0" Text="{Binding Subject}" TextWrapping="Wrap"/>
-                      </StackPanel>
-                    </DataTemplate>
-                  </TextBlock.DataTemplates>
-                </TextBlock>
-              </DataTemplate>
-            </ItemsControl.ItemTemplate>
-          </ItemsControl>
+                          <TextBlock Classes="primary" Margin="0,8,0,0" Text="{Binding Subject}" TextWrapping="Wrap"/>
+                        </StackPanel>
+                      </DataTemplate>
+                    </TextBlock.DataTemplates>
+                  </TextBlock>
+                </DataTemplate>
+              </ItemsControl.ItemTemplate>
+            </ItemsControl>
+          </ScrollViewer>
 
           <!-- REFS -->
           <TextBlock Grid.Row="3" Grid.Column="0" Classes="info_label" Text="{DynamicResource Text.CommitDetail.Info.Refs}" IsVisible="{Binding HasDecorators}"/>

--- a/src/Views/CommitBaseInfo.axaml.cs
+++ b/src/Views/CommitBaseInfo.axaml.cs
@@ -55,6 +55,15 @@ namespace SourceGit.Views
             set => SetValue(IssueTrackerRulesProperty, value);
         }
 
+        public static readonly StyledProperty<AvaloniaList<string>> ChildrenProperty =
+            AvaloniaProperty.Register<CommitBaseInfo, AvaloniaList<string>>(nameof(Children));
+
+        public AvaloniaList<string> Children
+        {
+            get => GetValue(ChildrenProperty);
+            set => SetValue(ChildrenProperty, value);
+        }
+
         public CommitBaseInfo()
         {
             InitializeComponent();

--- a/src/Views/CommitDetail.axaml
+++ b/src/Views/CommitDetail.axaml
@@ -24,6 +24,7 @@
                             SignInfo="{Binding SignInfo}"
                             SupportsContainsIn="True"
                             WebLinks="{Binding WebLinks}"
+                            Children="{Binding Children}"
                             IssueTrackerRules="{Binding IssueTrackerRules}"/>
 
           <!-- Line -->

--- a/src/Views/Preference.axaml
+++ b/src/Views/Preference.axaml
@@ -45,7 +45,7 @@
           <TabItem.Header>
             <TextBlock Classes="tab_header" Text="{DynamicResource Text.Preference.General}"/>
           </TabItem.Header>
-          <Grid Margin="8" RowDefinitions="32,32,32,32,32,32" ColumnDefinitions="Auto,*">
+          <Grid Margin="8" RowDefinitions="32,32,32,32,32,32,32" ColumnDefinitions="Auto,*">
             <TextBlock Grid.Row="0" Grid.Column="0"
                        Text="{DynamicResource Text.Preference.General.Locale}"
                        HorizontalAlignment="Right"
@@ -114,6 +114,11 @@
                       Height="32"
                       Content="{DynamicResource Text.Preference.General.Check4UpdatesOnStartup}"
                       IsChecked="{Binding Source={x:Static vm:Preference.Instance}, Path=Check4UpdatesOnStartup, Mode=TwoWay}"/>
+
+            <CheckBox Grid.Row="6" Grid.Column="1"
+                      Height="32"
+                      Content="{DynamicResource Text.Preference.General.ShowChildren}"
+                      IsChecked="{Binding Source={x:Static vm:Preference.Instance}, Path=ShowChildren, Mode=TwoWay}"/>
           </Grid>
         </TabItem>
 
@@ -188,7 +193,7 @@
                   </Border>
                 </NumericUpDown.InnerLeftContent>
               </NumericUpDown>
-            </Grid>            
+            </Grid>
 
             <TextBlock Grid.Row="4" Grid.Column="0"
                        Text="{DynamicResource Text.Preference.Appearance.ThemeOverrides}"


### PR DESCRIPTION
This is an updated version of a previously merged and reverted #673.

The general case remains almost as slow as it was, with the following optimizations:
* The tree is walked one commit less for each ref which contains the commit.
* Git is doing slightly less work as the search is based on parents,  not on children.  As the output is filtered by us anyway, this should be more efficient,  though I didn't measure to be frank.

Additionally,  the git command now respects:
* Filter settings.  The refs that are not visible are not searched, which should eliminate a certain amount of commits for git to chew through.  The impact should not really be worthwhile,  as either most of the time is spent on the references that don't contain the searched commit,  or the searched commit is far enough from the refs for git to take time to reach it anyway.
* `Preference.Instance.MaxHistoryCommits`.  This might provide a positive impact in cases when not all of the common ancestors made it to the graph,  which in practice should not be the case.

I don't see any further optimization opportunities.

That said,  I've tried to address the performance problem by loading children asynchronously.  In the repos that I commonly use this produces no effect whatsoever as the children are found before the view is actually drawn.  I don't have access to the `UnrealEngine` repo,  so I used Torvalds' Linux tree as my test stand,  and indeed for the commits that are further up the tree the commit details get drawn first without children,  and then shortly children blink into the view;  the further I go down the tree,  the longer it takes for the commit details to get rendered,  so that at some point children tasks starts producing results before the view is rendered.  In my testing I only saw times above 0.5 seconds when GC was running;  though performance issues are IO-bound in this case,  so I am not sure whether this figure is representative.

**TL;DR**:  in my testing this iteration is usable with big repos.