### PR TITLE
Add libicu dependency to RPM spec file

### DIFF
--- a/build/resources/rpm/SPECS/build.spec
+++ b/build/resources/rpm/SPECS/build.spec
@@ -7,6 +7,7 @@ URL: https://sourcegit-scm.github.io/
 Source: https://github.com/sourcegit-scm/sourcegit/archive/refs/tags/v%_version.tar.gz
 Requires: libX11.so.6()(%{__isa_bits}bit)
 Requires: libSM.so.6()(%{__isa_bits}bit)
+Requires: libicu
 
 %define _build_id_links none
 


### PR DESCRIPTION
I discovered that on modern fedora 41 sourcegit rpm package does not install `libicu` dependency, which leads to crash when trying to launch an app:

```
⬢ [user1@toolbx sourcegit]$ sudo dnf install build/sourcegit-0.0.1-1.x86_64.rpm
Updating and loading repositories:
 Fedora 41 openh264 (From Cisco) - x86_64                               100% |   2.5 KiB/s |   4.8 KiB |  00m02s
 Fedora 41 - x86_64 - Updates                                           100% |   2.0 MiB/s |   6.5 MiB |  00m03s
 Fedora 41 - x86_64                                                     100% |   2.5 MiB/s |  35.5 MiB |  00m14s
Repositories loaded.
Package                             Arch      Version                             Repository                Size
Installing:
 sourcegit                          x86_64    0.0.1-1                             @commandline          57.8 MiB
Installing dependencies:
 fontconfig                         x86_64    2.15.0-8.fc41                       fedora               791.9 KiB
 freetype                           x86_64    2.13.3-1.fc41                       fedora               850.5 KiB
 graphite2                          x86_64    1.3.14-16.fc41                      fedora               192.0 KiB
 harfbuzz                           x86_64    9.0.0-3.fc41                        fedora                 2.6 MiB
 libpng                             x86_64    2:1.6.40-4.fc41                     fedora               245.8 KiB
 xml-common                         noarch    0.6.3-65.fc41                       fedora                78.4 KiB

Transaction Summary:
 Installing:         7 packages

Total size of inbound packages is 19 MiB. Need to download 2 MiB.
After this operation, 63 MiB extra will be used (install 63 MiB, remove 0 B).
Is this ok [y/N]: y
[1/6] xml-common-0:0.6.3-65.fc41.noarch                                 100% | 165.3 KiB/s |  31.2 KiB |  00m00s
[2/6] freetype-0:2.13.3-1.fc41.x86_64                                   100% | 934.4 KiB/s | 409.2 KiB |  00m00s
[3/6] fontconfig-0:2.15.0-8.fc41.x86_64                                 100% | 534.4 KiB/s | 269.9 KiB |  00m01s
[4/6] libpng-2:1.6.40-4.fc41.x86_64                                     100% |   1.6 MiB/s | 120.3 KiB |  00m00s
[5/6] graphite2-0:1.3.14-16.fc41.x86_64                                 100% |   1.1 MiB/s |  95.1 KiB |  00m00s
[6/6] harfbuzz-0:9.0.0-3.fc41.x86_64                                    100% |   1.2 MiB/s |   1.0 MiB |  00m01s
----------------------------------------------------------------------------------------------------------------
[6/6] Total                                                             100% |   1.0 MiB/s |   1.9 MiB |  00m02s
Running transaction
[1/9] Verify package files                                              100% |  44.0   B/s |   7.0   B |  00m00s
[2/9] Prepare transaction                                               100% |  43.0   B/s |   7.0   B |  00m00s
[3/9] Installing graphite2-0:1.3.14-16.fc41.x86_64                      100% |   3.9 MiB/s | 194.1 KiB |  00m00s
[4/9] Installing libpng-2:1.6.40-4.fc41.x86_64                          100% |   9.3 MiB/s | 247.1 KiB |  00m00s
[5/9] Installing harfbuzz-0:9.0.0-3.fc41.x86_64                         100% |  49.1 MiB/s |   2.7 MiB |  00m00s
[6/9] Installing freetype-0:2.13.3-1.fc41.x86_64                        100% |  21.9 MiB/s | 852.2 KiB |  00m00s
[7/9] Installing xml-common-0:0.6.3-65.fc41.noarch                      100% |   5.3 MiB/s |  81.1 KiB |  00m00s
[8/9] Installing fontconfig-0:2.15.0-8.fc41.x86_64                      100% | 673.1 KiB/s | 811.1 KiB |  00m01s
[9/9] Installing sourcegit-0:0.0.1-1.x86_64                             100% |  74.9 MiB/s |  57.8 MiB |  00m01s
Warning: skipped PGP checks for 1 package from repository: @commandline
Complete!
⬢ [user1@toolbx sourcegit]$ sourcegit
Process terminated. Couldn't find a valid ICU package installed on the system. Please install libicu (or icu-libs) using your package manager and try again. Alternatively you can set the configuration flag System.Globalization.Invariant to true if you want to run with no globalization support. Please see https://aka.ms/dotnet-missing-libicu for more information.
   at System.RuntimeExceptionHelpers.FailFast(String, Exception, String, RhFailFastReason, IntPtr, IntPtr) + 0x1e7
   at System.Globalization.GlobalizationMode.Settings..cctor() + 0xb7
   at System.Runtime.CompilerServices.ClassConstructorRunner.EnsureClassConstructorRun(StaticClassConstructionContext*) + 0xb3
   at System.Runtime.CompilerServices.ClassConstructorRunner.CheckStaticClassConstructionReturnNonGCStaticBase(StaticClassConstructionContext*, IntPtr) + 0x9
   at System.Globalization.CultureData.CreateCultureWithInvariantData() + 0x3e7
   at System.Globalization.CultureData.get_Invariant() + 0x16
   at System.Globalization.CultureData.GetCultureData(String, Boolean) + 0x29
   at System.Globalization.CultureInfo..ctor(String name, Boolean useUserOverride) + 0x20
   at System.Reflection.AssemblyName.set_CultureName(String) + 0x3a
   at System.Reflection.RuntimeAssemblyName.CopyToAssemblyName(AssemblyName) + 0x3f
   at System.Reflection.Runtime.Assemblies.RuntimeAssemblyInfo.GetName() + 0x37
   at Avalonia.X11PlatformOptions..ctor() + 0x30d
   at SourceGit.Native.Linux.SetupApp(AppBuilder builder) + 0x23
   at SourceGit.App.BuildAvaloniaApp() + 0x127
   at SourceGit.App.Main(String[] args) + 0xd3
Aborted (core dumped)
```

Note: `build/sourcegit-0.0.1-1.x86_64.rpm` package is built from latest changes on dev branch

This PR adds `libicu` as explicit dependency. Tested manually, newly built rpm package works fine.