### PR TITLE
Show URL in tooltip on Remote

### DIFF
--- a/src/ViewModels/BranchTreeNode.cs
+++ b/src/ViewModels/BranchTreeNode.cs
@@ -56,7 +56,8 @@ namespace SourceGit.ViewModels
 
         public string Tooltip
         {
-            get => Backend is Models.Branch b ? b.FriendlyName : null;
+            get => Backend is Models.Branch b ? 
+                b.FriendlyName : (Backend is Models.Remote r ? r.URL : null);
         }
 
         private Models.FilterMode _filterMode = Models.FilterMode.None;


### PR DESCRIPTION
For the Remote root-nodes under REMOTES in the left sidebar, tooltip now shows the `URL` field from `Models.Remote`.