### PR TITLE
feat: show CommitRelationTracking on CommitGraph (#940)

### DIFF
--- a/src/Models/CommitGraph.cs
+++ b/src/Models/CommitGraph.cs
@@ -54,6 +54,7 @@ namespace SourceGit.Models
             public Point Center;
             public int Color;
             public bool IsMerged;
+            public string SHA;
         }
 
         public List<Path> Paths { get; } = [];
@@ -149,7 +150,7 @@ namespace SourceGit.Models
                 // Calculate link position of this commit.
                 var position = new Point(major?.LastX ?? offsetX, offsetY);
                 var dotColor = major?.Path.Color ?? 0;
-                var anchor = new Dot() { Center = position, Color = dotColor, IsMerged = isMerged };
+                var anchor = new Dot() { Center = position, Color = dotColor, IsMerged = isMerged, SHA = commit.SHA };
                 if (commit.IsCurrentHead)
                     anchor.Type = DotType.Head;
                 else if (commit.Parents.Count > 1)

--- a/src/Views/CommitRelationTracking.axaml.cs
+++ b/src/Views/CommitRelationTracking.axaml.cs
@@ -28,5 +28,22 @@ namespace SourceGit.Views
                 });
             });
         }
+
+        public CommitRelationTracking(string repoPath, string commitHash)
+        {
+            InitializeComponent();
+
+            LoadingIcon.IsVisible = true;
+
+            Task.Run(() =>
+            {
+                var containsIn = new Commands.QueryRefsContainsCommit(repoPath, commitHash).Result();
+                Dispatcher.UIThread.Invoke(() =>
+                {
+                    Container.ItemsSource = containsIn;
+                    LoadingIcon.IsVisible = false;
+                });
+            });
+        }
     }
 }

--- a/src/Views/Histories.axaml
+++ b/src/Views/Histories.axaml
@@ -207,7 +207,7 @@
                          DotBrush="{DynamicResource Brush.Contents}"
                          OnlyHighlightCurrentBranch="{Binding $parent[v:Histories].OnlyHighlightCurrentBranch}"
                          HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
-                         IsHitTestVisible="False"
+                         IsHitTestVisible="True"
                          ClipToBounds="True"/>
         </Grid>
       </Grid>


### PR DESCRIPTION
- Add SHA property to the Dot class and assign commit SHA to anchor instances in the CommitGraph model.
- Add constructor to initialize commit relation tracking with repository path and commit hash, enabling querying and displaying related refs while managing loading state.
- Add pointer interaction handlers to the `CommitGraph` class for displaying commit details on click, updating cursor on hover, and resetting cursor on exit.

Only tested on Windows 10.

![Image](https://github.com/user-attachments/assets/a498b83a-3df8-42aa-97a3-e3209873fecd)