### PR TITLE
Change text selection brush to improve readability

### DIFF
--- a/src/Resources/Styles.axaml
+++ b/src/Resources/Styles.axaml
@@ -4,6 +4,7 @@
         xmlns:vm="using:SourceGit.ViewModels"
         xmlns:c="using:SourceGit.Converters"
         xmlns:ae="using:AvaloniaEdit"
+        xmlns:aee="using:AvaloniaEdit.Editing"
         xmlns:aes="using:AvaloniaEdit.Search">
   <Design.PreviewWith>
     <StackPanel Orientation="Vertical">
@@ -578,6 +579,19 @@
     <Style Selector="^:disabled Path">
       <Setter Property="Fill" Value="{DynamicResource Brush.FG2}"/>
     </Style>
+  </Style>
+
+  <Style Selector="aee|TextArea">
+    <Setter Property="SelectionBorder">
+      <Setter.Value>
+        <Pen Brush="{DynamicResource SystemAccentColor}" Thickness="1" />
+      </Setter.Value>
+    </Setter>
+    <Setter Property="SelectionBrush">
+      <Setter.Value>
+        <SolidColorBrush Opacity="0.5" Color="{DynamicResource SystemAccentColor}" />
+      </Setter.Value>
+    </Setter>
   </Style>
 
   <Style Selector="aes|SearchPanel">


### PR DESCRIPTION
This PR changes the text selection brush for the AvaloniaEdit `TextEditor`.

### Problem
The text selection brush is the `SystemAccentColor`, which is a solid blue on Windows 11 by default. This can reduce the readability of the text when syntax highlighting is enabled.

### Solution
I suggest to use a semi-transparent brush to improve the readability.

### Before
![image](https://github.com/user-attachments/assets/8f706c97-9104-4a12-85bc-1fd62564e164)
![image](https://github.com/user-attachments/assets/de4a2ece-883e-47ff-8b58-6a1bb2690b1d)

### After
![image](https://github.com/user-attachments/assets/0043cad6-069c-4135-a26a-a8bc9e6ad0b8)
![image](https://github.com/user-attachments/assets/030547db-9f38-49d0-8bf3-3a58d2db8abf)