### PR TITLE
System tray icon

### DIFF
--- a/src/App.Commands.cs
+++ b/src/App.Commands.cs
@@ -36,7 +36,8 @@ namespace SourceGit
 #endif
             }
         }
-
+        
+        public static readonly Command Unminimize = new Command(_ => ShowWindow());
         public static readonly Command OpenPreferencesCommand = new Command(_ => OpenDialog(new Views.Preferences()));
         public static readonly Command OpenHotkeysCommand = new Command(_ => OpenDialog(new Views.Hotkeys()));
         public static readonly Command OpenAppDataDirCommand = new Command(_ => Native.OS.OpenInFileManager(Native.OS.DataDir));

--- a/src/Native/MacOS.cs
+++ b/src/Native/MacOS.cs
@@ -88,5 +88,7 @@ namespace SourceGit.Native
         {
             Process.Start("open", $"\"{file}\"");
         }
+
+        public bool EnsureSingleInstance() { return true; }
     }
 }

--- a/src/Native/OS.cs
+++ b/src/Native/OS.cs
@@ -23,6 +23,8 @@ namespace SourceGit.Native
             void OpenInFileManager(string path, bool select);
             void OpenBrowser(string url);
             void OpenWithDefaultEditor(string file);
+
+            bool EnsureSingleInstance();
         }
 
         public static string DataDir
@@ -219,6 +221,11 @@ namespace SourceGit.Native
 
         [GeneratedRegex(@"^git version[\s\w]*(\d+)\.(\d+)[\.\-](\d+).*$")]
         private static partial Regex REG_GIT_VERSION();
+
+        public static bool EnsureSingleInstance()
+        {
+            return _backend.EnsureSingleInstance();
+        }
 
         private static IBackend _backend = null;
         private static string _gitExecutable = string.Empty;

--- a/src/Native/Windows.cs
+++ b/src/Native/Windows.cs
@@ -14,6 +14,8 @@ namespace SourceGit.Native
     [SupportedOSPlatform("windows")]
     internal class Windows : OS.IBackend
     {
+        private FileStream _fs = null;
+        
         [StructLayout(LayoutKind.Sequential)]
         internal struct RTL_OSVERSIONINFOEX
         {
@@ -392,6 +394,26 @@ namespace SourceGit.Native
             }
 
             return null;
+        }
+
+        public bool EnsureSingleInstance()
+        {
+            var pidfile = Path.Combine(Path.GetTempPath(), "sourcegit.pid");
+            var pid = Process.GetCurrentProcess().Id.ToString();
+            Console.WriteLine("pid " + pid);
+
+            try
+            {
+                _fs = File.OpenWrite(pidfile);
+                _fs.Lock(0, 1000);
+                new StreamWriter(_fs).Write(pid);
+                return true;
+            }
+            catch (IOException)
+            {
+                Console.WriteLine("another SourceGit is running");
+                return false;
+            }
         }
     }
 }

--- a/src/Resources/Locales/en_US.axaml
+++ b/src/Resources/Locales/en_US.axaml
@@ -470,6 +470,7 @@
   <x:String x:Key="Text.Preferences.Appearance.ThemeOverrides" xml:space="preserve">Theme Overrides</x:String>
   <x:String x:Key="Text.Preferences.Appearance.UseFixedTabWidth" xml:space="preserve">Use fixed tab width in titlebar</x:String>
   <x:String x:Key="Text.Preferences.Appearance.UseNativeWindowFrame" xml:space="preserve">Use native window frame</x:String>
+  <x:String x:Key="Text.Preferences.Appearance.SystemTrayIcon" xml:space="preserve">System tray icon (needs restart)</x:String>  
   <x:String x:Key="Text.Preferences.DiffMerge" xml:space="preserve">DIFF/MERGE TOOL</x:String>
   <x:String x:Key="Text.Preferences.DiffMerge.Path" xml:space="preserve">Install Path</x:String>
   <x:String x:Key="Text.Preferences.DiffMerge.Path.Placeholder" xml:space="preserve">Input path for diff/merge tool</x:String>

