### PR TITLE
Feat/conflict popup

### DIFF
--- a/src/Resources/Locales/de_DE.axaml
+++ b/src/Resources/Locales/de_DE.axaml
@@ -178,6 +178,8 @@
   <x:String x:Key="Text.ConfigureWorkspace.Color" xml:space="preserve">Farbe</x:String>
   <x:String x:Key="Text.ConfigureWorkspace.Name" xml:space="preserve">Name</x:String>
   <x:String x:Key="Text.ConfigureWorkspace.Restore" xml:space="preserve">Zuletzt geöffnete Tabs beim Starten wiederherstellen</x:String>
+  <x:String x:Key="Text.ConflictDialog.Title">Nicht aufgelöste Konflikte</x:String>
+  <x:String x:Key="Text.ConflictDialog.Message">In Ihrer Arbeitskopie befinden sich nicht aufgelöste Konflikte!</x:String>
   <x:String x:Key="Text.ConventionalCommit" xml:space="preserve">Konventionelle Commit-Hilfe</x:String>
   <x:String x:Key="Text.ConventionalCommit.BreakingChanges" xml:space="preserve">Breaking Change:</x:String>
   <x:String x:Key="Text.ConventionalCommit.ClosedIssue" xml:space="preserve">Geschlossenes Ticket:</x:String>

--- a/src/Resources/Locales/en_US.axaml
+++ b/src/Resources/Locales/en_US.axaml
@@ -186,6 +186,8 @@
   <x:String x:Key="Text.ConfirmEmptyCommit.NoLocalChanges" xml:space="preserve">Empty commit detected! Do you want to continue (--allow-empty)?</x:String>
   <x:String x:Key="Text.ConfirmEmptyCommit.StageAllThenCommit" xml:space="preserve">STAGE ALL &amp; COMMIT</x:String>
   <x:String x:Key="Text.ConfirmEmptyCommit.WithLocalChanges" xml:space="preserve">Empty commit detected! Do you want to continue (--allow-empty) or stage all then commit?</x:String>
+  <x:String x:Key="Text.ConflictDialog.Title">Unresolved Conflicts</x:String>
+  <x:String x:Key="Text.ConflictDialog.Message">There are unresolved conflicts in your working copy!</x:String>
   <x:String x:Key="Text.ConventionalCommit" xml:space="preserve">Conventional Commit Helper</x:String>
   <x:String x:Key="Text.ConventionalCommit.BreakingChanges" xml:space="preserve">Breaking Change:</x:String>
   <x:String x:Key="Text.ConventionalCommit.ClosedIssue" xml:space="preserve">Closed Issue:</x:String>

--- a/src/Resources/Locales/es_ES.axaml
+++ b/src/Resources/Locales/es_ES.axaml
@@ -187,6 +187,8 @@
   <x:String x:Key="Text.ConfirmEmptyCommit.NoLocalChanges" xml:space="preserve">¡Commit vacío detectado! ¿Quieres continuar (--allow-empty)?</x:String>
   <x:String x:Key="Text.ConfirmEmptyCommit.StageAllThenCommit" xml:space="preserve">HACER STAGE A TODO &amp; COMMIT</x:String>
   <x:String x:Key="Text.ConfirmEmptyCommit.WithLocalChanges" xml:space="preserve">¡Commit vacío detectado! ¿Quieres continuar (--allow-empty) o hacer stage a todo y después commit?</x:String>
+  <x:String x:Key="Text.ConflictDialog.Title">Conflictos sin resolver</x:String>
+  <x:String x:Key="Text.ConflictDialog.Message">¡Hay conflictos sin resolver en tu copia de trabajo!</x:String>
   <x:String x:Key="Text.ConventionalCommit" xml:space="preserve">Asistente de Commit Convencional</x:String>
   <x:String x:Key="Text.ConventionalCommit.BreakingChanges" xml:space="preserve">Cambio Importante:</x:String>
   <x:String x:Key="Text.ConventionalCommit.ClosedIssue" xml:space="preserve">Incidencia Cerrada:</x:String>

