### PR TITLE
New feature: system tray icon

### DIFF
--- a/src/App.Commands.cs
+++ b/src/App.Commands.cs
@@ -37,7 +37,7 @@ namespace SourceGit
             }
         }
 
-        public static readonly Command OpenPreferenceCommand = new Command(_ => OpenDialog(new Views.Preference()));
+        public static readonly Command OpenPreferenceCommand = new Command(_ => { OpenDialog(new Views.Preference()); });
         public static readonly Command OpenHotkeysCommand = new Command(_ => OpenDialog(new Views.Hotkeys()));
         public static readonly Command OpenAppDataDirCommand = new Command(_ => Native.OS.OpenInFileManager(Native.OS.DataDir));
         public static readonly Command OpenAboutCommand = new Command(_ => OpenDialog(new Views.About()));

--- a/src/App.Commands.cs
+++ b/src/App.Commands.cs
@@ -37,7 +37,8 @@ namespace SourceGit
             }
         }
 
-        public static readonly Command OpenPreferenceCommand = new Command(_ => { OpenDialog(new Views.Preference()); });
+        public static readonly Command Unminimize = new Command(_ => ShowWindow());
+        public static readonly Command OpenPreferenceCommand = new Command(_ => { ShowWindow(); OpenDialog(new Views.Preference()); });
         public static readonly Command OpenHotkeysCommand = new Command(_ => OpenDialog(new Views.Hotkeys()));
         public static readonly Command OpenAppDataDirCommand = new Command(_ => Native.OS.OpenInFileManager(Native.OS.DataDir));
         public static readonly Command OpenAboutCommand = new Command(_ => OpenDialog(new Views.About()));

--- a/src/App.axaml
+++ b/src/App.axaml
@@ -41,4 +41,5 @@
       <NativeMenuItem Header="{DynamicResource Text.Quit}" Command="{x:Static s:App.QuitCommand}" Gesture="⌘+Q"/>
     </NativeMenu>
   </NativeMenu.Menu>
+
 </Application>

--- a/src/App.axaml
+++ b/src/App.axaml
@@ -41,5 +41,4 @@
       <NativeMenuItem Header="{DynamicResource Text.Quit}" Command="{x:Static s:App.QuitCommand}" Gesture="⌘+Q"/>
     </NativeMenu>
   </NativeMenu.Menu>
-
 </Application>

--- a/src/App.axaml.cs
+++ b/src/App.axaml.cs
@@ -210,7 +210,7 @@ namespace SourceGit
                         ]
                     }
                 };
-
+                icons[0].Clicked += (_, _) => ShowWindow();
                 TrayIcon.SetIcons(Current, icons);
             }
         }
@@ -576,11 +576,15 @@ namespace SourceGit
             if (desktop.Args != null && desktop.Args.Length == 1 && Directory.Exists(desktop.Args[0]))
                 startupRepo = desktop.Args[0];
 
+            var pref = ViewModels.Preference.Instance;
+            if (pref.SystemTrayIcon) {
+                desktop.ShutdownMode = ShutdownMode.OnExplicitShutdown;
+            }
+
             _launcher = new ViewModels.Launcher(startupRepo);
             desktop.MainWindow = new Views.Launcher() { DataContext = _launcher };
 
         #if !DISABLE_UPDATE_DETECTION
-            var pref = ViewModels.Preference.Instance;
             if (pref.ShouldCheck4UpdateOnStartup())
                 Check4Update();
         #endif

--- a/src/App.axaml.cs
+++ b/src/App.axaml.cs
@@ -14,6 +14,8 @@ using Avalonia.Data.Core.Plugins;
 using Avalonia.Markup.Xaml;
 using Avalonia.Media;
 using Avalonia.Media.Fonts;
+using Avalonia.Media.Imaging;
+using Avalonia.Platform;
 using Avalonia.Platform.Storage;
 using Avalonia.Styling;
 using Avalonia.Threading;
@@ -85,6 +87,7 @@ namespace SourceGit
             SetLocale(pref.Locale);
             SetTheme(pref.Theme, pref.ThemeOverrides);
             SetFonts(pref.DefaultFontFamily, pref.MonospaceFontFamily, pref.OnlyUseMonoFontInEditor);
+            SetupTrayIcon(pref.SystemTrayIcon);
         }
 
         public override void OnFrameworkInitializationCompleted()
@@ -189,6 +192,26 @@ namespace SourceGit
             else
             {
                 Models.CommitGraph.SetDefaultPens();
+            }
+        }
+
+        public static void SetupTrayIcon(bool enable)
+        {
+            if (enable)
+            {
+                var icons = new TrayIcons {
+                    new TrayIcon {
+                        Icon = new WindowIcon(new Bitmap(AssetLoader.Open(new Uri("avares://SourceGit/App.ico")))),
+                        Menu = [
+                            new NativeMenuItem(Text("Open")),
+                            new NativeMenuItem(Text("Preference")) {Command = OpenPreferenceCommand},
+                            new NativeMenuItemSeparator(),
+                            new NativeMenuItem(Text("Quit")) {Command = QuitCommand},
+                        ]
+                    }
+                };
+
+                TrayIcon.SetIcons(Current, icons);
             }
         }
 

