### PR TITLE
localization: update spanish translations

### DIFF
--- a/src/Resources/Locales/es_ES.axaml
+++ b/src/Resources/Locales/es_ES.axaml
@@ -189,6 +189,7 @@
   <x:String x:Key="Text.Copy" xml:space="preserve">Copiar</x:String>
   <x:String x:Key="Text.CopyAllText" xml:space="preserve">Copiar Todo el Texto</x:String>
   <x:String x:Key="Text.CopyPath" xml:space="preserve">Copiar Ruta</x:String>
+  <x:String x:Key="Text.CopyFullPath" xml:space="preserve">Copiar Ruta Completa</x:String>
   <x:String x:Key="Text.CreateBranch" xml:space="preserve">Crear Rama...</x:String>
   <x:String x:Key="Text.CreateBranch.BasedOn" xml:space="preserve">Basado En:</x:String>
   <x:String x:Key="Text.CreateBranch.Checkout" xml:space="preserve">Checkout de la rama creada</x:String>


### PR DESCRIPTION
add literal translation for 'CopyFullPath' string

> [!NOTE]
> Literal for **Copy Full Path** is "Copiar Ruta Completa", but it may be changed to "Copiar Ruta Absoluta" (translation for "_Copy Absolute Path_") in the future if the context of the English text changes.