### PR TITLE
refactor: use $GIT_COMMON_DIR instead of cut $GIT_DIR/worktrees

### DIFF
--- a/src/Commands/QueryGitCommonDir.cs
+++ b/src/Commands/QueryGitCommonDir.cs
@@ -1,0 +1,26 @@
+﻿using System.IO;
+
+namespace SourceGit.Commands
+{
+    public class QueryGitCommonDir : Command
+    {
+        public QueryGitCommonDir(string workDir)
+        {
+            WorkingDirectory = workDir;
+            Args = "rev-parse --git-common-dir";
+            RaiseError = false;
+        }
+
+        public string Result()
+        {
+            var rs = ReadToEnd().StdOut;
+            if (string.IsNullOrEmpty(rs))
+                return null;
+
+            rs = rs.Trim();
+            if (Path.IsPathRooted(rs))
+                return rs;
+            return Path.GetFullPath(Path.Combine(WorkingDirectory, rs));
+        }
+    }
+}

--- a/src/Models/IRepository.cs
+++ b/src/Models/IRepository.cs
@@ -4,6 +4,7 @@
     {
         string FullPath { get; set; }
         string GitDir { get; set; }
+        string GitCommonDir { get; set; }
 
         void RefreshBranches();
         void RefreshWorktrees();

--- a/src/Models/Watcher.cs
+++ b/src/Models/Watcher.cs
@@ -24,11 +24,7 @@ namespace SourceGit.Models
             _wcWatcher.EnableRaisingEvents = true;
 
             // If this repository is a worktree repository, just watch the main repository's gitdir.
-            var gitDirNormalized = _repo.GitDir.Replace("\\", "/");
-            var worktreeIdx = gitDirNormalized.IndexOf(".git/worktrees/", StringComparison.Ordinal);
-            var repoWatchDir = _repo.GitDir;
-            if (worktreeIdx > 0)
-                repoWatchDir = _repo.GitDir.Substring(0, worktreeIdx + 4);
+            var repoWatchDir = _repo.GitCommonDir.Replace("\\", "/");
 
             _repoWatcher = new FileSystemWatcher();
             _repoWatcher.Path = repoWatchDir;

--- a/src/Resources/Locales/de_DE.axaml
+++ b/src/Resources/Locales/de_DE.axaml
@@ -509,7 +509,7 @@
   <x:String x:Key="Text.PruneRemote" xml:space="preserve">Remote löschen</x:String>
   <x:String x:Key="Text.PruneRemote.Target" xml:space="preserve">Ziel:</x:String>
   <x:String x:Key="Text.PruneWorktrees" xml:space="preserve">Worktrees löschen</x:String>
-  <x:String x:Key="Text.PruneWorktrees.Tip" xml:space="preserve">Worktree Informationen in `$GIT_DIR/worktrees` löschen</x:String>
+  <x:String x:Key="Text.PruneWorktrees.Tip" xml:space="preserve">Worktree Informationen in `$GIT_COMMON_DIR/worktrees` löschen</x:String>
   <x:String x:Key="Text.Pull" xml:space="preserve">Pull</x:String>
   <x:String x:Key="Text.Pull.Branch" xml:space="preserve">Remote-Branch:</x:String>
   <x:String x:Key="Text.Pull.FetchAllBranches" xml:space="preserve">Alle Branches fetchen</x:String>

--- a/src/Resources/Locales/en_US.axaml
+++ b/src/Resources/Locales/en_US.axaml
@@ -512,7 +512,7 @@
   <x:String x:Key="Text.PruneRemote" xml:space="preserve">Prune Remote</x:String>
   <x:String x:Key="Text.PruneRemote.Target" xml:space="preserve">Target:</x:String>
   <x:String x:Key="Text.PruneWorktrees" xml:space="preserve">Prune Worktrees</x:String>
-  <x:String x:Key="Text.PruneWorktrees.Tip" xml:space="preserve">Prune worktree information in `$GIT_DIR/worktrees`</x:String>
+  <x:String x:Key="Text.PruneWorktrees.Tip" xml:space="preserve">Prune worktree information in `$GIT_COMMON_DIR/worktrees`</x:String>
   <x:String x:Key="Text.Pull" xml:space="preserve">Pull</x:String>
   <x:String x:Key="Text.Pull.Branch" xml:space="preserve">Remote Branch:</x:String>
   <x:String x:Key="Text.Pull.FetchAllBranches" xml:space="preserve">Fetch all branches</x:String>

--- a/src/Resources/Locales/es_ES.axaml
+++ b/src/Resources/Locales/es_ES.axaml
@@ -516,7 +516,7 @@
   <x:String x:Key="Text.PruneRemote" xml:space="preserve">Podar Remoto</x:String>
   <x:String x:Key="Text.PruneRemote.Target" xml:space="preserve">Destino:</x:String>
   <x:String x:Key="Text.PruneWorktrees" xml:space="preserve">Podar Worktrees</x:String>
-  <x:String x:Key="Text.PruneWorktrees.Tip" xml:space="preserve">Podar información de worktree en `$GIT_DIR/worktrees`</x:String>
+  <x:String x:Key="Text.PruneWorktrees.Tip" xml:space="preserve">Podar información de worktree en `$GIT_COMMON_DIR/worktrees`</x:String>
   <x:String x:Key="Text.Pull" xml:space="preserve">Pull</x:String>
   <x:String x:Key="Text.Pull.Branch" xml:space="preserve">Rama Remota:</x:String>
   <x:String x:Key="Text.Pull.FetchAllBranches" xml:space="preserve">Fetch todas las ramas</x:String>

--- a/src/Resources/Locales/fr_FR.axaml
+++ b/src/Resources/Locales/fr_FR.axaml
@@ -484,7 +484,7 @@
   <x:String x:Key="Text.PruneRemote" xml:space="preserve">Élaguer une branche distant</x:String> <!-- If it is indeed about a branch -->
   <x:String x:Key="Text.PruneRemote.Target" xml:space="preserve">Cible :</x:String>
   <x:String x:Key="Text.PruneWorktrees" xml:space="preserve">Élaguer les Worktrees</x:String>
-  <x:String x:Key="Text.PruneWorktrees.Tip" xml:space="preserve"> Élaguer les information de worktree dans `$GIT_DIR/worktrees`</x:String>
+  <x:String x:Key="Text.PruneWorktrees.Tip" xml:space="preserve"> Élaguer les information de worktree dans `$GIT_COMMON_DIR/worktrees`</x:String>
   <x:String x:Key="Text.Pull" xml:space="preserve">Pull</x:String>
   <x:String x:Key="Text.Pull.Branch" xml:space="preserve">Branche distante :</x:String>
   <x:String x:Key="Text.Pull.FetchAllBranches" xml:space="preserve">Fetch toutes les branches</x:String>

--- a/src/Resources/Locales/it_IT.axaml
+++ b/src/Resources/Locales/it_IT.axaml
@@ -515,7 +515,7 @@
   <x:String x:Key="Text.PruneRemote" xml:space="preserve">Potatura Remota</x:String>
   <x:String x:Key="Text.PruneRemote.Target" xml:space="preserve">Destinazione:</x:String>
   <x:String x:Key="Text.PruneWorktrees" xml:space="preserve">Potatura Worktrees</x:String>
-  <x:String x:Key="Text.PruneWorktrees.Tip" xml:space="preserve">Potatura delle informazioni di worktree in `$GIT_DIR/worktrees`</x:String>
+  <x:String x:Key="Text.PruneWorktrees.Tip" xml:space="preserve">Potatura delle informazioni di worktree in `$GIT_COMMON_DIR/worktrees`</x:String>
   <x:String x:Key="Text.Pull" xml:space="preserve">Scarica</x:String>
   <x:String x:Key="Text.Pull.Branch" xml:space="preserve">Branch Remoto:</x:String>
   <x:String x:Key="Text.Pull.FetchAllBranches" xml:space="preserve">Recupera tutti i branch</x:String>

--- a/src/Resources/Locales/pt_BR.axaml
+++ b/src/Resources/Locales/pt_BR.axaml
@@ -498,7 +498,7 @@
   <x:String x:Key="Text.PruneRemote" xml:space="preserve">Prunar Remoto</x:String>
   <x:String x:Key="Text.PruneRemote.Target" xml:space="preserve">Alvo:</x:String>
   <x:String x:Key="Text.PruneWorktrees" xml:space="preserve">Podar Worktrees</x:String>
-  <x:String x:Key="Text.PruneWorktrees.Tip" xml:space="preserve">Podar informações de worktree em `$GIT_DIR/worktrees`</x:String>
+  <x:String x:Key="Text.PruneWorktrees.Tip" xml:space="preserve">Podar informações de worktree em `$GIT_COMMON_DIR/worktrees`</x:String>
   <x:String x:Key="Text.Pull" xml:space="preserve">Puxar</x:String>
   <x:String x:Key="Text.Pull.Branch" xml:space="preserve">Branch Remoto:</x:String>
   <x:String x:Key="Text.Pull.FetchAllBranches" xml:space="preserve">Buscar todos os branches</x:String>

--- a/src/Resources/Locales/ru_RU.axaml
+++ b/src/Resources/Locales/ru_RU.axaml
@@ -516,7 +516,7 @@
   <x:String x:Key="Text.PruneRemote" xml:space="preserve">Удалить внешний репозиторий</x:String>
   <x:String x:Key="Text.PruneRemote.Target" xml:space="preserve">Цель:</x:String>
   <x:String x:Key="Text.PruneWorktrees" xml:space="preserve">Удалить рабочий каталог</x:String>
-  <x:String x:Key="Text.PruneWorktrees.Tip" xml:space="preserve">Информация об обрезке рабочего каталога в «$GIT_DIR/worktrees»</x:String>
+  <x:String x:Key="Text.PruneWorktrees.Tip" xml:space="preserve">Информация об обрезке рабочего каталога в «$GIT_COMMON_DIR/worktrees»</x:String>
   <x:String x:Key="Text.Pull" xml:space="preserve">Забрать</x:String>
   <x:String x:Key="Text.Pull.Branch" xml:space="preserve">Ветка внешнего репозитория:</x:String>
   <x:String x:Key="Text.Pull.FetchAllBranches" xml:space="preserve">Извлечь все ветки</x:String>

--- a/src/Resources/Locales/zh_CN.axaml
+++ b/src/Resources/Locales/zh_CN.axaml
@@ -516,7 +516,7 @@
   <x:String x:Key="Text.PruneRemote" xml:space="preserve">清理远程已删除分支</x:String>
   <x:String x:Key="Text.PruneRemote.Target" xml:space="preserve">目标 ：</x:String>
   <x:String x:Key="Text.PruneWorktrees" xml:space="preserve">清理工作树</x:String>
-  <x:String x:Key="Text.PruneWorktrees.Tip" xml:space="preserve">清理在`$GIT_DIR/worktrees`中的无效工作树信息</x:String>
+  <x:String x:Key="Text.PruneWorktrees.Tip" xml:space="preserve">清理在`$GIT_COMMON_DIR/worktrees`中的无效工作树信息</x:String>
   <x:String x:Key="Text.Pull" xml:space="preserve">拉回(pull)</x:String>
   <x:String x:Key="Text.Pull.Branch" xml:space="preserve">拉取分支 ：</x:String>
   <x:String x:Key="Text.Pull.FetchAllBranches" xml:space="preserve">拉取远程中的所有分支变更</x:String>

--- a/src/Resources/Locales/zh_TW.axaml
+++ b/src/Resources/Locales/zh_TW.axaml
@@ -515,7 +515,7 @@
   <x:String x:Key="Text.PruneRemote" xml:space="preserve">清理遠端已刪除分支</x:String>
   <x:String x:Key="Text.PruneRemote.Target" xml:space="preserve">目標:</x:String>
   <x:String x:Key="Text.PruneWorktrees" xml:space="preserve">清理工作區</x:String>
-  <x:String x:Key="Text.PruneWorktrees.Tip" xml:space="preserve">清理在 `$GIT_DIR/worktrees` 中的無效工作區資訊</x:String>
+  <x:String x:Key="Text.PruneWorktrees.Tip" xml:space="preserve">清理在 `$GIT_COMMON_DIR/worktrees` 中的無效工作區資訊</x:String>
   <x:String x:Key="Text.Pull" xml:space="preserve">拉取 (pull)</x:String>
   <x:String x:Key="Text.Pull.Branch" xml:space="preserve">拉取分支:</x:String>
   <x:String x:Key="Text.Pull.FetchAllBranches" xml:space="preserve">拉取遠端中的所有分支</x:String>

--- a/src/ViewModels/Launcher.cs
+++ b/src/ViewModels/Launcher.cs
@@ -282,6 +282,7 @@ namespace SourceGit.ViewModels
 
             var isBare = new Commands.IsBareRepository(node.Id).Result();
             var gitDir = node.Id;
+            var gitCommonDir = gitDir;
             if (!isBare)
             {
                 gitDir = new Commands.QueryGitDir(node.Id).Result();
@@ -291,9 +292,12 @@ namespace SourceGit.ViewModels
                     App.RaiseException(ctx, "Given path is not a valid git repository!");
                     return;
                 }
+                gitCommonDir = new Commands.QueryGitCommonDir(node.Id).Result();
+                if (string.IsNullOrEmpty(gitCommonDir))
+                    gitCommonDir = gitDir;
             }
 
