### PR TITLE
fix: Trim and normalize commit message history line endings

### DIFF
--- a/src/Models/RepositorySettings.cs
+++ b/src/Models/RepositorySettings.cs
@@ -417,6 +417,7 @@ namespace SourceGit.Models
 
         public void PushCommitMessage(string message)
         {
+            message = message.Trim().ReplaceLineEndings("\n");
             var existIdx = CommitMessages.IndexOf(message);
             if (existIdx == 0)
                 return;


### PR DESCRIPTION
![1747707585467](https://github.com/user-attachments/assets/432da7ef-eca4-4100-9f65-ea380709fa41)

When using `Amend`, `CommitMessages` may store duplicate commit messages.