--- a/src/Resources/Locales/ru_RU.axaml
+++ b/src/Resources/Locales/ru_RU.axaml
@@ -472,6 +472,7 @@
   <x:String x:Key="Text.Preferences.Appearance.ThemeOverrides" xml:space="preserve">Переопределение темы</x:String>
   <x:String x:Key="Text.Preferences.Appearance.UseFixedTabWidth" xml:space="preserve">Использовать фиксированную ширину табуляции в строке заголовка.</x:String>
   <x:String x:Key="Text.Preferences.Appearance.UseNativeWindowFrame" xml:space="preserve">Использовать системное окно</x:String>
+  <x:String x:Key="Text.Preferences.Appearance.SystemTrayIcon" xml:space="preserve">Иконка в системном лотке (нужен перезапуск)</x:String>
   <x:String x:Key="Text.Preferences.DiffMerge" xml:space="preserve">ИНСТРУМЕНТ РАЗЛИЧИЙ/СЛИЯНИЯ</x:String>
   <x:String x:Key="Text.Preferences.DiffMerge.Path" xml:space="preserve">Путь установки</x:String>
   <x:String x:Key="Text.Preferences.DiffMerge.Path.Placeholder" xml:space="preserve">Введите путь для инструмента различия/слияния</x:String>

--- a/src/ViewModels/Launcher.cs
+++ b/src/ViewModels/Launcher.cs
@@ -29,6 +29,8 @@ namespace SourceGit.ViewModels
             private set => SetProperty(ref _activeWorkspace, value);
         }
 
+        public bool InterceptQuit { get; set; } = false;
+
         public LauncherPage ActivePage
         {
             get => _activePage;
@@ -47,7 +49,6 @@ namespace SourceGit.ViewModels
         public Launcher(string startupRepo)
         {
             _ignoreIndexChange = true;
-
             Pages = new AvaloniaList<LauncherPage>();
             AddNewTab();
 

--- a/src/ViewModels/Preferences.cs
+++ b/src/ViewModels/Preferences.cs
@@ -348,6 +348,12 @@ namespace SourceGit.ViewModels
             set => SetProperty(ref _lastCheckUpdateTime, value);
         }
 
+        public bool SystemTrayIcon 
+        {
+            get => _systemTrayIcon;
+            set => SetProperty(ref _systemTrayIcon, value);
+        }
+
         public bool IsGitConfigured()
         {
             var path = GitInstallPath;
@@ -682,5 +688,7 @@ namespace SourceGit.ViewModels
         private string _externalMergeToolPath = string.Empty;
 
         private uint _statisticsSampleColor = 0xFF00FF00;
+
+        private bool _systemTrayIcon = false;
     }
 }

--- a/src/Views/Launcher.axaml.cs
+++ b/src/Views/Launcher.axaml.cs
@@ -262,7 +262,13 @@ namespace SourceGit.Views
 
         protected override void OnClosing(WindowClosingEventArgs e)
         {
-            (DataContext as ViewModels.Launcher)?.Quit(Width, Height);
+            var launcher = DataContext as ViewModels.Launcher;
+            if (launcher is { InterceptQuit: true }) {
+                e.Cancel = true;
+                Hide();
+            } else {
+                launcher?.Quit(Width, Height);
+            }
             base.OnClosing(e);
         }
 

--- a/src/Views/Preferences.axaml
+++ b/src/Views/Preferences.axaml
@@ -148,7 +148,7 @@
           <TabItem.Header>
             <TextBlock Classes="tab_header" Text="{DynamicResource Text.Preferences.Appearance}"/>
           </TabItem.Header>
-          <Grid Margin="8" RowDefinitions="32,32,32,32,32,32,32,Auto" ColumnDefinitions="Auto,*">
+          <Grid Margin="8" RowDefinitions="32,32,32,32,32,Auto" ColumnDefinitions="Auto,*">
             <TextBlock Grid.Row="0" Grid.Column="0"
                        Text="{DynamicResource Text.Preferences.Appearance.Theme}"
                        HorizontalAlignment="Right"
@@ -232,21 +232,26 @@
               </TextBox.InnerRightContent>
             </TextBox>
 
-            <CheckBox Grid.Row="5" Grid.Column="1"
-                      Content="{DynamicResource Text.Preferences.Appearance.OnlyUseMonoFontInEditor}"
-                      IsChecked="{Binding OnlyUseMonoFontInEditor, Mode=TwoWay}"/>
+            <StackPanel Grid.Row="5" Grid.Column="1">
+              <CheckBox Content="{DynamicResource Text.Preferences.Appearance.OnlyUseMonoFontInEditor}"
+                        IsChecked="{Binding OnlyUseMonoFontInEditor, Mode=TwoWay}"/>
 
