### PR TITLE
refactor: Update submodules individually to avoid failures (#925)

### DIFF
--- a/src/Commands/Clone.cs
+++ b/src/Commands/Clone.cs
@@ -12,7 +12,7 @@ namespace SourceGit.Commands
             WorkingDirectory = path;
             TraitErrorAsOutput = true;
             SSHKey = sshKey;
-            Args = "clone --progress --verbose --recurse-submodules ";
+            Args = "clone --progress --verbose ";
 
             if (!string.IsNullOrEmpty(extraArgs))
                 Args += $"{extraArgs} ";

--- a/src/Commands/QuerySubmodules.cs
+++ b/src/Commands/QuerySubmodules.cs
@@ -24,8 +24,6 @@ namespace SourceGit.Commands
         {
             var submodules = new List<Models.Submodule>();
             var rs = ReadToEnd();
-            if (!rs.IsSuccess)
-                return submodules;
 
             var builder = new StringBuilder();
             var lines = rs.StdOut.Split('\n', System.StringSplitOptions.RemoveEmptyEntries);

--- a/src/ViewModels/Clone.cs
+++ b/src/ViewModels/Clone.cs
@@ -127,6 +127,14 @@ namespace SourceGit.ViewModels
                     config.Set("remote.origin.sshkey", _sshKey);
                 }
 
+                // individually update submodule (if any)
+                var submoduleList = new Commands.QuerySubmodules(path).Result();
+                foreach (var submodule in submoduleList)
+                {
+                    var update = new Commands.Submodule(path);
+                    update.Update(submodule.Path, true, true, false, SetProgressDescription);
+                }
+
                 CallUIThread(() =>
                 {
                     var node = Preferences.Instance.FindOrAddNodeByRepositoryPath(path, null, true);

--- a/src/ViewModels/UpdateSubmodules.cs
+++ b/src/ViewModels/UpdateSubmodules.cs
@@ -56,25 +56,24 @@ namespace SourceGit.ViewModels
         {
             _repo.SetWatcherEnabled(false);
 
-            string target = string.Empty;
+            List<string> targets;
             if (_updateAll)
-            {
-                ProgressDescription = "Updating submodules ...";
-            }
+                targets = Submodules;
             else
-            {
-                target = SelectedSubmodule;
-                ProgressDescription = $"Updating submodule {target} ...";
-            }
+                targets = [SelectedSubmodule];
 
             return Task.Run(() =>
             {
-                new Commands.Submodule(_repo.FullPath).Update(
-                    target,
-                    EnableInit,
-                    EnableRecursive,
-                    EnableRemote,
-                    SetProgressDescription);
+                foreach (var submodule in targets)
+                {
+                    ProgressDescription = $"Updating submodule {submodule} ...";
+                    new Commands.Submodule(_repo.FullPath).Update(
+                        submodule,
+                        EnableInit,
+                        EnableRecursive,
+                        EnableRemote,
+                        SetProgressDescription);
+                }
 
                 CallUIThread(() => _repo.SetWatcherEnabled(true));
                 return true;


### PR DESCRIPTION
- Remove `--recurse-submodules` flag from the clone command to simplify the cloning process.
- Refactor submodule update logic to handle updating all submodules in a loop and improve progress description handling.
- Attempt to parse submodule list regardless of `submodule status` success.

Fixes #925 & #935