### PR TITLE
Switch WinMerge from 3-way merge to 2-way merge

### DIFF
--- a/src/Models/ExternalMerger.cs
+++ b/src/Models/ExternalMerger.cs
@@ -39,7 +39,7 @@ namespace SourceGit.Models
                     new ExternalMerger(4, "tortoise_merge", "Tortoise Merge", "TortoiseMerge.exe;TortoiseGitMerge.exe", "-base:\"$BASE\" -theirs:\"$REMOTE\" -mine:\"$LOCAL\" -merged:\"$MERGED\"", "-base:\"$LOCAL\" -theirs:\"$REMOTE\""),
                     new ExternalMerger(5, "kdiff3", "KDiff3", "kdiff3.exe", "\"$REMOTE\" -b \"$BASE\" \"$LOCAL\" -o \"$MERGED\"", "\"$LOCAL\" \"$REMOTE\""),
                     new ExternalMerger(6, "beyond_compare", "Beyond Compare", "BComp.exe", "\"$REMOTE\" \"$LOCAL\" \"$BASE\" \"$MERGED\"", "\"$LOCAL\" \"$REMOTE\""),
-                    new ExternalMerger(7, "win_merge", "WinMerge", "WinMergeU.exe", "-u -e \"$REMOTE\" \"$LOCAL\" \"$MERGED\"", "-u -e \"$LOCAL\" \"$REMOTE\""),
+                    new ExternalMerger(7, "win_merge", "WinMerge", "WinMergeU.exe", "\"$MERGED\"", "-u -e \"$LOCAL\" \"$REMOTE\""),
                     new ExternalMerger(8, "codium", "VSCodium", "VSCodium.exe", "-n --wait \"$MERGED\"", "-n --wait --diff \"$LOCAL\" \"$REMOTE\""),
                     new ExternalMerger(9, "p4merge", "P4Merge", "p4merge.exe", "-tw 4 \"$BASE\" \"$LOCAL\" \"$REMOTE\" \"$MERGED\"", "-tw 4 \"$LOCAL\" \"$REMOTE\""),
                 };


### PR DESCRIPTION
The WinMerge preset in the application opens WinMerge in a 3-way merge configuration with theirs version on the left, ours in the middle and raw conflict file on the right:
![image](https://github.com/user-attachments/assets/645353ab-0447-46c5-ab1a-626719ab130e)
This seems to be aligned with the advice on the internet,  but provides suboptimal user experience.  The fact that WinMerge doesn't have keyboard shortcuts to operate on the middle pane doesn't help either.

Winmerge supports opening conflict files directly,  and for them it creates a 2 pane UI with theirs version on the left and ours on the right:
![image](https://github.com/user-attachments/assets/93c6af34-ae12-43fd-a157-b8f066fbbc5d)
Ours is what is eventually saved when the conflict is resolved.

To me the latter appears to be much more useful,  _though I can see how someone may want to keep both ours and theirs in their view for the whole conflict resolution session_.