-            <CheckBox Grid.Row="6" Grid.Column="1"
-                      Height="32"
-                      Content="{DynamicResource Text.Preferences.Appearance.UseFixedTabWidth}"
-                      IsChecked="{Binding Source={x:Static vm:Preferences.Instance}, Path=UseFixedTabWidth, Mode=TwoWay}"/>
+              <CheckBox Height="32"
+                        Content="{DynamicResource Text.Preferences.Appearance.UseFixedTabWidth}"
+                        IsChecked="{Binding Source={x:Static vm:Preferences.Instance}, Path=UseFixedTabWidth, Mode=TwoWay}"/>
 
-            <CheckBox Grid.Row="7" Grid.Column="1"
-                      Height="32"
-                      Content="{DynamicResource Text.Preferences.Appearance.UseNativeWindowFrame}"
-                      IsChecked="{Binding Source={x:Static vm:Preferences.Instance}, Path=UseSystemWindowFrame, Mode=OneTime}"
-                      IsVisible="{OnPlatform False, Linux=True}"
-                      IsCheckedChanged="OnUseNativeWindowFrameChanged"/>
+              <CheckBox Height="32"
+                        Content="{DynamicResource Text.Preferences.Appearance.UseNativeWindowFrame}"
+                        IsChecked="{Binding Source={x:Static vm:Preferences.Instance}, Path=UseSystemWindowFrame, Mode=OneTime}"
+                        IsVisible="{OnPlatform False, Linux=True}"
+                        IsCheckedChanged="OnUseNativeWindowFrameChanged"/>
+              
+              <CheckBox Height="32"
+                        Content="{DynamicResource Text.Preferences.Appearance.SystemTrayIcon}"
+                        IsChecked="{Binding Path=SystemTrayIcon, Mode=OneTime}"
+                        IsVisible="True"
+                        IsCheckedChanged="OnSystemTrayIconCheckedChanged"/>
+            </StackPanel>
           </Grid>
         </TabItem>
 

--- a/src/Views/Preferences.axaml.cs
+++ b/src/Views/Preferences.axaml.cs
@@ -342,6 +342,17 @@ namespace SourceGit.Views
 
             e.Handled = true;
         }
+        private void OnSystemTrayIconCheckedChanged(object sender, RoutedEventArgs e)
+        {
+            if (sender is CheckBox box)
+            {
+                ViewModels.Preferences.Instance.SystemTrayIcon = box.IsChecked == true;
+                var dialog = new ConfirmRestart();
+                App.OpenDialog(dialog);
+            }
+
+            e.Handled = true;
+        }
 
         private void OnGitInstallPathChanged(object sender, TextChangedEventArgs e)
         {


### PR DESCRIPTION
Implements https://github.com/sourcegit-scm/sourcegit/discussions/805

# General description

When this feature is enabled, first launched instance of SourceGit doesn't quit when window closing button is pressed. Instead it hides in system tray and stays running.

This feature can be enabled or disabled either from "Preferences" dialog (menu -> Preferences -> Appearance) or by manually editing `preference.json` file.

# Implementation details

## Window hiding

Sourcegit intercepts `OnClosing` event, cancels it and calls `Hide` instead ([link to code](https://github.com/wl2776/sourcegit/blob/feature/system-tray-icon/src/Views/Launcher.axaml.cs#L261))

## Preventing from creation of several system tray icons

When another instance of the SourceHGit is launched from the command line or from the system launcher, it will create another identical icon in the system tray, if no additional checking is performed.

To prevent this, every SourceGit instance tries to create a lock file in the system temporary directory ([link to code](https://github.com/wl2776/sourcegit/blob/feature/system-tray-icon/src/Native/Linux.cs#L103)). If this operation fails, it means that another SourceGit is running and the system tray icon is already created. In this case, no system tray icons are created, and `OnClosing` event causes exit.

On MacOS [no lock file is created](https://github.com/wl2776/sourcegit/blob/feature/system-tray-icon/src/Native/MacOS.cs#L89), thus relying on the [OS guarantees to launch only one instance of a packaged application](https://github.com/AvaloniaUI/Avalonia/discussions/17854#discussioncomment-11700510).

# Why?

Because opening application that is already running is still much faster than launch a new instance.

# Note

Tested on Windows and Linux only.
MacOS is NOT tested.
