### PR TITLE
Task/UI usability tweaks

### DIFF
--- a/src/App.axaml.cs
+++ b/src/App.axaml.cs
@@ -109,8 +109,13 @@ namespace SourceGit
         {
             if (data is Views.ChromelessWindow window)
             {
-                if (showAsDialog && Current?.ApplicationLifetime is IClassicDesktopStyleApplicationLifetime { MainWindow: { } owner })
-                    window.ShowDialog(owner);
+                if (Current?.ApplicationLifetime is IClassicDesktopStyleApplicationLifetime { MainWindow: { } owner })
+                {
+                    if (showAsDialog)
+                        window.ShowDialog(owner);
+                    else
+                        window.Show(owner);
+                }
                 else
                     window.Show();
 

--- a/src/Views/About.axaml
+++ b/src/Views/About.axaml
@@ -10,7 +10,6 @@
                     Title="{DynamicResource Text.About}"
                     Width="520" Height="230"
                     CanResize="False"
-                    ShowInTaskbar="False"
                     WindowStartupLocation="CenterOwner">
   <Grid RowDefinitions="Auto,*">
     <!-- TitleBar -->
@@ -64,7 +63,6 @@
         </StackPanel>
 
         <TextBlock x:Name="TxtCopyright" Margin="0,40,0,0" Foreground="{DynamicResource Brush.FG2}"/>
-
       </StackPanel>
     </Grid>
   </Grid>

--- a/src/Views/About.axaml
+++ b/src/Views/About.axaml
@@ -10,7 +10,8 @@
                     Title="{DynamicResource Text.About}"
                     Width="520" Height="230"
                     CanResize="False"
-                    WindowStartupLocation="CenterScreen">
+                    ShowInTaskbar="False"
+                    WindowStartupLocation="CenterOwner">
   <Grid RowDefinitions="Auto,*">
     <!-- TitleBar -->
     <Grid Grid.Row="0" Height="28" IsVisible="{Binding !#ThisControl.UseSystemWindowFrame}">
@@ -62,8 +63,8 @@
           </Button>
         </StackPanel>
 
-
         <TextBlock x:Name="TxtCopyright" Margin="0,40,0,0" Foreground="{DynamicResource Brush.FG2}"/>
+
       </StackPanel>
     </Grid>
   </Grid>

--- a/src/Views/About.axaml
+++ b/src/Views/About.axaml
@@ -67,4 +67,9 @@
       </StackPanel>
     </Grid>
   </Grid>
+
+  <Window.KeyBindings>
+    <KeyBinding Gesture="Escape" Command="{Binding #ThisControl.Close}"/>
+  </Window.KeyBindings>
+
 </v:ChromelessWindow>

--- a/src/Views/ConfirmEmptyCommit.axaml
+++ b/src/Views/ConfirmEmptyCommit.axaml
@@ -12,6 +12,7 @@
                     Title="{DynamicResource Text.Warn}"
                     SizeToContent="WidthAndHeight"
                     CanResize="False"
+                    ShowInTaskbar="False"
                     WindowStartupLocation="CenterOwner">
   <Grid RowDefinitions="Auto,Auto,Auto">
     <!-- TitleBar -->
@@ -66,6 +67,7 @@
               Click="CloseWindow"
               Content="{DynamicResource Text.Cancel}"
               HorizontalContentAlignment="Center"
+              IsCancel="True"
               VerticalContentAlignment="Center"/>
     </StackPanel>
   </Grid>


### PR DESCRIPTION
A couple of minor usability tweaks you might consider, when I was running SourceGit in a multi-monitor setup on Windows
- ConfirmEmptyCommit dialog responds to Cancel button
- ConfirmEmptyCommit not shown in Taskbar (modal dialog)
- About form centered in parent (not primary monitor)
- About form closes on Escape
