### PR TITLE
Task/UI usability tweaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ build/*.rpm
 build/*.AppImage
 SourceGit.app/
 build.command
+src/Properties/launchSettings.json

--- a/src/App.axaml.cs
+++ b/src/App.axaml.cs
@@ -109,11 +109,13 @@ namespace SourceGit
         {
             if (data is Views.ChromelessWindow window)
             {
-                if (showAsDialog && Current?.ApplicationLifetime is IClassicDesktopStyleApplicationLifetime { MainWindow: { } owner })
-                    window.ShowDialog(owner);
-                else
-                    window.Show();
-
+                if (Current?.ApplicationLifetime is IClassicDesktopStyleApplicationLifetime { MainWindow: { } owner })
+                {
+                    if (showAsDialog)
+                        window.ShowDialog(owner);
+                    else
+                        window.Show(owner);
+                }
                 return;
             }
 

--- a/src/App.axaml.cs
+++ b/src/App.axaml.cs
@@ -116,6 +116,9 @@ namespace SourceGit
                     else
                         window.Show(owner);
                 }
+                else
+                    window.Show();
+
                 return;
             }
 

--- a/src/Views/About.axaml
+++ b/src/Views/About.axaml
@@ -10,7 +10,7 @@
                     Title="{DynamicResource Text.About}"
                     Width="520" Height="230"
                     CanResize="False"
-                    WindowStartupLocation="CenterScreen">
+                    WindowStartupLocation="CenterOwner">
   <Grid RowDefinitions="Auto,*">
     <!-- TitleBar -->
     <Grid Grid.Row="0" Height="28" IsVisible="{Binding !#ThisControl.UseSystemWindowFrame}">

--- a/src/Views/About.axaml
+++ b/src/Views/About.axaml
@@ -67,4 +67,9 @@
       </StackPanel>
     </Grid>
   </Grid>
+
+  <Window.KeyBindings>
+    <KeyBinding Gesture="Escape" Command="{Binding #ThisControl.Close}"/>
+  </Window.KeyBindings>
+
 </v:ChromelessWindow>

--- a/src/Views/ConfirmEmptyCommit.axaml
+++ b/src/Views/ConfirmEmptyCommit.axaml
@@ -12,6 +12,7 @@
                     Title="{DynamicResource Text.Warn}"
                     SizeToContent="WidthAndHeight"
                     CanResize="False"
+                    ShowInTaskbar="False"
                     WindowStartupLocation="CenterOwner">
   <Grid RowDefinitions="Auto,Auto,Auto">
     <!-- TitleBar -->
@@ -64,6 +65,7 @@
               Height="30"
               Margin="4,0"
               Click="CloseWindow"
+              IsCancel="True"
               Content="{DynamicResource Text.Cancel}"
               HorizontalContentAlignment="Center"
               VerticalContentAlignment="Center"/>


### PR DESCRIPTION
A couple of minor usability tweaks I found, when I was running SourceGit in a multi-monitor setup on Windows

- ConfirmEmptyCommit dialog responds to Cancel button
- ConfirmEmptyCommit not shown in Taskbar (modal dialog)
- About form centered in parent (not primary monitor)
- About form closes on Escape