### PR TITLE
Avoid duplication of Repository tab

### DIFF
--- a/src/ViewModels/Launcher.cs
+++ b/src/ViewModels/Launcher.cs
@@ -134,7 +134,7 @@ namespace SourceGit.ViewModels
         {
             var existingRepositoriesPAge =
                 Pages.FirstOrDefault(p => string.IsNullOrEmpty(p.Node.Name));
-            if (existingRepositoriesPAge != null)
+            if (existingRepositoriesPAge is not null)
             {
                 ActivePage = existingRepositoriesPAge;
             }

--- a/src/ViewModels/Launcher.cs
+++ b/src/ViewModels/Launcher.cs
@@ -1,6 +1,6 @@
 using System;
 using System.IO;
-
+using System.Linq;
 using Avalonia.Collections;
 using Avalonia.Controls;
 using Avalonia.Input;
@@ -132,9 +132,18 @@ namespace SourceGit.ViewModels
 
         public void AddNewTab()
         {
-            var page = new LauncherPage();
-            Pages.Add(page);
-            ActivePage = page;
+            var existingRepositoriesPAge =
+                Pages.FirstOrDefault(p => string.IsNullOrEmpty(p.Node.Name));
+            if (existingRepositoriesPAge != null)
+            {
+                ActivePage = existingRepositoriesPAge;
+            }
+            else
+            {
+                var page = new LauncherPage();
+                Pages.Add(page);
+                ActivePage = page;
+            }
         }
 
         public void MoveTab(LauncherPage from, LauncherPage to)


### PR DESCRIPTION
I and my colleagues have noticed that with a large number of open repositories it is much more convenient to find and navigate using a new tab. This tab contains a search with a list of already opened repositories, which significantly speeds up and simplifies work. In fact, we use this page as an analog of the `Go to everything` in Rider or `Code search` in VS (which is the same hotkey combination `Ctrl+T`).
And thus using this plug-in during the day you can create quite a few copies of it, which is not convenient.

In this PR it is suggested to keep a new tab in one copy at most.