### PR TITLE
Fix IsConflictResolved check for submodule

### DIFF
--- a/src/ViewModels/Conflict.cs
+++ b/src/ViewModels/Conflict.cs
@@ -1,4 +1,6 @@
-﻿namespace SourceGit.ViewModels
+﻿using System;
+
+namespace SourceGit.ViewModels
 {
     public class ConflictSourceBranch
     {
@@ -46,7 +48,9 @@
             _wc = wc;
             _change = change;
 
-            IsResolved = new Commands.IsConflictResolved(repo.FullPath, change).Result();
+            var isSubmodule = repo.Submodules.Find(x => x.Path.Equals(change.Path, StringComparison.Ordinal)) != null;
+
+            IsResolved = !isSubmodule && new Commands.IsConflictResolved(repo.FullPath, change).Result();
 
             var context = wc.InProgressContext;
             if (context is CherryPickInProgress cherryPick)


### PR DESCRIPTION
Improved IsConflicResolved check, to work correctly for submodule conflicts.

~~Added an extra (lock-free) call to git-status with `--porcelain=v2` which makes it easy to check that:~~
* ~~The file is still "unmerged".~~
* ~~The file is a submodule (or not).~~

If the file is a submodule, we always ~~return `false` (while it's unmerged)~~ regard the conflict as unresolved (while Unstaged), since we can't use text-diff check on submodules and the conflict is not resolved until it's Staged.