### PR TITLE
feat: change worktree presentation

### DIFF
--- a/src/Commands/Worktree.cs
+++ b/src/Commands/Worktree.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 
 namespace SourceGit.Commands
 {
@@ -26,6 +27,7 @@ namespace SourceGit.Commands
                     if (line.StartsWith("worktree ", StringComparison.Ordinal))
                     {
                         last = new Models.Worktree() { FullPath = line.Substring(9).Trim() };
+                        last.RelativePath = Path.GetRelativePath(WorkingDirectory, last.FullPath);
                         worktrees.Add(last);
                     }
                     else if (line.StartsWith("bare", StringComparison.Ordinal))

--- a/src/Models/Worktree.cs
+++ b/src/Models/Worktree.cs
@@ -6,6 +6,7 @@ namespace SourceGit.Models
     {
         public string Branch { get; set; } = string.Empty;
         public string FullPath { get; set; } = string.Empty;
+        public string RelativePath { get; set; } = string.Empty;
         public string Head { get; set; } = string.Empty;
         public bool IsBare { get; set; } = false;
         public bool IsDetached { get; set; } = false;
@@ -21,15 +22,15 @@ namespace SourceGit.Models
             get
             {
                 if (IsDetached)
-                    return $"(deteched HEAD at {Head.Substring(10)})";
+                    return $"deteched HEAD at {Head.Substring(10)}";
 
                 if (Branch.StartsWith("refs/heads/", System.StringComparison.Ordinal))
-                    return $"({Branch.Substring(11)})";
+                    return Branch.Substring(11);
 
                 if (Branch.StartsWith("refs/remotes/", System.StringComparison.Ordinal))
-                    return $"({Branch.Substring(13)})";
+                    return Branch.Substring(13);
 
-                return $"({Branch})";
+                return Branch;
             }
         }
 

--- a/src/Views/RemoveWorktree.axaml
+++ b/src/Views/RemoveWorktree.axaml
@@ -18,8 +18,8 @@
       <Grid Grid.Row="0" Grid.Column="1" ColumnDefinitions="Auto,*">
         <Path Grid.Column="0" Width="12" Height="12" Data="{StaticResource Icons.Worktree}"/>
         <TextBlock Grid.Column="1" Classes="primary" Margin="8,0,0,0" TextTrimming="CharacterEllipsis">
-          <Run Text="{Binding Target.FullPath}"/>
-          <Run Text="{Binding Target.Name}" Foreground="{DynamicResource Brush.FG2}"/>
+          <Run Text="{Binding Target.Name}"/>
+          (<Run Text="{Binding Target.RelativePath}" Foreground="{DynamicResource Brush.FG2}"/>)
         </TextBlock>
       </Grid>
 

--- a/src/Views/Repository.axaml
+++ b/src/Views/Repository.axaml
@@ -372,8 +372,8 @@
                 <Grid ColumnDefinitions="Auto,*,22">
                   <Path Grid.Column="0" Width="10" Height="10" Margin="8,0,0,0" Data="{StaticResource Icons.Worktree}"/>
                   <TextBlock Grid.Column="1" Classes="primary" Margin="8,0,0,0" TextTrimming="CharacterEllipsis">
-                    <Run Text="{Binding FullPath}"/>
-                    <Run Text="{Binding Name}" Foreground="{DynamicResource Brush.FG2}"/>
+                    <Run Text="{Binding Name}"/>
+                    (<Run Text="{Binding RelativePath}" Foreground="{DynamicResource Brush.FG2}"/>)
                   </TextBlock>
                   <Path Grid.Column="2" Width="10" Height="10" Margin="4,0,0,0" Data="{StaticResource Icons.Lock}" Fill="{DynamicResource Brush.FG2}" IsVisible="{Binding IsLocked}"/>
                 </Grid>


### PR DESCRIPTION
Present the worktree name first, then relative path to the main repo.

This is more aligned with Git's own UI,  and works better with UI size constrains.