### PR TITLE
Fix: LFS locks does not show if the user name has a dot in it

### DIFF
--- a/src/Commands/LFS.cs
+++ b/src/Commands/LFS.cs
@@ -7,7 +7,7 @@ namespace SourceGit.Commands
 {
     public partial class LFS
     {
-        [GeneratedRegex(@"^(.+)\s+(\w+)\s+\w+:(\d+)$")]
+        [GeneratedRegex(@"^(.+)\s+([\w.]+)\s+\w+:(\d+)$")]
         private static partial Regex REG_LOCK();
 
         class SubCmd : Command


### PR DESCRIPTION
Changed the regex to show locks from users with a "." character in their git username.

Before:
![Screenshot_2025-01-13_151405](https://github.com/user-attachments/assets/fdc449c9-13c9-4f4f-a109-cdadc1337796)
After:
![Screenshot_2025-01-13_151343](https://github.com/user-attachments/assets/a026860f-9c08-4b8f-a9a6-a503c0467827)
