### PR TITLE
Add more FileSystemWatcher patterns, to improve refresh of submodules

### DIFF
--- a/src/Models/Watcher.cs
+++ b/src/Models/Watcher.cs
@@ -154,7 +154,21 @@ namespace SourceGit.Models
                 return;
 
             var name = e.Name.Replace("\\", "/");
-            if (name.StartsWith("modules", StringComparison.Ordinal) && name.EndsWith("HEAD", StringComparison.Ordinal))
+
+            if (name.Contains("fsmonitor--daemon/", StringComparison.Ordinal))
+                return;
+
+            if (name.StartsWith("modules", StringComparison.Ordinal))
+            {
+                if (name.EndsWith("/HEAD", StringComparison.Ordinal) ||
+                    name.EndsWith("/ORIG_HEAD", StringComparison.Ordinal))
+                {
+                    _updateSubmodules = DateTime.Now.AddSeconds(1).ToFileTime();
+                    _updateWC = DateTime.Now.AddSeconds(1).ToFileTime();
+                }
+            }
+            else if (name.Equals("MERGE_HEAD", StringComparison.Ordinal) ||
+                name.Equals("AUTO_MERGE", StringComparison.Ordinal))
             {
                 _updateSubmodules = DateTime.Now.AddSeconds(1).ToFileTime();
                 _updateWC = DateTime.Now.AddSeconds(1).ToFileTime();
@@ -187,7 +201,13 @@ namespace SourceGit.Models
                 return;
 
             var name = e.Name.Replace("\\", "/");
-            if (name.Equals(".git", StringComparison.Ordinal) || name.StartsWith(".git/", StringComparison.Ordinal))
+
+            if (name.Equals(".git", StringComparison.Ordinal) ||
+                name.StartsWith(".git/", StringComparison.Ordinal) ||
+                name.EndsWith("/.git", StringComparison.Ordinal))
+                return;
+
+            if (name.StartsWith(".vs/", StringComparison.Ordinal) && name.EndsWith("/.suo", StringComparison.Ordinal))
                 return;
 
             if (name.Equals(".gitmodules", StringComparison.Ordinal))


### PR DESCRIPTION
Fixes #1344.

Added a few more patterns in `Watcher.OnRepositoryChanged()` and `Watcher.OnWorkingCopyChanged()` :
* Skip files frequently updated by Git `fsmonitor--daemon` and Visual Studio, to ease debugging and for early exit. 
* Skip `.git` file under submodule directories, for consistency.
* Check also for `ORIG_HEAD` under `.git/modules/<submodule>/`, to improve handling of submodules.
* Check for `MERGE_HEAD` and `AUTO_MERGE` under `.git/`, to improve handling of submodules (etc) during merging.

NOTE: Maybe the `MERGE_HEAD` and/or `AUTO_MERGE` files should affect some other update-timers as well, if needed to improve refresh during Merging? (Currently only affecting `_updateSubmodules` and `_updateWC`.)
