### PR TITLE
Improve usability of "interactive rebase"

### DIFF
--- a/src/ViewModels/Histories.cs
+++ b/src/ViewModels/Histories.cs
@@ -566,7 +566,7 @@ namespace SourceGit.ViewModels
 
                 menu.Items.Add(new MenuItem() { Header = "-" });
 
-                if (commit.IsMerged && current.Head != commit.SHA)
+                if (current.Head != commit.SHA)
                 {
                     var interactiveRebase = new MenuItem();
                     interactiveRebase.Header = new Views.NameHighlightedTextBlock("CommitCM.InteractiveRebase", current.Name);


### PR DESCRIPTION
my workflow often involves creating temporary branches to reorder commits before I push to remotes, and often I use interactive rebase to move *some* commits from one branch to another (much quicker than cherry picking them, especially when there are multiple to move).

however SourceGit has only ever allowed me to use an interactive rebase if the target is inline with my current branch, so I found myself continuously switching to another Git GUI for nothing more than just this step.

turns out this was quite easy to change, it actually took me longer to find the code that handles this than it did to change it... probably since this is the first time I've ever touched a C++ project (JetBrains Rider helped me big time here).

---

for reference, here are some screenshots of the change in action.

first the "Histories" panel, showing the context menu with the "Interactivly Rebase <branch> on Here" option:

![Screenshot 2025-02-28 at 08 40 05](https://github.com/user-attachments/assets/187fd122-ded9-4851-b456-dcab839de6cb)

then the "Interactive Rebase" window, scrolled to show the first commit to be moved:

![Screenshot 2025-02-28 at 08 41 02](https://github.com/user-attachments/assets/82f9d83d-667c-446b-8286-29f527aa3985)

the `current.Head != commit.SHA` condition was retained so that SourceGit doesn't allow anyone to try an interactive rebase to the current `HEAD`...

@love-linger, do you have any objection to including this change?