### PR TITLE
fix: Dispose _autoFetchTimer before _setting set to null

### DIFF
--- a/src/ViewModels/Repository.cs
+++ b/src/ViewModels/Repository.cs
@@ -427,11 +427,11 @@ namespace SourceGit.ViewModels
             {
                 // Ignore
             }
-            _settings = null;
-            _historiesFilterMode = Models.FilterMode.None;
-
             _autoFetchTimer.Dispose();
             _autoFetchTimer = null;
+
+            _settings = null;
+            _historiesFilterMode = Models.FilterMode.None;
 
             _watcher?.Dispose();
             _histories.Cleanup();


### PR DESCRIPTION
I met NRE when switching the workspace, I think this can fix the issue.

```log
Crash::: System.NullReferenceException: Object reference not set to an instance of an object.

----------------------------
Version: 8.41.0.0
OS: Unix 6.9.6.64
Framework: .NETCoreApp,Version=v9.0
Source: SourceGit
---------------------------

   at SourceGit.ViewModels.Repository.AutoFetchImpl(Object sender) + 0x137
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext, ContextCallback, Object) + 0xb7
--- End of stack trace from previous location ---
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext, ContextCallback, Object) + 0x123
   at System.Threading.TimerQueueTimer.Fire(Boolean) + 0x5a
   at System.Threading.TimerQueue.FireNextTimers() + 0x240
   at System.Threading.ThreadPoolWorkQueue.Dispatch() + 0x25c
   at System.Threading.PortableThreadPool.WorkerThread.WorkerThreadStart() + 0x15c
   at System.Threading.Thread.StartThread(IntPtr) + 0x109
   at System.Threading.Thread.ThreadEntryPoint(IntPtr) + 0x19
```