### PR TITLE
fix: Update unstaged filed counter when unstaged files change

### DIFF
--- a/src/ViewModels/WorkingCopy.cs
+++ b/src/ViewModels/WorkingCopy.cs
@@ -214,8 +214,10 @@ namespace SourceGit.ViewModels
             OnPropertyChanged(nameof(SelectedStaged));
 
             _visibleUnstaged.Clear();
-            _unstaged.Clear();
             OnPropertyChanged(nameof(VisibleUnstaged));
+
+            _unstaged.Clear();
+            OnPropertyChanged(nameof(Unstaged));
 
             _staged.Clear();
             OnPropertyChanged(nameof(Staged));

--- a/src/ViewModels/WorkingCopy.cs
+++ b/src/ViewModels/WorkingCopy.cs
@@ -307,6 +307,7 @@ namespace SourceGit.ViewModels
                 _isLoadingData = true;
                 HasUnsolvedConflicts = hasConflict;
                 VisibleUnstaged = visibleUnstaged;
+                OnPropertyChanged(nameof(Unstaged));
                 Staged = staged;
                 SelectedUnstaged = selectedUnstaged;
                 SelectedStaged = selectedStaged;


### PR DESCRIPTION
There is one annoying bug I noticed: when you change the unstaged files list in any way - stage single file, stage all, whatever - the number in header does not change. This fix addresses the issue.

I don't particularly like how there is a single call to `OnPropertyChanged` inside the call to `Dispatcher.UIThread.Invoke` as it is not consistent with surrounding code, but it would require further refactoring to fix that, so if it makes sense to improve this fix - please let me know.