### PR TITLE
fix: schedule DWM frame extension to next render frame on Windows 10

### DIFF
--- a/src/Native/Windows.cs
+++ b/src/Native/Windows.cs
@@ -8,6 +8,7 @@ using System.Text;
 
 using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Threading;
 
 namespace SourceGit.Native
 {
@@ -214,12 +215,17 @@ namespace SourceGit.Native
 
         private void FixWindowFrameOnWin10(Window w)
         {
-            var platformHandle = w.TryGetPlatformHandle();
-            if (platformHandle == null)
-                return;
+            // Schedule the DWM frame extension to run in the next render frame
+            // to ensure proper timing with the window initialization sequence
+            Dispatcher.UIThread.InvokeAsync(() =>
+            {
+                var platformHandle = w.TryGetPlatformHandle();
+                if (platformHandle == null)
+                    return;
 
-            var margins = new MARGINS { cxLeftWidth = 1, cxRightWidth = 1, cyTopHeight = 1, cyBottomHeight = 1 };
-            DwmExtendFrameIntoClientArea(platformHandle.Handle, ref margins);
+                var margins = new MARGINS { cxLeftWidth = 1, cxRightWidth = 1, cyTopHeight = 1, cyBottomHeight = 1 };
+                DwmExtendFrameIntoClientArea(platformHandle.Handle, ref margins);
+            }, DispatcherPriority.Render);
         }
 
         #region EXTERNAL_EDITOR_FINDER


### PR DESCRIPTION
The DwmExtendFrameIntoClientArea call needs to be posted to the next render frame to ensure the window handle is fully initialized and avoid potential race conditions.

Fixes #1086 