--- a/src/Resources/Locales/fr_FR.axaml
+++ b/src/Resources/Locales/fr_FR.axaml
@@ -181,6 +181,8 @@
   <x:String x:Key="Text.ConfigureWorkspace.Color" xml:space="preserve">Couleur</x:String>
   <x:String x:Key="Text.ConfigureWorkspace.Name" xml:space="preserve">Nom</x:String>
   <x:String x:Key="Text.ConfigureWorkspace.Restore" xml:space="preserve">Restaurer les onglets au démarrage</x:String>
+  <x:String x:Key="Text.ConflictDialog.Title">Conflits non résolus</x:String>
+  <x:String x:Key="Text.ConflictDialog.Message">Il y a des conflits non résolus dans votre copie de travail !</x:String>
   <x:String x:Key="Text.ConventionalCommit" xml:space="preserve">Assistant Commits Conventionnels</x:String>
   <x:String x:Key="Text.ConventionalCommit.BreakingChanges" xml:space="preserve">Changement Radical :</x:String>
   <x:String x:Key="Text.ConventionalCommit.ClosedIssue" xml:space="preserve">Incident Clos :</x:String>

--- a/src/Resources/Locales/it_IT.axaml
+++ b/src/Resources/Locales/it_IT.axaml
@@ -181,6 +181,8 @@
   <x:String x:Key="Text.ConfigureWorkspace.Color" xml:space="preserve">Colore</x:String>
   <x:String x:Key="Text.ConfigureWorkspace.Name" xml:space="preserve">Nome</x:String>
   <x:String x:Key="Text.ConfigureWorkspace.Restore" xml:space="preserve">Ripristina schede all'avvio</x:String>
+  <x:String x:Key="Text.ConflictDialog.Title">Conflitti non risolti</x:String>
+  <x:String x:Key="Text.ConflictDialog.Message">Ci sono conflitti non risolti nella tua copia di lavoro!</x:String>
   <x:String x:Key="Text.ConventionalCommit" xml:space="preserve">Guida Commit Convenzionali</x:String>
   <x:String x:Key="Text.ConventionalCommit.BreakingChanges" xml:space="preserve">Modifica Sostanziale:</x:String>
   <x:String x:Key="Text.ConventionalCommit.ClosedIssue" xml:space="preserve">Issue Chiusa:</x:String>

--- a/src/Resources/Locales/ja_JP.axaml
+++ b/src/Resources/Locales/ja_JP.axaml
@@ -181,6 +181,8 @@
   <x:String x:Key="Text.ConfigureWorkspace.Color" xml:space="preserve">色</x:String>
   <x:String x:Key="Text.ConfigureWorkspace.Name" xml:space="preserve">名前</x:String>
   <x:String x:Key="Text.ConfigureWorkspace.Restore" xml:space="preserve">起動時にタブを復元</x:String>
+  <x:String x:Key="Text.ConflictDialog.Title">未解決の競合</x:String>
+  <x:String x:Key="Text.ConflictDialog.Message">作業コピーに未解決の競合があります！</x:String>
   <x:String x:Key="Text.ConventionalCommit" xml:space="preserve">Conventional Commitヘルパー</x:String>
   <x:String x:Key="Text.ConventionalCommit.BreakingChanges" xml:space="preserve">破壊的変更:</x:String>
   <x:String x:Key="Text.ConventionalCommit.ClosedIssue" xml:space="preserve">閉じたIssue:</x:String>

--- a/src/Resources/Locales/pt_BR.axaml
+++ b/src/Resources/Locales/pt_BR.axaml
@@ -163,6 +163,8 @@
   <x:String x:Key="Text.ConfigureWorkspace.Color" xml:space="preserve">Cor</x:String>
   <x:String x:Key="Text.ConfigureWorkspace.Name" xml:space="preserve">Nome</x:String>
   <x:String x:Key="Text.ConfigureWorkspace.Restore" xml:space="preserve">Restaurar abas ao inicializar</x:String>
+  <x:String x:Key="Text.ConflictDialog.Title">Conflitos não resolvidos</x:String>
+  <x:String x:Key="Text.ConflictDialog.Message">Há conflitos não resolvidos na sua cópia de trabalho!</x:String>
   <x:String x:Key="Text.ConventionalCommit" xml:space="preserve">Assistente de Conventional Commit</x:String>
   <x:String x:Key="Text.ConventionalCommit.BreakingChanges" xml:space="preserve">Breaking Change:</x:String>
   <x:String x:Key="Text.ConventionalCommit.ClosedIssue" xml:space="preserve">Ticket encerrado:</x:String>

