### PR TITLE
Use ComboBox to select font

### DIFF
--- a/src/ViewModels/Preferences.cs
+++ b/src/ViewModels/Preferences.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Avalonia.Collections;
@@ -381,6 +382,10 @@ namespace SourceGit.ViewModels
             set => SetProperty(ref _lastCheckUpdateTime, value);
         }
 
+        public List<string> Fonts { get; private set; } = [string.Empty, ..systemFonts.Value];
+
+        public List<string> MonoFonts { get; private set; } = [string.Empty, ..systemFonts.Value];
+
         public void SetCanModify()
         {
             _isReadonly = false;
@@ -695,5 +700,9 @@ namespace SourceGit.ViewModels
         private string _externalMergeToolPath = string.Empty;
 
         private uint _statisticsSampleColor = 0xFF00FF00;
+
+        private static readonly Lazy<List<string>> systemFonts = new(
+            () => [..Avalonia.Media.FontManager.Current.SystemFonts.Select(e => e.Name).OrderBy(e => e)],
+            System.Threading.LazyThreadSafetyMode.PublicationOnly);
     }
 }

--- a/src/Views/Preferences.axaml
+++ b/src/Views/Preferences.axaml
@@ -175,19 +175,38 @@
                        Text="{DynamicResource Text.Preferences.Appearance.DefaultFont}"
                        HorizontalAlignment="Right"
                        Margin="0,0,16,0"/>
-            <TextBox Grid.Row="1" Grid.Column="1"
-                     Height="28"
-                     CornerRadius="3"
-                     Text="{Binding DefaultFontFamily, Mode=TwoWay}"/>
+
+            <ComboBox Grid.Row="1" Grid.Column="1"
+                      MinHeight="28"
+                      Padding="8,0"
+                      CornerRadius="3"
+                      HorizontalAlignment="Stretch"
+                      SelectedItem="{Binding DefaultFontFamily, Mode=TwoWay}"
+                      ItemsSource="{Binding Fonts}">
+              <ComboBox.ItemTemplate>
+                <DataTemplate>
+                  <TextBlock Text="{Binding}" FontFamily="{Binding}" />
+                </DataTemplate>
+              </ComboBox.ItemTemplate>
+            </ComboBox>
 
             <TextBlock Grid.Row="2" Grid.Column="0"
                        Text="{DynamicResource Text.Preferences.Appearance.MonospaceFont}"
                        HorizontalAlignment="Right"
                        Margin="0,0,16,0"/>
-            <TextBox Grid.Row="2" Grid.Column="1"
-                     Height="28"
-                     CornerRadius="3"
-                     Text="{Binding MonospaceFontFamily, Mode=TwoWay}"/>
+            <ComboBox Grid.Row="2" Grid.Column="1"
+                      MinHeight="28"
+                      Padding="8,0"
+                      CornerRadius="3"
+                      HorizontalAlignment="Stretch"
+                      SelectedItem="{Binding MonospaceFontFamily, Mode=TwoWay}"
+                      ItemsSource="{Binding Fonts}">
+              <ComboBox.ItemTemplate>
+                <DataTemplate>
+                  <TextBlock Text="{Binding}" FontFamily="{Binding}" />
+                </DataTemplate>
+              </ComboBox.ItemTemplate>
+            </ComboBox>
 
             <TextBlock Grid.Row="3" Grid.Column="0"
                        Text="{DynamicResource Text.Preferences.Appearance.FontSize}"


### PR DESCRIPTION
It uses text input for fonts now

![Image](https://github.com/user-attachments/assets/924f3608-5d53-4d7c-bee4-24a9ed20acc0)

It will be easier to use if use ComboBox to select system fonts

![Image](https://github.com/user-attachments/assets/461487b9-528d-47b9-88fe-0402d93782a7)

Tested on windows 11