### PR TITLE
fix: Ensure each ImageView instance calculates its own aspect ratio

### DIFF
--- a/src/Views/DiffView.axaml
+++ b/src/Views/DiffView.axaml
@@ -129,6 +129,7 @@
             <ToggleButton Classes="line_path"
                           Width="28"
                           IsChecked="{Binding IgnoreWhitespace, Mode=TwoWay}"
+                          IsVisible="{Binding IsTextDiff}"
                           ToolTip.Tip="{DynamicResource Text.Diff.IgnoreWhitespace}">
               <Path Width="14" Height="14" Stretch="Uniform" Data="{StaticResource Icons.Whitespace}"/>
             </ToggleButton>

--- a/src/Views/ImageContainer.cs
+++ b/src/Views/ImageContainer.cs
@@ -92,6 +92,20 @@ namespace SourceGit.Views
 
             return availableSize;
         }
+
+        protected override Size ArrangeOverride(Size finalSize)
+        {
+            if (Image is { } image)
+            {
+                var imageSize = image.Size;
+                var scaleW = finalSize.Width / imageSize.Width;
+                var scaleH = finalSize.Height / imageSize.Height;
+                var scale = Math.Min(scaleW, scaleH);
+                return new Size(scale * imageSize.Width, scale * imageSize.Height);
+            }
+
+            return base.ArrangeOverride(finalSize);
+        }
     }
 
     public class ImageSwipeControl : ImageContainer


### PR DESCRIPTION
- Modified ArrangeOverride methods in ImageView class to independently calculate and apply the aspect ratio based on the instance's image.

Old effect:
![image](https://github.com/user-attachments/assets/9702a070-84d1-4449-b3d5-8c812ee93cf6)


New effect:
![image](https://github.com/user-attachments/assets/e0e0407e-cff1-467c-81ad-426836f49d5d)
