### PR TITLE
[Feature] Support for WSL git

### DIFF
--- a/src/Commands/Command.cs
+++ b/src/Commands/Command.cs
@@ -167,6 +167,19 @@ namespace SourceGit.Commands
                 start.Environment.Add("LANG", "C");
                 start.Environment.Add("LC_ALL", "C");
             }
+            else if (OperatingSystem.IsWindows())
+            {
+                // Use WSL git for WSL paths on Windows
+                var wsl = new Models.WSL() { Path = WorkingDirectory };
+                if (wsl.IsWSLPath())
+                {
+                    start.FileName = "wsl";
+                    start.Arguments = $"git {start.Arguments}";
+
+                    wsl.SetEnvironmentForProcess(start);
+                    selfExecFile = start.Environment["SSH_ASKPASS"];
+                }
+            }
 
             // Force using this app as git editor.
             switch (Editor)

--- a/src/Commands/Command.cs
+++ b/src/Commands/Command.cs
@@ -31,6 +31,7 @@ namespace SourceGit.Commands
         public EditorType Editor { get; set; } = EditorType.CoreEditor;
         public string SSHKey { get; set; } = string.Empty;
         public string Args { get; set; } = string.Empty;
+        protected Models.WSL WSL { get; private set; }
 
         // Only used in `ExecAsync` mode.
         public CancellationToken CancellationToken { get; set; } = CancellationToken.None;
@@ -195,6 +196,18 @@ namespace SourceGit.Commands
                 .Append("--no-pager -c core.quotepath=off -c credential.helper=")
                 .Append(Native.OS.CredentialHelper)
                 .Append(' ');
