### PR TITLE
Explicitly provided fully qualified reference for the git branch.

### DIFF
--- a/src/Commands/Branch.cs
+++ b/src/Commands/Branch.cs
@@ -62,7 +62,7 @@
             if (exists)
             {
                 cmd.SSHKey = new Config(repo).Get($"remote.{remote}.sshkey");
-                cmd.Args = $"push {remote} --delete {name}";
+                cmd.Args = $"push {remote} --delete refs/heads/{name}";
             }
             else
             {


### PR DESCRIPTION
Explicitly provided fully qualified reference for the git branch, because there can be a tag and a branch with identical names.

Fixed the push command for branch deletion

Updated the `push` command to use `--delete refs/heads/{name}` instead of `--delete {name}` for clearer branch reference when deleting a remote branch.