### PR TITLE
fix: Enter key does not stage/unstage all selected items

### DIFF
--- a/src/Views/ChangeCollectionView.axaml.cs
+++ b/src/Views/ChangeCollectionView.axaml.cs
@@ -42,7 +42,7 @@ namespace SourceGit.Views
                 }
             }
 
-            if (!e.Handled && e.Key != Key.Space)
+            if (!e.Handled && e.Key != Key.Space && e.Key != Key.Enter)
                 base.OnKeyDown(e);
         }
     }


### PR DESCRIPTION
The `Space` and `Enter` keys can be used to stage or unstage the selected items in the working copy. The `Space` key works correctly, but the `Enter` key does not.

### Cause:
The `ListBox` in the `ChangeCollectionView` changes the selection when `Enter` is pressed before `WorkingCopy` can stage/unstage the selected items.

### Solution:
Same as for `Space`. The `ChangeCollectionView` should ignore the `Enter` key and not forward the `KeyDown` event to the underlying `ListBox`.