### PR TITLE
Option to delete only not merged branches

### DIFF
--- a/src/Commands/Branch.cs
+++ b/src/Commands/Branch.cs
@@ -34,12 +34,20 @@
             return cmd.Exec();
         }
 
-        public static bool DeleteLocal(string repo, string name)
+        public static bool DeleteLocal(string repo, string name, bool deleteNotMerged)
         {
             var cmd = new Command();
             cmd.WorkingDirectory = repo;
             cmd.Context = repo;
-            cmd.Args = $"branch -D {name}";
+            if (deleteNotMerged)
+            {
+                cmd.Args = $"branch -D {name}";
+            }
+            else
+            {
+                cmd.Args = $"branch -d {name}";
+            }
+
             return cmd.Exec();
         }
 

--- a/src/Resources/Locales/en_US.axaml
+++ b/src/Resources/Locales/en_US.axaml
@@ -216,6 +216,7 @@
   <x:String x:Key="Text.DeleteBranch.Branch" xml:space="preserve">Branch:</x:String>
   <x:String x:Key="Text.DeleteBranch.IsRemoteTip" xml:space="preserve">You are about to delete a remote branch!!!</x:String>
   <x:String x:Key="Text.DeleteBranch.WithTrackingRemote" xml:space="preserve">Also delete remote branch ${0}$</x:String>
+  <x:String x:Key="Text.DeleteBranch.NotMerged" xml:space="preserve">Also delete if not merged</x:String>
   <x:String x:Key="Text.DeleteMultiBranch" xml:space="preserve">Delete Multiple Branches</x:String>
   <x:String x:Key="Text.DeleteMultiBranch.Tip" xml:space="preserve">You are trying to delete multiple branches at one time. Be sure to double-check before taking action!</x:String>
   <x:String x:Key="Text.DeleteRemote" xml:space="preserve">Delete Remote</x:String>

--- a/src/ViewModels/DeleteBranch.cs
+++ b/src/ViewModels/DeleteBranch.cs
@@ -21,11 +21,23 @@ namespace SourceGit.ViewModels
             get;
             private set;
         }
+        
+        public object DeleteNotMergedTip
+        {
+            get;
+            private set;
+        }
 
         public bool AlsoDeleteTrackingRemote
         {
             get => _alsoDeleteTrackingRemote;
             set => SetProperty(ref _alsoDeleteTrackingRemote, value);
+        }
+        
+        public bool DeleteNotMerged
+        {
+            get => _deleteNotMerged;
+            set => SetProperty(ref _deleteNotMerged, value);
         }
 
         public DeleteBranch(Repository repo, Models.Branch branch)
@@ -39,6 +51,7 @@ namespace SourceGit.ViewModels
                 if (TrackingRemoteBranch != null)
                     DeleteTrackingRemoteTip = new Views.NameHighlightedTextBlock("DeleteBranch.WithTrackingRemote", TrackingRemoteBranch.FriendlyName);
             }
+            DeleteNotMergedTip = new Views.NameHighlightedTextBlock("DeleteBranch.NotMerged");
 
             View = new Views.DeleteBranch() { DataContext = this };
         }
@@ -52,7 +65,7 @@ namespace SourceGit.ViewModels
             {
                 if (Target.IsLocal)
                 {
-                    Commands.Branch.DeleteLocal(_repo.FullPath, Target.Name);
+                    Commands.Branch.DeleteLocal(_repo.FullPath, Target.Name, _deleteNotMerged);
 
                     if (_alsoDeleteTrackingRemote && TrackingRemoteBranch != null)
                     {
@@ -76,5 +89,6 @@ namespace SourceGit.ViewModels
 
         private readonly Repository _repo = null;
         private bool _alsoDeleteTrackingRemote = false;
+        private bool _deleteNotMerged = false;
     }
 }

--- a/src/ViewModels/DeleteMultipleBranches.cs
+++ b/src/ViewModels/DeleteMultipleBranches.cs
@@ -10,11 +10,25 @@ namespace SourceGit.ViewModels
             get;
         }
 
-        public DeleteMultipleBranches(Repository repo, List<Models.Branch> branches, bool isLocal)
+        public object DeleteNotMergedTip
+        {
+            get;
+            private set;
+        }
+        
+        public bool DeleteNotMerged
+        {
+            get => _deleteNotMerged;
+            set => SetProperty(ref _deleteNotMerged, value);
+        }
+
+        public DeleteMultipleBranches(Repository repo, List<Models.Branch> branches, bool isLocal, bool deleteNotMerged)
         {
             _repo = repo;
             _isLocal = isLocal;
+            _deleteNotMerged = deleteNotMerged;
             Targets = branches;
+            DeleteNotMergedTip = new Views.NameHighlightedTextBlock("DeleteBranch.NotMerged");
             View = new Views.DeleteMultipleBranches() { DataContext = this };
         }
 
