### PR TITLE
fix: Append UserName to the SourceGitIPCChannel NamedPipeServerStream…

### DIFF
--- a/src/Models/IpcChannel.cs
+++ b/src/Models/IpcChannel.cs
@@ -22,7 +22,7 @@ namespace SourceGit.Models
                 _singletoneLock = File.Open(Path.Combine(Native.OS.DataDir, "process.lock"), FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None);
                 _isFirstInstance = true;
                 _server = new NamedPipeServerStream(
-                    "SourceGitIPCChannel",
+                    "SourceGitIPCChannel" + Environment.UserName,
                     PipeDirection.In,
                     -1,
                     PipeTransmissionMode.Byte,
@@ -40,7 +40,7 @@ namespace SourceGit.Models
         {
             try
             {
-                using (var client = new NamedPipeClientStream(".", "SourceGitIPCChannel", PipeDirection.Out))
+                using (var client = new NamedPipeClientStream(".", "SourceGitIPCChannel" + Environment.UserName, PipeDirection.Out, PipeOptions.Asynchronous | PipeOptions.CurrentUserOnly))
                 {
                     client.Connect(1000);
                     if (!client.IsConnected)


### PR DESCRIPTION
When multiple users try to open SourceGit on the same server, the [NamedPipeServerStream](https://github.com/sourcegit-scm/sourcegit/blob/master/src/Models/IpcChannel.cs#L24) creation reports an exception with message "Address already in use", even with the PipeOptions.CurrentUserOnly option.
Appending the UserName to the SourceGitIPCChannel NamedPipeServerStream fixes the issue.