### PR TITLE
fix: when upstream is null show CommitAndPush and stop auto push (#955)

### DIFF
--- a/src/ViewModels/LauncherPage.cs
+++ b/src/ViewModels/LauncherPage.cs
@@ -59,14 +59,16 @@ namespace SourceGit.ViewModels
         public void StartPopup(Popup popup)
         {
             Popup = popup;
-            ProcessPopup();
+            ProcessPopup(true);
         }
 
-        public async void ProcessPopup()
+        public async void ProcessPopup(bool autoCheck = false)
         {
             if (_popup != null)
             {
                 if (!_popup.Check())
+                    return;
+                if (autoCheck && !_popup.AutoCheck())
                     return;
 
                 _popup.InProgress = true;

--- a/src/ViewModels/Popup.cs
+++ b/src/ViewModels/Popup.cs
@@ -37,6 +37,11 @@ namespace SourceGit.ViewModels
             return !HasErrors;
         }
 
+        public virtual bool AutoCheck()
+        {
+            return true;
+        }
+
         public virtual Task<bool> Sure()
         {
             return null;

--- a/src/ViewModels/Push.cs
+++ b/src/ViewModels/Push.cs
@@ -152,6 +152,11 @@ namespace SourceGit.ViewModels
             View = new Views.Push() { DataContext = this };
         }
 
+        public override bool AutoCheck()
+        {
+            return !string.IsNullOrEmpty(_selectedRemoteBranch?.Head);
+        }
+
         public override Task<bool> Sure()
         {
             _repo.SetWatcherEnabled(false);

--- a/src/ViewModels/Repository.cs
+++ b/src/ViewModels/Repository.cs
@@ -937,9 +937,6 @@ namespace SourceGit.ViewModels
                 CurrentBranch = branches.Find(x => x.IsCurrent);
                 LocalBranchTrees = builder.Locals;
                 RemoteBranchTrees = builder.Remotes;
-
-                if (_workingCopy != null)
-                    _workingCopy.CanCommitWithPush = _currentBranch != null && !string.IsNullOrEmpty(_currentBranch.Upstream);
             });
         }
 

--- a/src/ViewModels/WorkingCopy.cs
+++ b/src/ViewModels/WorkingCopy.cs
@@ -26,12 +26,6 @@ namespace SourceGit.ViewModels
             }
         }
 
-        public bool CanCommitWithPush
-        {
-            get => _canCommitWithPush;
-            set => SetProperty(ref _canCommitWithPush, value);
-        }
-
         public bool HasUnsolvedConflicts
         {
             get => _hasUnsolvedConflicts;
@@ -1625,7 +1619,6 @@ namespace SourceGit.ViewModels
         private bool _isUnstaging = false;
         private bool _isCommitting = false;
         private bool _useAmend = false;
-        private bool _canCommitWithPush = false;
         private List<Models.Change> _cached = [];
         private List<Models.Change> _unstaged = [];
         private List<Models.Change> _staged = [];

--- a/src/Views/WorkingCopy.axaml
+++ b/src/Views/WorkingCopy.axaml
@@ -375,7 +375,6 @@
           <Button.IsVisible>
             <MultiBinding Converter="{x:Static BoolConverters.And}">
               <Binding Path="UseAmend" Converter="{x:Static BoolConverters.Not}"/>
-              <Binding Path="CanCommitWithPush"/>
               <Binding Path="InProgressContext" Converter="{x:Static ObjectConverters.IsNull}"/>
             </MultiBinding>
           </Button.IsVisible>  


### PR DESCRIPTION
Prevent the automatic execution of the push operation when the `NEW` label is visible. This would ensure that users have the opportunity to confirm the creation of a new branch on the remote, rename the branch, or cancel the operation.

Fixes #955 