--- a/src/Resources/Locales/ru_RU.axaml
+++ b/src/Resources/Locales/ru_RU.axaml
@@ -186,6 +186,8 @@
   <x:String x:Key="Text.ConfirmEmptyCommit.NoLocalChanges" xml:space="preserve">Обнаружена пустая ревизия! Вы хотите продолжить (--allow-empty)?</x:String>
   <x:String x:Key="Text.ConfirmEmptyCommit.StageAllThenCommit" xml:space="preserve">Подготовить все и зафиксировать ревизию</x:String>
   <x:String x:Key="Text.ConfirmEmptyCommit.WithLocalChanges" xml:space="preserve">Обнаружена пустая ревизия! Вы хотите продолжить (--allow-empty) или отложить все, затем зафиксировать ревизию?</x:String>
+  <x:String x:Key="Text.ConflictDialog.Title">Неразрешённые конфликты</x:String>
+  <x:String x:Key="Text.ConflictDialog.Message">В вашей рабочей копии есть неразрешённые конфликты!</x:String>
   <x:String x:Key="Text.ConventionalCommit" xml:space="preserve">Общепринятый помощник по ревизии</x:String>
   <x:String x:Key="Text.ConventionalCommit.BreakingChanges" xml:space="preserve">Кардинальные изменения:</x:String>
   <x:String x:Key="Text.ConventionalCommit.ClosedIssue" xml:space="preserve">Закрытая тема:</x:String>

--- a/src/Resources/Locales/ta_IN.axaml
+++ b/src/Resources/Locales/ta_IN.axaml
@@ -181,6 +181,8 @@
   <x:String x:Key="Text.ConfigureWorkspace.Color" xml:space="preserve">நிறம்</x:String>
   <x:String x:Key="Text.ConfigureWorkspace.Name" xml:space="preserve">பெயர்</x:String>
   <x:String x:Key="Text.ConfigureWorkspace.Restore" xml:space="preserve">தாவல்களை மீட்டமை</x:String>
+  <x:String x:Key="Text.ConflictDialog.Title">தீர்க்கப்படாத மோதல்கள்</x:String>
+  <x:String x:Key="Text.ConflictDialog.Message">உங்கள் வேலை நகலில் தீர்க்கப்படாத மோதல்கள் உள்ளன!</x:String>
   <x:String x:Key="Text.ConventionalCommit" xml:space="preserve">வழக்கமான உறுதிமொழி உதவியாளர்</x:String>
   <x:String x:Key="Text.ConventionalCommit.BreakingChanges" xml:space="preserve">உடைக்கும் மாற்றம்:</x:String>
   <x:String x:Key="Text.ConventionalCommit.ClosedIssue" xml:space="preserve">மூடப்பட்ட வெளியீடு சிக்கல்:</x:String>

--- a/src/Resources/Locales/uk_UA.axaml
+++ b/src/Resources/Locales/uk_UA.axaml
@@ -185,6 +185,8 @@
   <x:String x:Key="Text.ConfirmEmptyCommit.NoLocalChanges" xml:space="preserve">Виявлено порожній коміт! Продовжити (--allow-empty)?</x:String>
   <x:String x:Key="Text.ConfirmEmptyCommit.StageAllThenCommit" xml:space="preserve">ІНДЕКСУВАТИ ВСЕ ТА ЗАКОМІТИТИ</x:String>
   <x:String x:Key="Text.ConfirmEmptyCommit.WithLocalChanges" xml:space="preserve">Виявлено порожній коміт! Продовжити (--allow-empty) чи індексувати все та закомітити?</x:String>
+  <x:String x:Key="Text.ConflictDialog.Title">Невирішені конфлікти</x:String>
+  <x:String x:Key="Text.ConflictDialog.Message">У вашій робочій копії є невирішені конфлікти!</x:String>
   <x:String x:Key="Text.ConventionalCommit" xml:space="preserve">Допомога Conventional Commit</x:String>
   <x:String x:Key="Text.ConventionalCommit.BreakingChanges" xml:space="preserve">Зворотньо несумісні зміни:</x:String>
   <x:String x:Key="Text.ConventionalCommit.ClosedIssue" xml:space="preserve">Закрите завдання:</x:String>

