### PR TITLE
fix: don't reverse commit order when cherry-picking

### DIFF
--- a/src/ViewModels/CherryPick.cs
+++ b/src/ViewModels/CherryPick.cs
@@ -85,13 +85,9 @@ namespace SourceGit.ViewModels
                 }
                 else
                 {
-                    var builder = new StringBuilder();
-                    for (int i = Targets.Count - 1; i >= 0; i--)
-                        builder.Append($"{Targets[i].SHA} ");
-
                     succ = new Commands.CherryPick(
                         _repo.FullPath,
-                        builder.ToString(),
+                        string.Join(' ', Targets.ConvertAll(c => c.SHA)),
                         !AutoCommit,
                         AppendSourceToMessage,
                         string.Empty).Exec();


### PR DESCRIPTION
Fixes #726.  Looks like a980cc987d60c038e0ce92eee8fb972fb4737ac6 isn't sufficient.  It sorts the commits according to the ordering in history,  but then CherryPick ViewModel reverses the order.

This commit changes CherryPick ViewModel to use string.Join on the commit list without reordering,  so that the ordering is controlled entirely by the caller.