### PR TITLE
Added repositories for deb/rpm packages on buildkite

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -28,8 +28,7 @@ jobs:
          BUILDKITE_TOKEN: ${{ secrets.BUILDKITE_TOKEN }}
        run: |
          FILE=$(echo packages/*.deb)
-         echo $FILE
-         curl -X POST https://api.buildkite.com/v2/packages/organizations/stone-w4tch3r/registries/sourcegit-fork-test-deb/packages \
+         curl -X POST https://api.buildkite.com/v2/packages/organizations/sourcegit/registries/sourcegit-deb/packages \
            -H "Authorization: Bearer $BUILDKITE_TOKEN" \
            -F "file=@$FILE"
 
@@ -38,6 +37,6 @@ jobs:
          BUILDKITE_TOKEN: ${{ secrets.BUILDKITE_TOKEN }}
        run: |
          FILE=$(echo packages/*.rpm)
-         curl -X POST https://api.buildkite.com/v2/packages/organizations/stone-w4tch3r/registries/sourcegit-fork-test-rpm/packages \
+         curl -X POST https://api.buildkite.com/v2/packages/organizations/sourcegit/registries/sourcegit-rpm/packages \
            -H "Authorization: Bearer $BUILDKITE_TOKEN" \
            -F "file=@$FILE"

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -25,7 +25,8 @@ jobs:
          FILE=$(echo packages/*.deb)
          curl -X POST https://api.buildkite.com/v2/packages/organizations/sourcegit/registries/sourcegit-deb/packages \
            -H "Authorization: Bearer $BUILDKITE_TOKEN" \
-           -F "file=@$FILE"
+           -F "file=@$FILE" \
+           --fail
 
      - name: Publish RPM package
        env:
@@ -34,4 +35,5 @@ jobs:
          FILE=$(echo packages/*.rpm)
          curl -X POST https://api.buildkite.com/v2/packages/organizations/sourcegit/registries/sourcegit-rpm/packages \
            -H "Authorization: Bearer $BUILDKITE_TOKEN" \
-           -F "file=@$FILE"
+           -F "file=@$FILE" \
+           --fail

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -17,8 +17,16 @@ jobs:
      matrix:
        runtime: [linux-x64, linux-arm64]
    steps:
-     - name: Install package_cloud
-       run: gem install package_cloud
+     - name: Download and unpack buildkite CLI # ugly, but the only way for now
+       run: |
+         curl -s https://api.github.com/repos/buildkite/cli/releases/latest \
+         | grep "browser_download_url.*amd64.tar.gz" \
+         | cut -d : -f 2,3 \
+         | tr -d \" \
+         | wget -i - -O - \
+         | tar -xz \
+         && mv bk_*/bk . \
+         && rm bk_* -rfd
 
      - name: Download package artifacts
        uses: actions/download-artifact@v4
@@ -30,10 +38,12 @@ jobs:
        env:
          PACKAGECLOUD_TOKEN: ${{ secrets.PACKAGECLOUD_TOKEN }}
        run: |
-         package_cloud push your-username/sourcegit/debian/any packages/*.deb
+         curl -X POST https://api.buildkite.com/v2/packages/organizations/stone-w4tch3r/registries/sourcegit-fork-test-deb/packages \
+           -H "Authorization: Bearer $PACKAGECLOUD_TOKEN" \
+           -F "file=build/sourcegit-0.0.1-1.x86_64.rpm"
 
      - name: Publish RPM package
        env:
          PACKAGECLOUD_TOKEN: ${{ secrets.PACKAGECLOUD_TOKEN }}
        run: |
-         package_cloud push your-username/sourcegit/rpm_any/rpm_any packages/*.rpm
+         package_cloud push stone-w4tch3r/sourcegit-fork-test-rpm/rpm_any/rpm_any packages/*.rpm

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -1,4 +1,4 @@
-name: Publish to PackageCloud
+name: Publish to Buildkite
 on:
  workflow_call:
    inputs:
@@ -7,11 +7,11 @@ on:
        required: true
        type: string
    secrets:
-     PACKAGECLOUD_TOKEN:
+     BUILDKITE_TOKEN:
        required: true
 jobs:
  publish:
-   name: Publish to PackageCloud
+   name: Publish to Buildkite
    runs-on: ubuntu-latest
    strategy:
      matrix:

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -17,17 +17,6 @@ jobs:
      matrix:
        runtime: [linux-x64, linux-arm64]
    steps:
-     - name: Download and unpack buildkite CLI # ugly, but the only way for now
-       run: |
-         curl -s https://api.github.com/repos/buildkite/cli/releases/latest \
-         | grep "browser_download_url.*amd64.tar.gz" \
-         | cut -d : -f 2,3 \
-         | tr -d \" \
-         | wget -i - -O - \
-         | tar -xz \
-         && mv bk_*/bk . \
-         && rm bk_* -rfd
-
      - name: Download package artifacts
        uses: actions/download-artifact@v4
        with:
@@ -36,14 +25,18 @@ jobs:
 
      - name: Publish DEB package
        env:
-         PACKAGECLOUD_TOKEN: ${{ secrets.PACKAGECLOUD_TOKEN }}
+         BUILDKITE_TOKEN: ${{ secrets.BUILDKITE_TOKEN }}
        run: |
+         FILE=$(echo *.deb)
          curl -X POST https://api.buildkite.com/v2/packages/organizations/stone-w4tch3r/registries/sourcegit-fork-test-deb/packages \
-           -H "Authorization: Bearer $PACKAGECLOUD_TOKEN" \
-           -F "file=build/sourcegit-0.0.1-1.x86_64.rpm"
+           -H "Authorization: Bearer $BUILDKITE_TOKEN" \
+           -F "file=@$FILE"
 
      - name: Publish RPM package
        env:
-         PACKAGECLOUD_TOKEN: ${{ secrets.PACKAGECLOUD_TOKEN }}
+         BUILDKITE_TOKEN: ${{ secrets.BUILDKITE_TOKEN }}
        run: |
-         package_cloud push stone-w4tch3r/sourcegit-fork-test-rpm/rpm_any/rpm_any packages/*.rpm
+         FILE=$(echo *.rpm)
+         curl -X POST https://api.buildkite.com/v2/packages/organizations/stone-w4tch3r/registries/sourcegit-fork-test-rpm/packages \
+           -H "Authorization: Bearer $BUILDKITE_TOKEN" \
+           -F "file=@$FILE"

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -27,7 +27,7 @@ jobs:
        env:
          BUILDKITE_TOKEN: ${{ secrets.BUILDKITE_TOKEN }}
        run: |
-         FILE=$(echo *.deb)
+         FILE=$(echo packages/*.deb)
          echo $FILE
          curl -X POST https://api.buildkite.com/v2/packages/organizations/stone-w4tch3r/registries/sourcegit-fork-test-deb/packages \
            -H "Authorization: Bearer $BUILDKITE_TOKEN" \
@@ -37,7 +37,7 @@ jobs:
        env:
          BUILDKITE_TOKEN: ${{ secrets.BUILDKITE_TOKEN }}
        run: |
-         FILE=$(echo *.rpm)
+         FILE=$(echo packages/*.rpm)
          curl -X POST https://api.buildkite.com/v2/packages/organizations/stone-w4tch3r/registries/sourcegit-fork-test-rpm/packages \
            -H "Authorization: Bearer $BUILDKITE_TOKEN" \
            -F "file=@$FILE"

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -1,11 +1,6 @@
 name: Publish to Buildkite
 on:
  workflow_call:
-   inputs:
-     version:
-       description: SourceGit package version
-       required: true
-       type: string
    secrets:
      BUILDKITE_TOKEN:
        required: true

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -28,6 +28,7 @@ jobs:
          BUILDKITE_TOKEN: ${{ secrets.BUILDKITE_TOKEN }}
        run: |
          FILE=$(echo *.deb)
+         echo $FILE
          curl -X POST https://api.buildkite.com/v2/packages/organizations/stone-w4tch3r/registries/sourcegit-fork-test-deb/packages \
            -H "Authorization: Bearer $BUILDKITE_TOKEN" \
            -F "file=@$FILE"

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -1,0 +1,39 @@
+name: Publish to PackageCloud
+on:
+ workflow_call:
+   inputs:
+     version:
+       description: SourceGit package version
+       required: true
+       type: string
+   secrets:
+     PACKAGECLOUD_TOKEN:
+       required: true
+jobs:
+ publish:
+   name: Publish to PackageCloud
+   runs-on: ubuntu-latest
+   strategy:
+     matrix:
+       runtime: [linux-x64, linux-arm64]
+   steps:
+     - name: Install package_cloud
+       run: gem install package_cloud
+
+     - name: Download package artifacts
+       uses: actions/download-artifact@v4
+       with:
+         name: package.${{ matrix.runtime }}
+         path: packages
+
+     - name: Publish DEB package
+       env:
+         PACKAGECLOUD_TOKEN: ${{ secrets.PACKAGECLOUD_TOKEN }}
+       run: |
+         package_cloud push your-username/sourcegit/debian/any packages/*.deb
+
+     - name: Publish RPM package
+       env:
+         PACKAGECLOUD_TOKEN: ${{ secrets.PACKAGECLOUD_TOKEN }}
+       run: |
+         package_cloud push your-username/sourcegit/rpm_any/rpm_any packages/*.rpm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
     with:
       version: ${{ needs.version.outputs.version }}
     secrets:
-      PACKAGECLOUD_TOKEN: ${{ secrets.PACKAGECLOUD_TOKEN }}
+      BUILDKITE_TOKEN: ${{ secrets.BUILDKITE_TOKEN }}
   release:
     needs: [package, version]
     name: Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,14 @@ jobs:
     uses: ./.github/workflows/package.yml
     with:
       version: ${{ needs.version.outputs.version }}
+  publish-packages:
+    needs: [package, version]
+    name: Publish Packages
+    uses: ./.github/workflows/publish-packages.yml
+    with:
+      version: ${{ needs.version.outputs.version }}
+    secrets:
+      PACKAGECLOUD_TOKEN: ${{ secrets.PACKAGECLOUD_TOKEN }}
   release:
     needs: [package, version]
     name: Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,8 +28,6 @@ jobs:
     needs: [package, version]
     name: Publish Packages
     uses: ./.github/workflows/publish-packages.yml
-    with:
-      version: ${{ needs.version.outputs.version }}
     secrets:
       BUILDKITE_TOKEN: ${{ secrets.BUILDKITE_TOKEN }}
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,6 @@ jobs:
     with:
       version: ${{ needs.version.outputs.version }}
   publish-packages:
-    needs: [package, version]
     name: Publish Packages
     uses: ./.github/workflows/publish-packages.yml
     secrets:

--- a/SourceGit.sln
+++ b/SourceGit.sln
@@ -18,6 +18,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "workflows", "workflows", "{
 		.github\workflows\package.yml = .github\workflows\package.yml
 		.github\workflows\release.yml = .github\workflows\release.yml
 		.github\workflows\localization-check.yml = .github\workflows\localization-check.yml
+		.github\workflows\publish-packages.yml = .github\workflows\publish-packages.yml
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{49A7C2D6-558C-4FAA-8F5D-EEE81497AED7}"


### PR DESCRIPTION
In issue #298 we discussed distributing rpm/deb packages via dedicated repositories. 

Initial idea was to use packagecloud, but since it is now not accessible for new users, buildkite was used as a replacement. Actually, it was quite hard to handle all it's bugs, but now it works!

You can try test packages here:  [rpm](https://buildkite.com/organizations/stone-w4tch3r/packages/registries/sourcegit-fork-test-rpm) and [deb](https://buildkite.com/organizations/stone-w4tch3r/packages/registries/sourcegit-fork-test-deb).

To make it all work, you need: 
- register an organization named **sourcegit** on buildkite
- create two repositories: **sourcegit-deb** and **sorcegit-rpm**
- in personal settings create a token with **write_packages** and **read_packages** scopes
- configure **BUILDKITE_TOKEN** secret in repository settings
- push a release!