### PR TITLE
fix: Ignore the Chain-of-Thought in AI response

### DIFF
--- a/src/Models/OpenAI.cs
+++ b/src/Models/OpenAI.cs
@@ -19,7 +19,15 @@ namespace SourceGit.Models
         public string Server
         {
             get => _server;
-            set => SetProperty(ref _server, value);
+            set
+            {
+                // migrate old server value
+                if (!string.IsNullOrEmpty(value) && value.EndsWith("/chat/completions", StringComparison.Ordinal))
+                {
+                    value = value.Substring(0, value.Length - "/chat/completions".Length);
+                }
+                SetProperty(ref _server, value);
+            }
         }
 
         public string ApiKey

--- a/src/Views/AIAssistant.axaml.cs
+++ b/src/Views/AIAssistant.axaml.cs
@@ -2,18 +2,16 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
 using Avalonia.Interactivity;
 using Avalonia.Media;
 using Avalonia.Threading;
-
+using AvaloniaEdit;
 using AvaloniaEdit.Document;
 using AvaloniaEdit.Editing;
 using AvaloniaEdit.TextMate;
-using AvaloniaEdit;
 
 namespace SourceGit.Views
 {


### PR DESCRIPTION
I reviewed the code of the official OpenAI SDK, and it seems that the official SDK does not handle the direct return of the Chain-of-Thought `<think>{thinking}</think>\n\n{content}`. After switching to the official SDK, you may need to perform additional processing on the returned results.