@@ -30,7 +44,7 @@ namespace SourceGit.ViewModels
                     foreach (var target in Targets)
                     {
                         SetProgressDescription($"Deleting local branch : {target.Name}");
-                        Commands.Branch.DeleteLocal(_repo.FullPath, target.Name);
+                        Commands.Branch.DeleteLocal(_repo.FullPath, target.Name, _deleteNotMerged);
                     }
                 }
                 else
@@ -54,5 +68,6 @@ namespace SourceGit.ViewModels
 
         private Repository _repo = null;
         private bool _isLocal = false;
+        private bool _deleteNotMerged = false;
     }
 }

--- a/src/ViewModels/Repository.cs
+++ b/src/ViewModels/Repository.cs
@@ -944,10 +944,10 @@ namespace SourceGit.ViewModels
             }
         }
 
-        public void DeleteMultipleBranches(List<Models.Branch> branches, bool isLocal)
+        public void DeleteMultipleBranches(List<Models.Branch> branches, bool isLocal, bool deleteNotMerged)
         {
             if (PopupHost.CanCreatePopup())
-                PopupHost.ShowPopup(new DeleteMultipleBranches(this, branches, isLocal));
+                PopupHost.ShowPopup(new DeleteMultipleBranches(this, branches, isLocal, deleteNotMerged));
         }
 
         public void CreateNewTag()

--- a/src/Views/BranchTree.axaml.cs
+++ b/src/Views/BranchTree.axaml.cs
@@ -401,7 +401,7 @@ namespace SourceGit.Views
                 deleteMulti.Icon = App.CreateMenuIcon("Icons.Clear");
                 deleteMulti.Click += (_, ev) =>
                 {
-                    repo.DeleteMultipleBranches(branches, branches[0].IsLocal);
+                    repo.DeleteMultipleBranches(branches, branches[0].IsLocal, false);
                     ev.Handled = true;
                 };
                 menu.Items.Add(deleteMulti);

--- a/src/Views/DeleteBranch.axaml
+++ b/src/Views/DeleteBranch.axaml
@@ -11,7 +11,7 @@
                Classes="bold"
                Text="{DynamicResource Text.DeleteBranch}"/>
     
-    <Grid Margin="0,16,8,0" RowDefinitions="32,Auto" ColumnDefinitions="120,*">
+    <Grid Margin="0,16,8,0" RowDefinitions="32,Auto, Auto" ColumnDefinitions="120,*">
       <TextBlock Grid.Row="0" Grid.Column="0" HorizontalAlignment="Right" Text="{DynamicResource Text.DeleteBranch.Branch}"/>
       <StackPanel Grid.Row="0" Grid.Column="1" Orientation="Horizontal">
         <Path Width="14" Height="14" Margin="8,0" Data="{StaticResource Icons.Branch}"/>
@@ -25,8 +25,12 @@
                    FontStyle="Italic"
                    VerticalAlignment="Center"/>
       </Border>
+      
+      <Border Grid.Row="1" Grid.Column="1" Height="32">
+        <CheckBox Margin="6,0,0,0" Content="{Binding DeleteNotMergedTip}" IsChecked="{Binding DeleteNotMerged, Mode=TwoWay}"/>
+      </Border>
 
-      <Border Grid.Row="1" Grid.Column="1" Height="32" IsVisible="{Binding TrackingRemoteBranch, Converter={x:Static ObjectConverters.IsNotNull}}">
+      <Border Grid.Row="2" Grid.Column="1" Height="32" IsVisible="{Binding TrackingRemoteBranch, Converter={x:Static ObjectConverters.IsNotNull}}">
         <CheckBox Margin="6,0,0,0" Content="{Binding DeleteTrackingRemoteTip}" IsChecked="{Binding AlsoDeleteTrackingRemote, Mode=TwoWay}"/>
       </Border>
     </Grid>

--- a/src/Views/DeleteMultipleBranches.axaml
+++ b/src/Views/DeleteMultipleBranches.axaml
@@ -50,6 +50,10 @@
         </ListBox.ItemTemplate>
       </ListBox>
     </Border>
+    
+    <Border Height="32">
+      <CheckBox Margin="6,0,0,0" Content="{Binding DeleteNotMergedTip}" IsChecked="{Binding DeleteNotMerged, Mode=TwoWay}"/>
+    </Border>
 
     <TextBlock Margin="4,8,0,0"
                Text="{DynamicResource Text.DeleteMultiBranch.Tip}"


### PR DESCRIPTION
As a user, I would like to ensure I don't delete not merged branches accidentally. This is also helpful when cleaning up local branches.
On additional change would be helpful here to add --prune in the fetch option. I can add that separately.