### PR TITLE
docs: Update README.md with APT source config changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ For **Linux** users:
   `deb` how to:
   ```shell
   curl https://codeberg.org/api/packages/yataro/debian/repository.key | sudo tee /etc/apt/keyrings/sourcegit.asc
-  echo "deb [signed-by=/etc/apt/keyrings/sourcegit.asc] https://codeberg.org/api/packages/yataro/debian generic main" | sudo tee /etc/apt/sources.list.d/sourcegit.list
+  echo "deb [signed-by=/etc/apt/keyrings/sourcegit.asc, arch=amd64,arm64] https://codeberg.org/api/packages/yataro/debian generic main" | sudo tee /etc/apt/sources.list.d/sourcegit.list
   sudo apt update
   sudo apt install sourcegit
   ```


### PR DESCRIPTION
- Update APT source configuration to include architecture-specific settings.

Avoid i386 not support warning on debian.