### PR TITLE
feat: Added option to prune outdated refs during fetch

### DIFF
--- a/src/Commands/Fetch.cs
+++ b/src/Commands/Fetch.cs
@@ -4,7 +4,7 @@ namespace SourceGit.Commands
 {
     public class Fetch : Command
     {
-        public Fetch(string repo, string remote, bool noTags, bool force, Action<string> outputHandler)
+        public Fetch(string repo, string remote, bool noTags, bool force, bool prune, Action<string> outputHandler)
         {
             _outputHandler = outputHandler;
             WorkingDirectory = repo;
@@ -20,6 +20,9 @@ namespace SourceGit.Commands
 
             if (force)
                 Args += "--force ";
+
+            if (prune)
+                Args += "--prune ";
 
             Args += remote;
         }

--- a/src/Resources/Locales/en_US.axaml
+++ b/src/Resources/Locales/en_US.axaml
@@ -287,6 +287,7 @@
   <x:String x:Key="Text.Fetch.AllRemotes" xml:space="preserve">Fetch all remotes</x:String>
   <x:String x:Key="Text.Fetch.Force" xml:space="preserve">Force override local refs</x:String>
   <x:String x:Key="Text.Fetch.NoTags" xml:space="preserve">Fetch without tags</x:String>
+  <x:String x:Key="Text.Fetch.Prune" xml:space="preserve">Prune outdated remote refs</x:String>
   <x:String x:Key="Text.Fetch.Remote" xml:space="preserve">Remote:</x:String>
   <x:String x:Key="Text.Fetch.Title" xml:space="preserve">Fetch Remote Changes</x:String>
   <x:String x:Key="Text.FileCM.AssumeUnchanged" xml:space="preserve">Assume unchanged</x:String>

--- a/src/ViewModels/AddRemote.cs
+++ b/src/ViewModels/AddRemote.cs
@@ -100,7 +100,7 @@ namespace SourceGit.ViewModels
                 {
                     SetProgressDescription("Fetching from added remote ...");
                     new Commands.Config(_repo.FullPath).Set($"remote.{_name}.sshkey", _useSSH ? SSHKey : null);
-                    new Commands.Fetch(_repo.FullPath, _name, false, false, SetProgressDescription).Exec();
+                    new Commands.Fetch(_repo.FullPath, _name, false, false, false, SetProgressDescription).Exec();
                 }
                 CallUIThread(() =>
                 {

--- a/src/ViewModels/Fetch.cs
+++ b/src/ViewModels/Fetch.cs
@@ -28,6 +28,12 @@ namespace SourceGit.ViewModels
             set => _repo.Settings.FetchWithoutTags = value;
         }
 
+        public bool Prune
+        {
+            get;
+            set;
+        }
+
         public bool Force
         {
             get => _repo.Settings.EnableForceOnFetch;
@@ -46,8 +52,9 @@ namespace SourceGit.ViewModels
         {
             _repo.SetWatcherEnabled(false);
 
-            var notags = _repo.Settings.FetchWithoutTags;
-            var force = _repo.Settings.EnableForceOnFetch;
+            var notags = NoTags;
+            var force = Force;
+            var prune = Prune;
             return Task.Run(() =>
             {
                 if (FetchAllRemotes)
@@ -55,13 +62,13 @@ namespace SourceGit.ViewModels
                     foreach (var remote in _repo.Remotes)
                     {
                         SetProgressDescription($"Fetching remote: {remote.Name}");
-                        new Commands.Fetch(_repo.FullPath, remote.Name, notags, force, SetProgressDescription).Exec();
+                        new Commands.Fetch(_repo.FullPath, remote.Name, notags, force, prune, SetProgressDescription).Exec();
                     }
                 }
                 else
                 {
                     SetProgressDescription($"Fetching remote: {SelectedRemote.Name}");
-                    new Commands.Fetch(_repo.FullPath, SelectedRemote.Name, notags, force, SetProgressDescription).Exec();
+                    new Commands.Fetch(_repo.FullPath, SelectedRemote.Name, notags, force, prune, SetProgressDescription).Exec();
                 }
 
                 CallUIThread(() =>

--- a/src/ViewModels/Pull.cs
+++ b/src/ViewModels/Pull.cs
@@ -151,6 +151,7 @@ namespace SourceGit.ViewModels
                         _repo.FullPath,
                         _selectedRemote.Name,
                         NoTags,
+                        false, 
                         false,
                         SetProgressDescription).Exec();
 

--- a/src/ViewModels/Repository.cs
+++ b/src/ViewModels/Repository.cs
@@ -2433,7 +2433,7 @@ namespace SourceGit.ViewModels
 
             Dispatcher.UIThread.Invoke(() => IsAutoFetching = true);
             foreach (var remote in remotes)
-                new Commands.Fetch(_fullpath, remote, false, false, null) { RaiseError = false }.Exec();
+                new Commands.Fetch(_fullpath, remote, false, false, false, null) { RaiseError = false }.Exec();
             _lastFetchTime = DateTime.Now;
             Dispatcher.UIThread.Invoke(() => IsAutoFetching = false);
         }

--- a/src/Views/Fetch.axaml
+++ b/src/Views/Fetch.axaml
@@ -11,7 +11,7 @@
     <TextBlock FontSize="18"
                Classes="bold"
                Text="{DynamicResource Text.Fetch.Title}"/>
-    <Grid Margin="0,16,0,0" RowDefinitions="32,32,32,32" ColumnDefinitions="120,*">
+    <Grid Margin="0,16,0,0" RowDefinitions="32,32,32,32,32" ColumnDefinitions="120,*">
       <TextBlock Grid.Row="0" Grid.Column="0"
                  HorizontalAlignment="Right" VerticalAlignment="Center"
                  Margin="0,0,8,0"
@@ -46,6 +46,11 @@
                 Content="{DynamicResource Text.Fetch.NoTags}"
                 IsChecked="{Binding NoTags, Mode=TwoWay}"
                 ToolTip.Tip="--no-tags"/>
+      
+      <CheckBox Grid.Row="4" Grid.Column="1"
+                Content="{DynamicResource Text.Fetch.Prune}"
+                IsChecked="{Binding Prune, Mode=TwoWay}"
+                ToolTip.Tip="--prune"/>
     </Grid>
   </StackPanel>
 </UserControl>


### PR DESCRIPTION
This change adds options to Fetch dialog to prune outdated remote references, i.e. those remotes that do not exist anymore.