### PR TITLE
[fix] OnSHAPressed avoid right click nav

### DIFF
--- a/src/Views/CommitBaseInfo.axaml.cs
+++ b/src/Views/CommitBaseInfo.axaml.cs
@@ -151,7 +151,9 @@ namespace SourceGit.Views
 
         private void OnSHAPressed(object sender, PointerPressedEventArgs e)
         {
-            if (DataContext is ViewModels.CommitDetail detail && sender is Control { DataContext: string sha })
+            var point = e.GetCurrentPoint(this);
+
+            if (point.Properties.IsLeftButtonPressed && DataContext is ViewModels.CommitDetail detail && sender is Control { DataContext: string sha })
             {
                 detail.NavigateTo(sha);
             }


### PR DESCRIPTION
- When the right click button is pressed it should not navigate to the parent. Navigation actions only should execute with the left button.