### PR TITLE
Don't show Unmerged files in Staged area

### DIFF
--- a/src/ViewModels/WorkingCopy.cs
+++ b/src/ViewModels/WorkingCopy.cs
@@ -1535,7 +1535,8 @@ namespace SourceGit.ViewModels
             foreach (var c in _cached)
             {
                 if (c.Index != Models.ChangeState.None &&
-                    c.Index != Models.ChangeState.Untracked)
+                    c.Index != Models.ChangeState.Untracked &&
+                    !c.IsConflict)
                     rs.Add(c);
             }
             return rs;


### PR DESCRIPTION
Unmerged files (i.e unresolved conflicts) should only appear in the Unstaged area, and not "duplicated" in the Staged area.

Motivation:
* The user-friendly git-status command does not show these as "Changes to be committed".
* If they appear in the Staged area, they are quite redundant since the Diff view will just show "No changes or only EOL changes".
* Some other Git UIs (like Fork) don't show these as Staged items either.

NOTE: According to the docs for git-status "Short Format" and `--porcelain` format(s), the `<XY>` field values for _**unmerged paths**_ (specifically) do NOT actually represent the Index & Working-tree states, INSTEAD they represent the states introduced by each HEAD in the merge (i.e Theirs & Ours, relative to Base).