### PR TITLE
fix: adjust SHA regex pattern to min 6 chars

### DIFF
--- a/src/Views/CommitMessagePresenter.cs
+++ b/src/Views/CommitMessagePresenter.cs
@@ -15,7 +15,7 @@ namespace SourceGit.Views
 {
     public partial class CommitMessagePresenter : SelectableTextBlock
     {
-        [GeneratedRegex(@"\b([0-9a-fA-F]{10,40})\b")]
+        [GeneratedRegex(@"\b([0-9a-fA-F]{6,40})\b")]
         private static partial Regex REG_SHA_FORMAT();
 
         public static readonly StyledProperty<string> MessageProperty =


### PR DESCRIPTION
- Adjust the SHA regex pattern to match commit hashes with a minimum length of 6 characters instead of 10.

The minimum length of a Git commit ID can be 4 hexadecimal characters. Considering that `Diff.cs` uses a 6-40 character string for validation, the check for commit IDs in the commit message has been shortened to 6 characters. For example, GitHub considers a 7-character string as a valid commit ID.