### PR TITLE
doc: Update default path for windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ This software creates a folder `$"{System.Environment.SpecialFolder.ApplicationD
 
 | OS      | PATH                                                |
 |---------|-----------------------------------------------------|
-| Windows | `C:\Users\USER_NAME\AppData\Roaming\SourceGit`      |
+| Windows | `%APPDATA%\SourceGit`                               |
 | Linux   | `${HOME}/.config/SourceGit` or `${HOME}/.sourcegit` |
 | macOS   | `${HOME}/Library/Application Support/SourceGit`     |
 


### PR DESCRIPTION
`%APPDATA%\SourceGit` can be copied to the file browser address bar to open the folder directly.