### PR TITLE
Refactoring: Add new constant Models.Commit.EmptyTreeSHA1

### DIFF
--- a/src/Commands/IsBinary.cs
+++ b/src/Commands/IsBinary.cs
@@ -11,7 +11,7 @@ namespace SourceGit.Commands
         {
             WorkingDirectory = repo;
             Context = repo;
-            Args = $"diff 4b825dc642cb6eb9a060e54bf8d69288fbee4904 {commit} --numstat -- \"{path}\"";
+            Args = $"diff {Models.Commit.EmptyTreeSHA1} {commit} --numstat -- \"{path}\"";
             RaiseError = false;
         }
 

--- a/src/Models/Commit.cs
+++ b/src/Models/Commit.cs
@@ -18,6 +18,9 @@ namespace SourceGit.Models
 
     public class Commit
     {
+        // As retrieved by: git mktree </dev/null
+        public static readonly string EmptyTreeSHA1 = "4b825dc642cb6eb9a060e54bf8d69288fbee4904";
+
         public static double OpacityForNotMerged
         {
             get;

--- a/src/Models/DiffOption.cs
+++ b/src/Models/DiffOption.cs
@@ -65,7 +65,7 @@ namespace SourceGit.Models
         /// <param name="change"></param>
         public DiffOption(Commit commit, Change change)
         {
-            var baseRevision = commit.Parents.Count == 0 ? "4b825dc642cb6eb9a060e54bf8d69288fbee4904" : $"{commit.SHA}^";
+            var baseRevision = commit.Parents.Count == 0 ? Models.Commit.EmptyTreeSHA1 : $"{commit.SHA}^";
             _revisions.Add(baseRevision);
             _revisions.Add(commit.SHA);
             _path = change.Path;
@@ -79,7 +79,7 @@ namespace SourceGit.Models
         /// <param name="file"></param>
         public DiffOption(Commit commit, string file)
         {
-            var baseRevision = commit.Parents.Count == 0 ? "4b825dc642cb6eb9a060e54bf8d69288fbee4904" : $"{commit.SHA}^";
+            var baseRevision = commit.Parents.Count == 0 ? Models.Commit.EmptyTreeSHA1 : $"{commit.SHA}^";
             _revisions.Add(baseRevision);
             _revisions.Add(commit.SHA);
             _path = file;

--- a/src/ViewModels/CommitDetail.cs
+++ b/src/ViewModels/CommitDetail.cs
@@ -336,7 +336,7 @@ namespace SourceGit.ViewModels
                 options.DefaultExtension = ".patch";
                 options.FileTypeChoices = [new FilePickerFileType("Patch File") { Patterns = ["*.patch"] }];
 
-                var baseRevision = _commit.Parents.Count == 0 ? "4b825dc642cb6eb9a060e54bf8d69288fbee4904" : _commit.Parents[0];
+                var baseRevision = _commit.Parents.Count == 0 ? Models.Commit.EmptyTreeSHA1 : _commit.Parents[0];
                 var storageFile = await storageProvider.SaveFilePickerAsync(options);
                 if (storageFile != null)
                 {
@@ -595,7 +595,7 @@ namespace SourceGit.ViewModels
 
             Task.Run(() =>
             {
-                var parent = _commit.Parents.Count == 0 ? "4b825dc642cb6eb9a060e54bf8d69288fbee4904" : _commit.Parents[0];
+                var parent = _commit.Parents.Count == 0 ? Models.Commit.EmptyTreeSHA1 : _commit.Parents[0];
                 var cmd = new Commands.CompareRevisions(_repo.FullPath, parent, _commit.SHA) { CancellationToken = token };
                 var changes = cmd.Result();
                 var visible = changes;

--- a/src/ViewModels/StashesPage.cs
+++ b/src/ViewModels/StashesPage.cs
@@ -69,7 +69,7 @@ namespace SourceGit.ViewModels
                                 changes = new Commands.CompareRevisions(_repo.FullPath, $"{value.SHA}^", value.SHA).Result();
                                 if (value.Parents.Count == 3)
                                 {
-                                    var untracked = new Commands.CompareRevisions(_repo.FullPath, "4b825dc642cb6eb9a060e54bf8d69288fbee4904", value.Parents[2]).Result();
+                                    var untracked = new Commands.CompareRevisions(_repo.FullPath, Models.Commit.EmptyTreeSHA1, value.Parents[2]).Result();
                                     var needSort = changes.Count > 0;
 
                                     foreach (var c in untracked)
@@ -107,7 +107,7 @@ namespace SourceGit.ViewModels
                     if (value == null)
                         DiffContext = null;
                     else if (value.Index == Models.ChangeState.Added && _selectedStash.Parents.Count == 3)
-                        DiffContext = new DiffContext(_repo.FullPath, new Models.DiffOption("4b825dc642cb6eb9a060e54bf8d69288fbee4904", _selectedStash.Parents[2], value), _diffContext);
+                        DiffContext = new DiffContext(_repo.FullPath, new Models.DiffOption(Models.Commit.EmptyTreeSHA1, _selectedStash.Parents[2], value), _diffContext);
                     else
                         DiffContext = new DiffContext(_repo.FullPath, new Models.DiffOption(_selectedStash.Parents[0], _selectedStash.SHA, value), _diffContext);
                 }
@@ -182,7 +182,7 @@ namespace SourceGit.ViewModels
                     foreach (var c in _changes)
                     {
                         if (c.Index == Models.ChangeState.Added && _selectedStash.Parents.Count == 3)
-                            opts.Add(new Models.DiffOption("4b825dc642cb6eb9a060e54bf8d69288fbee4904", _selectedStash.Parents[2], c));
+                            opts.Add(new Models.DiffOption(Models.Commit.EmptyTreeSHA1, _selectedStash.Parents[2], c));
                         else
                             opts.Add(new Models.DiffOption(_selectedStash.Parents[0], _selectedStash.SHA, c));
                     }

--- a/src/ViewModels/WorkingCopy.cs
+++ b/src/ViewModels/WorkingCopy.cs
@@ -1528,7 +1528,7 @@ namespace SourceGit.ViewModels
             if (_useAmend)
             {
                 var head = new Commands.QuerySingleCommit(_repo.FullPath, "HEAD").Result();
-                return new Commands.QueryStagedChangesWithAmend(_repo.FullPath, head.Parents.Count == 0 ? "4b825dc642cb6eb9a060e54bf8d69288fbee4904" : $"{head.SHA}^").Result();
+                return new Commands.QueryStagedChangesWithAmend(_repo.FullPath, head.Parents.Count == 0 ? Models.Commit.EmptyTreeSHA1 : $"{head.SHA}^").Result();
             }
 
             var rs = new List<Models.Change>();


### PR DESCRIPTION
Reduces redundant occurrences of this "magic number" to a single location.