+
+            // Use WSL git for WSL paths on Windows
+            WSL = new Models.WSL() { Path = WorkingDirectory };
+            if (WSL.IsWSLPath())
+            {
+                start.FileName = "wsl";
+                builder.Insert(0, "git ");
+
+                WSL.SetEnvironmentForProcess(start);
+                Args = WSL.ConvertArgumentPaths(Args);
+                selfExecFile = start.Environment["SSH_ASKPASS"];
+            }
 
             switch (Editor)
             {

--- a/src/Commands/Diff.cs
+++ b/src/Commands/Diff.cs
@@ -45,10 +45,18 @@ namespace SourceGit.Commands
             {
                 using var proc = new Process();
                 proc.StartInfo = CreateGitStartInfo(true);
-                proc.Start();
 
                 using var ms = new MemoryStream();
-                await proc.StandardOutput.BaseStream.CopyToAsync(ms, CancellationToken).ConfigureAwait(false);
+                if (WSL.IsWSLPath())
+                {
+                    var text = WSL.ReadFromPersistentShell(this, proc.StartInfo).StdOut;
+                    ms.Write(Encoding.UTF8.GetBytes(text));
+                }
+                else
+                {
+                    proc.Start();
+                    await proc.StandardOutput.BaseStream.CopyToAsync(ms, CancellationToken).ConfigureAwait(false);
+                }
 
                 var bytes = ms.ToArray();
                 var start = 0;
@@ -68,7 +76,8 @@ namespace SourceGit.Commands
                     start = end + 1;
                 }
 
-                await proc.WaitForExitAsync(CancellationToken).ConfigureAwait(false);
+                if (!WSL.IsWSLPath())
+                    await proc.WaitForExitAsync(CancellationToken).ConfigureAwait(false);
             }
             catch
             {

--- a/src/Commands/QueryLocalChanges.cs
+++ b/src/Commands/QueryLocalChanges.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
@@ -35,9 +36,19 @@ namespace SourceGit.Commands
             {
                 using var proc = new Process();
                 proc.StartInfo = CreateGitStartInfo(true);
-                proc.Start();
 
-                while (await proc.StandardOutput.ReadLineAsync().ConfigureAwait(false) is { } line)
+                TextReader lineReader;
+                if (WSL.IsWSLPath())
+                {
+                    lineReader = new StringReader(WSL.ReadFromPersistentShell(this, proc.StartInfo).StdOut);
+                }
+                else
+                {
+                    proc.Start();
+                    lineReader = proc.StandardOutput;
+                }
+
+                while (await lineReader.ReadLineAsync().ConfigureAwait(false) is { } line)
                 {
                     var match = REG_FORMAT().Match(line);
                     if (!match.Success)

--- a/src/Models/WSL.cs
+++ b/src/Models/WSL.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Diagnostics;
+using System.Text;
+
+namespace SourceGit.Models
+{
+    public class WSL
+    {
+        public string Path { get; set; } = "";
+
+        public bool IsWSLPath()
+        {
+            return OperatingSystem.IsWindows() && !string.IsNullOrEmpty(Path) &&
+                (Path.StartsWith("//wsl.localhost/", StringComparison.OrdinalIgnoreCase) ||
+                Path.StartsWith("//wsl$/", StringComparison.OrdinalIgnoreCase));
+        }
+
+        public void SetEnvironmentForProcess(ProcessStartInfo start)
+        {
+            start.Environment.Add("LANG", "C");
+            start.Environment.Add("LC_ALL", "C");
+
+            if (start.Environment.TryGetValue("SSH_ASKPASS", out var askPassPath) && !string.IsNullOrEmpty(askPassPath) && System.IO.Path.IsPathRooted(askPassPath))
+            {
+                // Convert Windows path to WSL path
+                var driveLetter = askPassPath[0].ToString();
+                start.Environment["SSH_ASKPASS"] = askPassPath
+                    .Replace($"{driveLetter}:\\", $"/mnt/{driveLetter.ToLowerInvariant()}/")
+                    .Replace('\\', '/');
+            }
+
+            var wslEnvirionment = new[] { "SSH_ASKPASS", "SSH_ASKPASS_REQUIRE", "SOURCEGIT_LAUNCH_AS_ASKPASS", "GIT_SSH_COMMAND", "LANG", "LC_ALL" };
+            var wslEnvBuilder = new StringBuilder();
+
+            foreach (string env in wslEnvirionment)
+            {
+                if (start.Environment.ContainsKey(env))
+                    wslEnvBuilder.Append($"{env}:");
+            }
+
+            // Forward environment variables for WSL
+            start.Environment.Add("WSLENV", wslEnvBuilder.ToString().TrimEnd(':'));
+        }
+    }
+}

--- a/src/Models/WSL.cs
+++ b/src/Models/WSL.cs
@@ -1,0 +1,348 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading;
+using Avalonia.Controls.ApplicationLifetimes;
+using Avalonia.Threading;
+using SourceGit.Commands;
+
+namespace SourceGit.Models
+{
+    public class WSL
+    {
+        public string Path { get; set; } = "";
+        public string GitDir { get; set; } = "";
+        public long RefreshInterval { get; set; } = TimeSpan.FromSeconds(2).Ticks;
+
+        private static readonly ConcurrentDictionary<string, Process> s_persistentShell = new();
+        private static readonly ConcurrentDictionary<string, Lazy<string>> s_linuxPath = new();
+        private static readonly Lock s_persistentLock = new();
+        private static volatile bool s_shutdownRequested;
+
+        public string DistroName
+        {
+            get
+            {
+                if (!IsWSLPath())
+                    return string.Empty;
+
+                var name = Path.Split(["//", "/"], StringSplitOptions.None)[2];
+                return name;
+            }
+        }
+
+        private long _lastRefresh;
+        private readonly IDictionary<string, DateTime> _gitFileTimestamps;
+
+        static WSL()
+        {
+            Dispatcher.UIThread.Post(() =>
+            {
+                if (OperatingSystem.IsWindows() && Avalonia.Application.Current?.ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
+                {
+                    desktop.Exit += CleanupPersistentWSLShell;
+                    desktop.ShutdownRequested += (_, e) => s_shutdownRequested = true;
+                }
+            });
+        }
+
+        public WSL()
+        {
+            _lastRefresh = DateTime.Now.ToFileTime();
+            _gitFileTimestamps = new Dictionary<string, DateTime>();
+        }
+
+        public bool ShouldWSLRefresh()
+        {
+            if (!IsWSLPath())
+                return false;
+
+            if (DateTime.Now.ToFileTime() - _lastRefresh > RefreshInterval)
+            {
+                _lastRefresh = DateTime.Now.ToFileTime();
+                return true;
+            }
+
+            return false;
+        }
+
+        public bool IsWSLPath()
+        {
+            return OperatingSystem.IsWindows() && 
+                !string.IsNullOrEmpty(Path) &&
+                (Path.StartsWith("//wsl.localhost/", StringComparison.OrdinalIgnoreCase) ||
+                Path.StartsWith("//wsl$/", StringComparison.OrdinalIgnoreCase));
+        }
+
+        public void SetEnvironmentForProcess(ProcessStartInfo start)
+        {
+            start.Environment["LANG"] = "C";
+            start.Environment["LC_ALL"] = "C";
+
+            if (start.Environment.TryGetValue("SSH_ASKPASS", out var askPassPath) && !string.IsNullOrEmpty(askPassPath) && System.IO.Path.IsPathRooted(askPassPath))
+            {
+                // Convert Windows path to WSL path
+                var driveLetter = askPassPath[0].ToString();
+                start.Environment["SSH_ASKPASS"] = askPassPath
+                    .Replace($"{driveLetter}:\\", $"/mnt/{driveLetter.ToLowerInvariant()}/")
+                    .Replace('\\', '/');
+            }
+
+            // Strip Windows paths from PATH if present and reconstruct with UNC paths
+            start.Environment["PATH"] = string.Join(';', s_linuxPath.GetOrAdd(DistroName, ReadSharedLinuxPath).Value
+                .Split(':', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .Where(path => !(path.StartsWith("/mnt/") && path.Length > 6 && char.IsAsciiLetter(path[5]) && path[6] == '/'))
+                .Select(path => $@"\\wsl.localhost\{DistroName}{path.Replace('/', '\\')}"));
+
+            var wslEnvironment = new[] { "SSH_ASKPASS", "SSH_ASKPASS_REQUIRE", "SOURCEGIT_LAUNCH_AS_ASKPASS", "GIT_SSH_COMMAND", "LANG", "LC_ALL" };
+            var wslEnvBuilder = new StringBuilder();
+
+            foreach (string env in wslEnvironment)
+            {
+                if (start.Environment.ContainsKey(env))
+                    wslEnvBuilder.Append($"{env}:");
+            }
+
+            // Forward environment variables for WSL
+            start.Environment["WSLENV"] = wslEnvBuilder.ToString().TrimEnd(':');
+            start.Environment["WSLENV"] = $"{start.Environment["WSLENV"]}:PATH/lp/u";
+        }
+
+        public string ConvertArgumentPaths(string args)
+        {
+            if (args.Contains("--pathspec-from-file="))
+            {
+                args = Regex.Replace(args,
+                    @"--pathspec-from-file=""([A-Z]):(\\[^""]+)""",
+                    match => $"--pathspec-from-file=\"/mnt/{match.Groups[1].Value.ToLowerInvariant()}{match.Groups[2].Value.Replace('\\', '/')}\"",
+                    RegexOptions.IgnoreCase);
+            }
+
+            if (args.Contains("-F "))
+            {
+                args = Regex.Replace(args,
+                    @"-F\s+""([A-Z]):(\\[^""]+)""",
+                    match => $"-F \"/mnt/{match.Groups[1].Value.ToLowerInvariant()}{match.Groups[2].Value.Replace('\\', '/')}\"",
+                    RegexOptions.IgnoreCase);
+            }
+
+            if (args.Contains("--file="))
+            {
+                args = Regex.Replace(args,
+                    @"--file=""([A-Z]):(\\[^""]+)""",
+                    match => $"--file=\"/mnt/{match.Groups[1].Value.ToLowerInvariant()}{match.Groups[2].Value.Replace('\\', '/')}\"",
+                    RegexOptions.IgnoreCase);
+            }
+
+            // Handle bare paths as last argument
+            args = Regex.Replace(args,
+                @"(\s|^)""([A-Z]):(\\[^""]+)""$",
+                match => $"{match.Groups[1].Value}\"/mnt/{match.Groups[2].Value.ToLowerInvariant()}{match.Groups[3].Value.Replace("\\", "/")}\"",
+                RegexOptions.IgnoreCase);
+
+            return args;
+        }
+
+        public List<string> GetModifiedGitFiles()
+        {
+            var modifiedFiles = new List<string>();
+
+            CheckGitFile("HEAD", modifiedFiles);
+            CheckGitFile("MERGE_HEAD", modifiedFiles);
+            CheckGitFile("AUTO_MERGE", modifiedFiles);
+            CheckGitFile("BISECT_START", modifiedFiles);
+            CheckGitFile("index", modifiedFiles);
+
+            CheckGitDirectory("refs/heads", modifiedFiles);
+            CheckGitDirectory("refs/remotes", modifiedFiles);
+            CheckGitDirectory("refs/tags", modifiedFiles);
+
+            CheckGitFile("refs/stash", modifiedFiles);
+            CheckGitFile("logs/refs/stash", modifiedFiles);
+
+            CheckGitDirectory("modules", modifiedFiles);
+            CheckGitDirectory("worktrees", modifiedFiles);
+
+            return modifiedFiles;
+        }
+
+        public Command.Result ReadFromPersistentShell(Command command, ProcessStartInfo start)
+        {
+            lock (s_persistentLock)
+            {
+                var process = s_persistentShell.GetOrAdd(DistroName, StartWSLShell);
+                if (process.HasExited)
+                {
+                    if (command is not QueryLocalChanges || s_shutdownRequested)
+                        return new Command.Result() { StdErr = $"WSL process was terminated in {DistroName}", IsSuccess = false };
+
+                    process = StartWSLShell(DistroName);
+                    s_persistentShell[DistroName] = process;
+                }
+
+                var linuxPath = "/" + string.Join("/", Path.Split(['/', '\\'], StringSplitOptions.RemoveEmptyEntries).Skip(2));
+                var commandline = $"git -C \"{linuxPath}\" {start.Arguments[4..]}";
+
+                process.StandardInput.WriteLine($"{commandline}; echo __STDOUT_COMPLETE__; echo __STDERR_COMPLETE__ >&2");
+                process.StandardInput.Flush();
+
+                var standardOutput = new StringBuilder();
+                var standardError = new StringBuilder();
+
+                string buffer;
+                while ((buffer = process.StandardOutput.ReadLine()) != null)
+                {
+                    if (buffer == "__STDOUT_COMPLETE__")
+                        break;
+                    standardOutput.Append(buffer).Append('\n');
+                }
+
+                while ((buffer = process.StandardError.ReadLine()) != null)
+                {
+                    if (buffer == "__STDERR_COMPLETE__")
+                        break;
+                    standardError.Append(buffer).Append('\n');
+                }
+
+                var rs = new Command.Result()
+                {
+                    StdOut = standardOutput.ToString(),
+                    StdErr = standardError.ToString(),
+                };
+
+                rs.IsSuccess = string.IsNullOrWhiteSpace(rs.StdErr);
+                return rs;
+            }
+        }
+
+        public void ReleaseFileWatcherLock(Watcher watcher, IRepository repo)
+        {
+            watcher.MarkWorkingCopyUpdated();
+            watcher.MarkTagUpdated();
+
+            repo.RefreshWorkingCopyChanges();
+            repo.RefreshTags();
+        }
+
+        public void RefreshWorkingCopy(Watcher watcher, IRepository repo)
+        {
+            watcher.MarkWorkingCopyUpdated();
+            repo.RefreshWorkingCopyChanges();
+        }
+
+        private void CheckGitFile(string fileName, List<string> modifiedFiles)
+        {
+            var fullPath = System.IO.Path.Combine(GitDir, fileName);
+            if (File.Exists(fullPath))
+            {
+                var lastWrite = File.GetLastWriteTime(fullPath);
+                if (!_gitFileTimestamps.TryGetValue(fileName, out var lastKnown) || lastWrite > lastKnown)
+                {
+                    _gitFileTimestamps[fileName] = lastWrite;
+                    modifiedFiles.Add(fileName);
+                }
+            }
+            else if (_gitFileTimestamps.ContainsKey(fileName))
+            {
+                _gitFileTimestamps.Remove(fileName);
+                modifiedFiles.Add(fileName);
+            }
+        }
+
+        private void CheckGitDirectory(string dirName, List<string> modifiedFiles)
+        {
+            var fullDirPath = System.IO.Path.Combine(GitDir, dirName);
+            if (!Directory.Exists(fullDirPath))
+                return;
+
+            var files = Directory.GetFiles(fullDirPath, "*", SearchOption.AllDirectories);
+            foreach (var file in files)
+            {
+                var relativePath = System.IO.Path.GetRelativePath(GitDir, file).Replace('\\', '/');
+                var lastWrite = File.GetLastWriteTime(file);
+
+                if (!_gitFileTimestamps.TryGetValue(relativePath, out var lastKnown) || lastWrite > lastKnown)
+                {
+                    _gitFileTimestamps[relativePath] = lastWrite;
+                    modifiedFiles.Add(relativePath);
+                }
+            }
+        }
+
+        private static Process StartWSLShell(string distroName)
+        {
+            var startInfo = new ProcessStartInfo()
+            {
+                FileName = "wsl.exe",
+                Arguments = $"-d {distroName} -e bash --noprofile --norc -i",
+                UseShellExecute = false,
+                RedirectStandardInput = true,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                CreateNoWindow = true
+            };
+
+            startInfo.Environment["HISTFILE"] = "/dev/null";
+            startInfo.Environment["LANG"] = "C";
+            startInfo.Environment["LC_ALL"] = "C";
+            startInfo.Environment["WSLENV"] = "HISTFILE:LANG:LC_ALL";
+
+            return Process.Start(startInfo);
+        }
+
+        private static void CleanupPersistentWSLShell(object sender, EventArgs e)
+        {
+            if (s_persistentShell.Count == 0)
+                return;
+
+            lock (s_persistentLock)
+            {
+                foreach (var process in s_persistentShell.Values)
+                {
+                    if (!process.HasExited)
+                        process.Kill();
+
+                    process.Dispose();
+                }
+
+                s_persistentShell.Clear();
+            }
+        }
+
+        private static Lazy<string> ReadSharedLinuxPath(string distroName)
+        {
+            return new Lazy<string>(() => ReadLinuxPath(distroName), isThreadSafe: true);
+        }
+
+        private static string ReadLinuxPath(string distroName)
+        {
+            var startInfo = new ProcessStartInfo()
+            {
+                FileName = "wsl.exe",
+                Arguments = $"-d {distroName} -e bash -ilc \"printf %s \\\"$PATH\\\"\"",
+                UseShellExecute = false,
+                RedirectStandardInput = true,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                CreateNoWindow = true
+            };
+
+            startInfo.Environment["HISTFILE"] = "/dev/null";
+            startInfo.Environment["LANG"] = "C";
+            startInfo.Environment["LC_ALL"] = "C";
+            startInfo.Environment["WSLENV"] = "HISTFILE:LANG:LC_ALL";
+
+            using var process = Process.Start(startInfo);
+            var path = process.StandardOutput.ReadToEnd();
+            process.StandardInput.Close();
+            process.Kill();
+            process.WaitForExit();
+            return path;
+        }
+    }
+}

--- a/src/Models/Watcher.cs
+++ b/src/Models/Watcher.cs
@@ -19,6 +19,9 @@ namespace SourceGit.Models
             public void Dispose()
             {
                 Interlocked.Decrement(ref _target._lockCount);
+
+                if(_target._wsl.IsWSLPath()) // Notify WSL model that File Watcher lock was released to force refresh
+                    _target._wsl.ReleaseFileWatcherLock(_target, _target._repo);
             }
 
             private Watcher _target;
@@ -76,6 +79,7 @@ namespace SourceGit.Models
             }
 
             _timer = new Timer(Tick, null, 100, 100);
+            _wsl = new WSL() { Path = fullpath, GitDir = gitDir };
 
             // Starts filesystem watchers in another thread to avoid UI blocking
             Task.Run(() =>
@@ -140,6 +144,16 @@ namespace SourceGit.Models
         {
             if (Interlocked.Read(ref _lockCount) > 0)
                 return;
+
+            // Refresh on timed interval for WSL repos, as File Watcher isn't supported in WSL
+            if (_wsl.ShouldWSLRefresh()) 
+            {
+                _wsl.RefreshWorkingCopy(this, _repo);
+                foreach (var file in _wsl.GetModifiedGitFiles())
+                {
+                    HandleGitDirFileChanged(file);
+                }
+            }
 
             var now = DateTime.Now.ToFileTime();
             var refreshCommits = false;
@@ -353,6 +367,7 @@ namespace SourceGit.Models
         private readonly string _root;
         private List<FileSystemWatcher> _watchers;
         private Timer _timer;
+        private WSL _wsl;
 
         private long _lockCount;
         private long _updateWC;

--- a/src/Native/Windows.cs
+++ b/src/Native/Windows.cs
@@ -189,6 +189,15 @@ namespace SourceGit.Native
             startInfo.WorkingDirectory = cwd;
             startInfo.FileName = terminal;
             startInfo.Arguments = args;
+
+            // For WSL paths override shell choice, and just open WSL session in current distro
+            var wsl = new Models.WSL() { Path = workdir };
+            if (wsl.IsWSLPath())
+            {
+                startInfo.FileName = "wsl.exe";
+                startInfo.Arguments = $"-d {wsl.DistroName}";
+            }
+
             Process.Start(startInfo);
         }
 

--- a/src/ViewModels/Repository.cs
+++ b/src/ViewModels/Repository.cs
@@ -869,7 +869,15 @@ namespace SourceGit.ViewModels
 
         public void SetWatcherEnabled(bool enabled)
         {
-            _watcher?.SetEnabled(enabled);
+            var wsl = new Models.WSL() { Path = FullPath };
+            if (wsl.IsWSLPath())
+            {
+                _watcher?.MarkBranchDirtyManually();
+            }
+            else
+            {
+                _watcher?.SetEnabled(enabled);
+            }
         }
 
         public void MarkBranchesDirtyManually()


### PR DESCRIPTION
Allows for sourcegit to use WSL git (from default distribution) when working inside a WSL directory with UNC path (i.e. `\\wsl.localhost`) on Windows. Dynamically chooses to use WSL git over windows git based on the filepath.

This allows users to manage WSL repos through the same windows instance of sourcegit alongside windows repos, which is a huge win for my own personal workflow. Partly based on similar WSL implementation in GitExtensions.