### PR TITLE
Enable tooltips for the commit hashes when handling conflicts

### DIFF
--- a/src/ViewModels/Repository.cs
+++ b/src/ViewModels/Repository.cs
@@ -821,6 +821,11 @@ namespace SourceGit.ViewModels
             }
         }
 
+        public Models.Commit GetCommitInfo(string sha)
+        {
+            return new Commands.QuerySingleCommit(_fullpath, sha).Result();
+        }
+
         public void NavigateToCurrentHead()
         {
             if (_currentBranch != null)

--- a/src/Views/WorkingCopy.axaml
+++ b/src/Views/WorkingCopy.axaml
@@ -216,7 +216,23 @@
                                      Foreground="DarkOrange"
                                      TextDecorations="Underline"
                                      Cursor="Hand"
-                                     PointerPressed="OnPressedSHA"/>
+                                     PointerPressed="OnPressedSHA"
+                                     PointerEntered="OnSHAPointerEntered"
+                                     ToolTip.ShowDelay="0">
+                            <TextBlock.DataTemplates>
+                              <DataTemplate DataType="m:Commit">
+                                <StackPanel MinWidth="400" Orientation="Vertical">
+                                  <Grid ColumnDefinitions="Auto,*,Auto">
+                                    <v:Avatar Grid.Column="0" Width="16" Height="16" VerticalAlignment="Center" IsHitTestVisible="False" User="{Binding Author}"/>
+                                    <TextBlock Grid.Column="1" Classes="primary" Text="{Binding Author.Name}" Margin="8,0,0,0"/>
+                                    <TextBlock Grid.Column="2" Classes="primary" Text="{Binding CommitterTimeStr}" Foreground="{DynamicResource Brush.FG2}" Margin="8,0,0,0"/>
+                                  </Grid>
+
+                                  <TextBlock Classes="primary" Margin="0,8,0,0" Text="{Binding Subject}" TextWrapping="Wrap"/>
+                                </StackPanel>
+                              </DataTemplate>
+                            </TextBlock.DataTemplates>
+                          </TextBlock>
                         </StackPanel>
                       </DataTemplate>
 
@@ -235,7 +251,23 @@
                                      Foreground="DarkOrange"
                                      TextDecorations="Underline"
                                      Cursor="Hand"
-                                     PointerPressed="OnPressedSHA"/>
+                                     PointerPressed="OnPressedSHA"
+                                     PointerEntered="OnSHAPointerEntered"
+                                     ToolTip.ShowDelay="0">
+                            <TextBlock.DataTemplates>
+                              <DataTemplate DataType="m:Commit">
+                                <StackPanel MinWidth="400" Orientation="Vertical">
+                                  <Grid ColumnDefinitions="Auto,*,Auto">
+                                    <v:Avatar Grid.Column="0" Width="16" Height="16" VerticalAlignment="Center" IsHitTestVisible="False" User="{Binding Author}"/>
+                                    <TextBlock Grid.Column="1" Classes="primary" Text="{Binding Author.Name}" Margin="8,0,0,0"/>
+                                    <TextBlock Grid.Column="2" Classes="primary" Text="{Binding CommitterTimeStr}" Foreground="{DynamicResource Brush.FG2}" Margin="8,0,0,0"/>
+                                  </Grid>
+
+                                  <TextBlock Classes="primary" Margin="0,8,0,0" Text="{Binding Subject}" TextWrapping="Wrap"/>
+                                </StackPanel>
+                              </DataTemplate>
+                            </TextBlock.DataTemplates>
+                          </TextBlock>
                           <TextBlock Margin="4,0,0,0" Text="{Binding Subject}"/>
                         </StackPanel>
                       </DataTemplate>


### PR DESCRIPTION
Before, you couldn't easily see the commit hash authors or message when resolving file conflicts. Now you can hover over the hashes to get a tooltip with a bit more information.

I have to admit that this is my first time working with C# and Avalonia, so I'm not sure how hacky my solution is... :sweat_smile: 