### PR TITLE
Add filterbox in Staged area, same as in Unstaged area

### DIFF
--- a/src/Views/WorkingCopy.axaml
+++ b/src/Views/WorkingCopy.axaml
@@ -129,7 +129,7 @@
                     Background="{DynamicResource Brush.Border0}"/>
 
       <!-- Staged -->
-      <Grid Grid.Row="2" RowDefinitions="28,*">
+      <Grid Grid.Row="2" RowDefinitions="28,36,*">
         <!-- Staged Toolbar -->
         <Border Grid.Row="0" BorderThickness="0,0,0,1" BorderBrush="{DynamicResource Brush.Border0}">
           <Grid ColumnDefinitions="Auto,Auto,Auto,Auto,*,Auto,Auto,Auto">
@@ -156,14 +156,47 @@
           </Grid>
         </Border>
 
+        <!-- Staged Filter -->
+        <Border Grid.Row="1" BorderThickness="0,0,0,1" BorderBrush="{DynamicResource Brush.Border0}">
+          <TextBox Height="24"
+                   Margin="4,0"
+                   BorderThickness="1"
+                   CornerRadius="12"
+                   Text="{Binding StagedFilter, Mode=TwoWay}"
+                   BorderBrush="{DynamicResource Brush.Border2}"
+                   VerticalContentAlignment="Center">
+            <TextBox.InnerLeftContent>
+              <Path Width="14" Height="14"
+                    Margin="6,0,0,0"
+                    Fill="{DynamicResource Brush.FG2}"
+                    Data="{StaticResource Icons.Search}"/>
+            </TextBox.InnerLeftContent>
+
+            <TextBox.InnerRightContent>
+              <Button Classes="icon_button"
+                      Width="16"
+                      Margin="0,0,6,0"
+                      Command="{Binding ClearStagedFilter}"
+                      IsVisible="{Binding StagedFilter, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"
+                      HorizontalAlignment="Right">
+                <Path Width="14" Height="14"
+                      Margin="0,1,0,0"
+                      Fill="{DynamicResource Brush.FG1}"
+                      Data="{StaticResource Icons.Clear}"/>
+              </Button>
+            </TextBox.InnerRightContent>
+          </TextBox>
+        </Border>
+        
         <!-- Staged Changes -->
-        <v:ChangeCollectionView Grid.Row="1"
+        <v:ChangeCollectionView Grid.Row="2"
                                 x:Name="StagedChangesView"
                                 Focusable="True"
+                                IsUnstagedChange="False"
                                 SelectionMode="Multiple"
                                 Background="{DynamicResource Brush.Contents}"
                                 ViewMode="{Binding Source={x:Static vm:Preferences.Instance}, Path=StagedChangeViewMode}"
-                                Changes="{Binding Staged}"
+                                Changes="{Binding VisibleStaged}"
                                 SelectedChanges="{Binding SelectedStaged, Mode=TwoWay}"
                                 ContextRequested="OnStagedContextRequested"
                                 ChangeDoubleTapped="OnStagedChangeDoubleTapped"


### PR DESCRIPTION
Implements #1155.

Adds a searchfilter-box, identical to the one in the Unstaged area.

Also adds a RaiseException if committing with a Staged-filter active, since otherwise more changes than the visible ones could be committed. NOTE: This could be made into a warning-dialog with options "Continue? Yes / No", similar to `ConfirmCommitWithoutFiles()`.