### PR TITLE
Fix: Swap selection start and end index if selection is created from bottom to top

### DIFF
--- a/src/Views/TextDiffView.axaml.cs
+++ b/src/Views/TextDiffView.axaml.cs
@@ -970,8 +970,19 @@ namespace SourceGit.Views
             }
 
             var lines = GetLines();
-            var startIdx = Math.Min(selection.StartPosition.Line - 1, lines.Count - 1);
-            var endIdx = Math.Min(selection.EndPosition.Line - 1, lines.Count - 1);
+
+            var startPosition = selection.StartPosition;
+            var endPosition = selection.EndPosition;
+            
+            if (startPosition.Line  > endPosition.Line 
+                || startPosition.Line == endPosition.Line && startPosition.Column > endPosition.Column)
+            {
+                // swap start and end
+                (startPosition, endPosition) = (endPosition, startPosition);
+            }
+            
+            var startIdx = Math.Min(startPosition.Line - 1, lines.Count - 1);
+            var endIdx = Math.Min(endPosition.Line - 1, lines.Count - 1);
 
             if (startIdx == endIdx)
             {
@@ -995,15 +1006,15 @@ namespace SourceGit.Views
                     line.Type == Models.TextDiffLineType.None)
                     continue;
 
-                if (i == startIdx && selection.StartPosition.Column > 1)
+                if (i == startIdx && startPosition.Column > 1)
                 {
-                    builder.AppendLine(line.Content.Substring(selection.StartPosition.Column - 1));
+                    builder.AppendLine(line.Content.Substring(startPosition.Column - 1));
                     continue;
                 }
 
-                if (i == endIdx && selection.EndPosition.Column < line.Content.Length)
+                if (i == endIdx && endPosition.Column < line.Content.Length)
                 {
-                    builder.AppendLine(line.Content.Substring(0, selection.EndPosition.Column));
+                    builder.AppendLine(line.Content.Substring(0, endPosition.Column));
                     continue;
                 }
 


### PR DESCRIPTION
Fixes #966.

Copying from file diff view failed if the selection is created from bottom to top. This causes Selection.StartPosition to be below Selection.EndPosition, so the for loop would not run. Swapping start and end position in these cases fixes the issue.

On a different note, I noticed that any exception thrown in this event handler crashes the application. I think in some cases, such as this, it might be better to catch and log the exception and prompt the user about it.