### PR TITLE
feature: Display notification with remote message during push

### DIFF
--- a/src/Commands/Push.cs
+++ b/src/Commands/Push.cs
@@ -1,4 +1,7 @@
 ﻿using System;
+using System.Collections.Generic;
+
+using Avalonia.Threading;
 
 namespace SourceGit.Commands
 {
@@ -39,11 +42,29 @@ namespace SourceGit.Commands
             Args += $"{remote} {refname}";
         }
 
+        public new bool Exec()
+        {
+            if (!base.Exec())
+            {
+                return false;
+            }
+            if (_remoteMessage.Count > 0)
+            {
+                Dispatcher.UIThread.Post(() => App.SendNotification(Context, string.Join("\n", _remoteMessage)));
+            }
+            return true;
+        }
+
         protected override void OnReadline(string line)
         {
+            if (line.StartsWith("remote: "))
+            {
+                _remoteMessage.Add(line.Substring(8));
+            }
             _outputHandler?.Invoke(line);
         }
 
         private readonly Action<string> _outputHandler = null;
+        private List<string> _remoteMessage = new List<string>();
     }
 }


### PR DESCRIPTION
This PR adds a notification with the remote message during push.

This is useful with Git servers that give messages, e.g. using Gitlab to retrieve the merge request URL (see example).
It parses the push log to generate a notification:
```
> git push
Total 0 (delta 0), reused 0 (delta 0), pack-reused 0 (from 0)
remote:
remote: To create a merge request for new_feature, visit:
remote:   https://gitlab.intopix.com/hw/tools/vncviewer_launcher/-/merge_requests/new?merge_request%5Bsource_branch%5D=new_feature
remote:
To gitlab.intopix.com:hw/tools/vncviewer_launcher.git
 * [new branch]      new_feature -> new_feature
```
![image](https://github.com/user-attachments/assets/c940b2f6-f574-4ecf-a7eb-5048e39393e7)

Best would be to be able to click the URL in the notification, but I'm don't think it's currently possible with AvaloniaUI.

Relates to https://github.com/sourcegit-scm/sourcegit/issues/1170