--- a/src/Resources/Locales/zh_CN.axaml
+++ b/src/Resources/Locales/zh_CN.axaml
@@ -190,6 +190,8 @@
   <x:String x:Key="Text.ConfirmEmptyCommit.NoLocalChanges" xml:space="preserve">提交未包含变更文件！是否继续(--allow-empty)？</x:String>
   <x:String x:Key="Text.ConfirmEmptyCommit.StageAllThenCommit" xml:space="preserve">自动暂存并提交</x:String>
   <x:String x:Key="Text.ConfirmEmptyCommit.WithLocalChanges" xml:space="preserve">提交未包含变更文件！是否继续(--allow-empty)或是自动暂存所有变更并提交？</x:String>
+  <x:String x:Key="Text.ConflictDialog.Title">未解决的冲突</x:String>
+  <x:String x:Key="Text.ConflictDialog.Message">您的工作副本中存在未解决的冲突！</x:String>
   <x:String x:Key="Text.ConventionalCommit" xml:space="preserve">规范化提交信息生成</x:String>
   <x:String x:Key="Text.ConventionalCommit.BreakingChanges" xml:space="preserve">破坏性更新：</x:String>
   <x:String x:Key="Text.ConventionalCommit.ClosedIssue" xml:space="preserve">关闭的ISSUE：</x:String>

--- a/src/Resources/Locales/zh_TW.axaml
+++ b/src/Resources/Locales/zh_TW.axaml
@@ -190,6 +190,8 @@
   <x:String x:Key="Text.ConfirmEmptyCommit.NoLocalChanges" xml:space="preserve">未包含任何檔案變更! 您是否仍要提交 (--allow-empty)?</x:String>
   <x:String x:Key="Text.ConfirmEmptyCommit.StageAllThenCommit" xml:space="preserve">自动暂存并提交</x:String>
   <x:String x:Key="Text.ConfirmEmptyCommit.WithLocalChanges" xml:space="preserve">未包含任何檔案變更! 您是否仍要提交 (--allow-empty)或者自動暫存全部變更並提交?</x:String>
+  <x:String x:Key="Text.ConflictDialog.Title">未解決的衝突</x:String>
+  <x:String x:Key="Text.ConflictDialog.Message">您的工作副本中有未解決的衝突！</x:String>
   <x:String x:Key="Text.ConventionalCommit" xml:space="preserve">產生約定式提交訊息</x:String>
   <x:String x:Key="Text.ConventionalCommit.BreakingChanges" xml:space="preserve">破壞性變更:</x:String>
   <x:String x:Key="Text.ConventionalCommit.ClosedIssue" xml:space="preserve">關閉的 Issue:</x:String>

--- a/src/ViewModels/WorkingCopy.cs
+++ b/src/ViewModels/WorkingCopy.cs
@@ -9,6 +9,8 @@ using Avalonia.Threading;
 
 using CommunityToolkit.Mvvm.ComponentModel;
 
+using SourceGit.Views;
+
 namespace SourceGit.ViewModels
 {
     public class WorkingCopy : ObservableObject
@@ -300,6 +302,15 @@ namespace SourceGit.ViewModels
 
             Dispatcher.UIThread.Invoke(() =>
             {
+                if((visibleUnstaged.Count > 0) && (hasConflict))
+                {
+                    _repo.RefreshBranches();
+                    _repo.RefreshCommits();
+                    _repo.SelectedViewIndex = 1;
+                    selectedUnstaged.Add(visibleUnstaged[0]);
+                    App.OpenDialog(new ConflictDialog());
+                }
+
                 _isLoadingData = true;
                 HasUnsolvedConflicts = hasConflict;
                 VisibleUnstaged = visibleUnstaged;
@@ -310,8 +321,8 @@ namespace SourceGit.ViewModels
                 SelectedStaged = selectedStaged;
                 _isLoadingData = false;
 
-                UpdateDetail();
                 UpdateInProgressState();
+                UpdateDetail();
             });
         }
 

--- a/src/Views/Conflict.axaml
+++ b/src/Views/Conflict.axaml
@@ -111,7 +111,7 @@
               <TextBlock Margin="6,0,0,0" Text="{DynamicResource Text.WorkingCopy.Conflicts.UseTheirs}" VerticalAlignment="Center"/>
             </StackPanel>
           </Button>