--- a/src/App.axaml.cs
+++ b/src/App.axaml.cs
@@ -203,7 +203,7 @@ namespace SourceGit
                     new TrayIcon {
                         Icon = new WindowIcon(new Bitmap(AssetLoader.Open(new Uri("avares://SourceGit/App.ico")))),
                         Menu = [
-                            new NativeMenuItem(Text("Open")),
+                            new NativeMenuItem(Text("Open")) {Command = Unminimize},
                             new NativeMenuItem(Text("Preference")) {Command = OpenPreferenceCommand},
                             new NativeMenuItemSeparator(),
                             new NativeMenuItem(Text("Quit")) {Command = QuitCommand},
@@ -214,7 +214,15 @@ namespace SourceGit
                 TrayIcon.SetIcons(Current, icons);
             }
         }
-
+        private static void ShowWindow()
+        {
+            if (Current?.ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop) {
+                desktop.MainWindow.WindowState = WindowState.Normal;
+                desktop.MainWindow.Show();
+                desktop.MainWindow.BringIntoView();
+                desktop.MainWindow.Focus();
+            }
+        }
         public static void SetFonts(string defaultFont, string monospaceFont, bool onlyUseMonospaceFontInEditor)
         {
             var app = Current as App;

--- a/src/Resources/Locales/en_US.axaml
+++ b/src/Resources/Locales/en_US.axaml
@@ -421,7 +421,7 @@
   <x:String x:Key="Text.Name" xml:space="preserve">Name:</x:String>
   <x:String x:Key="Text.NotConfigured" xml:space="preserve">Git has NOT been configured. Please to go [Preference] and configure it first.</x:String>
   <x:String x:Key="Text.Open" xml:space="preserve">Open SourceGit</x:String>
-  <x:String x:Key="Text.OpenAppDataDir" xml:space="preserve">Open Storage Directory</x:String>
+  <x:String x:Key="Text.OpenAppDataDir" xml:space="preserve">Open Data Storage Directory</x:String>
   <x:String x:Key="Text.OpenWith" xml:space="preserve">Open with...</x:String>
   <x:String x:Key="Text.Optional" xml:space="preserve">Optional.</x:String>
   <x:String x:Key="Text.PageTabBar.New" xml:space="preserve">Create New Page</x:String>

--- a/src/Resources/Locales/en_US.axaml
+++ b/src/Resources/Locales/en_US.axaml
@@ -420,7 +420,8 @@
   <x:String x:Key="Text.MoveRepositoryNode.Target" xml:space="preserve">Select parent node for:</x:String>
   <x:String x:Key="Text.Name" xml:space="preserve">Name:</x:String>
   <x:String x:Key="Text.NotConfigured" xml:space="preserve">Git has NOT been configured. Please to go [Preference] and configure it first.</x:String>
-  <x:String x:Key="Text.OpenAppDataDir" xml:space="preserve">Open Data Storage Directory</x:String>
+  <x:String x:Key="Text.Open" xml:space="preserve">Open SourceGit</x:String>
+  <x:String x:Key="Text.OpenAppDataDir" xml:space="preserve">Open Storage Directory</x:String>
   <x:String x:Key="Text.OpenWith" xml:space="preserve">Open with...</x:String>
   <x:String x:Key="Text.Optional" xml:space="preserve">Optional.</x:String>
   <x:String x:Key="Text.PageTabBar.New" xml:space="preserve">Create New Page</x:String>

--- a/src/ViewModels/Preference.cs
+++ b/src/ViewModels/Preference.cs
@@ -333,6 +333,12 @@ namespace SourceGit.ViewModels
             set => SetProperty(ref _lastCheckUpdateTime, value);
         }
 
+        public bool SystemTrayIcon 
+        {
+            get => _systemTrayIcon;
+            set => SetProperty(ref _systemTrayIcon, value);
+        }
+
         public bool IsGitConfigured()
         {
             var path = GitInstallPath;
@@ -663,5 +669,7 @@ namespace SourceGit.ViewModels
         private string _externalMergeToolPath = string.Empty;
 
         private uint _statisticsSampleColor = 0xFF00FF00;
+
+        private bool _systemTrayIcon = false;
     }
 }

--- a/src/Views/Launcher.axaml.cs
+++ b/src/Views/Launcher.axaml.cs
@@ -255,7 +255,13 @@ namespace SourceGit.Views
 
         protected override void OnClosing(WindowClosingEventArgs e)
         {
-            (DataContext as ViewModels.Launcher)?.Quit(Width, Height);
+            var pref = ViewModels.Preference.Instance;
+            if (pref.SystemTrayIcon) {
+                e.Cancel = true;
+                Hide();
+            } else {
+                (DataContext as ViewModels.Launcher)?.Quit(Width, Height);
+            }
             base.OnClosing(e);
         }
 


### PR DESCRIPTION
Implements https://github.com/sourcegit-scm/sourcegit/discussions/805

## To enable

1. Open SourceGit's data storage directory from main menu
   ![image](https://github.com/user-attachments/assets/8807f140-03f7-426d-b80d-6b67e752bcea)
2. Close SourceGit
3. Open file `preference.json` in any text editor
4. Add new field `"SystemTrayIcon": true`
   ![image](https://github.com/user-attachments/assets/112e183d-3ac6-44a5-8d78-f5fcd27baf03)

## Details

When this feature is enabled, SourceGit does not exit after click on window closing button.
Instead it stays in background, hiding in the system tray, without occupation of a space in the task bar.

![image](https://github.com/user-attachments/assets/66d08dae-49cc-4ba6-a14a-2a659439581b)

Main window can be restored with the left click on the system tray icon.

Right click on the icon opens the menu with the Quit item.

## To disable

1. Open SourceGit's data storage directory from main menu
2. Close SourceGit with the Quit menu from the system tray icon
3. Open file `preference.json` in any text editor
4. Remove field "SystemTrayIcon" completely or set its value to `false`