### PR TITLE
fix: Fix arguments order for checkout command

### DIFF
--- a/src/Commands/Checkout.cs
+++ b/src/Commands/Checkout.cs
@@ -27,9 +27,9 @@ namespace SourceGit.Commands
         {
             var builder = new StringBuilder();
             builder.Append("checkout --progress ");
-            builder.Append(allowOverwrite ? "-B " : "-b ");
             if (force)
                 builder.Append("--force ");
+            builder.Append(allowOverwrite ? "-B " : "-b ");
             builder.Append(branch);
             builder.Append(" ");
             builder.Append(basedOn);


### PR DESCRIPTION
This fixes this small issue introduced in 76a197aae760e3f51e6ac0bb523875ae0c68a888
![Screenshot 2025-05-26 182544](https://github.com/user-attachments/assets/497c7e05-a453-4dac-9813-d58c7f8a0e78)
