### PR TITLE
Crash on goto to SHA, NullReferenceException

### DIFF
--- a/src/Views/CommitMessagePresenter.cs
+++ b/src/Views/CommitMessagePresenter.cs
@@ -195,7 +195,7 @@ namespace SourceGit.Views
                             open.Icon = App.CreateMenuIcon("Icons.Commit");
                             open.Click += (_, ev) =>
                             {
-                                detail.NavigateTo(_lastHover.Link);
+                                detail.NavigateTo(link);
                                 ev.Handled = true;
                             };
 


### PR DESCRIPTION
When opening the context menu on a SHA in a commit message and using the "Go to" button, SourceGit crashes.

If the lambda to navigate to the SHA is called the `_lastHover` property is null. The `link` variable should be used as it is in the CopySHA logic.