-            var repo = new Repository(isBare, node.Id, gitDir);
+            var repo = new Repository(isBare, node.Id, gitDir, gitCommonDir);
             repo.Open();
 
             if (page == null)

--- a/src/ViewModels/Repository.cs
+++ b/src/ViewModels/Repository.cs
@@ -45,6 +45,12 @@ namespace SourceGit.ViewModels
             set => SetProperty(ref _gitDir, value);
         }
 
+        public string GitCommonDir
+        {
+            get => _gitCommonDir;
+            set => SetProperty(ref _gitCommonDir, value);
+        }
+
         public Models.RepositorySettings Settings
         {
             get => _settings;
@@ -429,11 +435,12 @@ namespace SourceGit.ViewModels
             set;
         } = 0;
 
-        public Repository(bool isBare, string path, string gitDir)
+        public Repository(bool isBare, string path, string gitDir, string gitCommonDir)
         {
             IsBare = isBare;
             FullPath = path;
             GitDir = gitDir;
+            GitCommonDir = gitCommonDir;
         }
 
         public void Open()
@@ -2437,6 +2444,7 @@ namespace SourceGit.ViewModels
 
         private string _fullpath = string.Empty;
         private string _gitDir = string.Empty;
+        private string _gitCommonDir = string.Empty;
         private Models.RepositorySettings _settings = null;
         private Models.FilterMode _historiesFilterMode = Models.FilterMode.None;
         private bool _hasAllowedSignersFile = false;


### PR DESCRIPTION
run `git rev-parse --git-dir --git-common-dir` can get both paths, but I don't have good idea to read these