-          <Button Classes="flat" Margin="8,0,0,0" Command="{Binding UseMine}" ToolTip.Tip="git checkout --theirs">
+          <Button Classes="flat" Margin="8,0,0,0" Command="{Binding UseMine}" ToolTip.Tip="git checkout --ours">
             <StackPanel Orientation="Horizontal">
               <Path Width="12" Height="12" Data="{StaticResource Icons.Local}"/>
               <TextBlock Margin="6,0,0,0" Text="{DynamicResource Text.WorkingCopy.Conflicts.UseMine}" VerticalAlignment="Center"/>

--- a/src/Views/ConflictDialog.axaml
+++ b/src/Views/ConflictDialog.axaml
@@ -1,0 +1,54 @@
+<v:ChromelessWindow xmlns="https://github.com/avaloniaui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+                    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+                    xmlns:v="using:SourceGit.Views"
+                    mc:Ignorable="d"
+                    x:Class="SourceGit.Views.ConflictDialog"
+                    x:Name="ThisControl"
+                    Icon="/App.ico"
+                    Title="{DynamicResource Text.ConflictDialog.Title}"
+                    Width="420" Height="160"
+                    CanResize="False"
+                    WindowStartupLocation="CenterOwner">
+
+  <Grid RowDefinitions="Auto,*">
+    <!-- Custom title bar -->
+    <Grid Grid.Row="0" Height="28" IsVisible="{Binding !#ThisControl.UseSystemWindowFrame}">
+      <Border Background="{DynamicResource Brush.TitleBar}"
+              BorderThickness="0,0,0,1"
+              BorderBrush="{DynamicResource Brush.Border0}"
+              PointerPressed="BeginMoveWindow"/>
+
+      <Path Width="14" Height="14"
+            Margin="10,0,0,0"
+            HorizontalAlignment="Left"
+            Data="{StaticResource Icons.Warn}"/>
+
+      <TextBlock Classes="bold"
+                 Text="{DynamicResource Text.ConflictDialog.Title}"
+                 HorizontalAlignment="Center" VerticalAlignment="Center"
+                 IsHitTestVisible="False"/>
+
+      <v:CaptionButtons HorizontalAlignment="Right"
+                        IsCloseButtonOnly="True"/>
+    </Grid>
+
+    <!-- Content -->
+    <StackPanel Grid.Row="1" Margin="20" Spacing="16" VerticalAlignment="Center">
+      <TextBlock x:Name="MessageText"
+                 TextWrapping="Wrap"
+                 FontSize="14"
+                 Foreground="{DynamicResource Brush.FG1}"
+                 Text="{DynamicResource Text.ConflictDialog.Message}" />
+
+      <Button Width="80"
+              HorizontalAlignment="Center"
+              HorizontalContentAlignment="Center"
+              VerticalContentAlignment="Center"
+              Classes="primary"
+              Content="{DynamicResource Text.Sure}"
+              Click="OnOK"/>
+    </StackPanel>
+  </Grid>
+</v:ChromelessWindow>

--- a/src/Views/ConflictDialog.axaml.cs
+++ b/src/Views/ConflictDialog.axaml.cs
@@ -1,0 +1,18 @@
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+
+namespace SourceGit.Views
+{
+    public partial class ConflictDialog : ChromelessWindow
+    {
+        public ConflictDialog()
+        {
+            InitializeComponent();
+        }
+
+        private void OnOK(object sender, RoutedEventArgs e)
+        {
+            Close();
+        }
+    }
+}


### PR DESCRIPTION
Addressed feature request https://github.com/sourcegit-scm/sourcegit/issues/1210

Now when there is a conflict (either on startup or after an attempted merge) that cannot be resolved, a popup appears and the view switches to the first conflict to resolve.

![image](https://github.com/user-attachments/assets/a28e8fbc-7557-4e5c-ae17-3d5432bd1620)

![image](https://github.com/user-attachments/assets/6bcd9510-26fc-40e5-be9e-58ac02465760)

Also, previously tool tip erroneously repeated --theirs when hovering over USE MINE
Now it correctly says --ours:

![image](https://github.com/user-attachments/assets/8a04b9b7-8a28-4d9f-8369-38f462f73908)
