### PR TITLE
[UI] Unify looks between file viewer and history file content

### DIFF
--- a/src/ViewModels/CommitDetail.cs
+++ b/src/ViewModels/CommitDetail.cs
@@ -213,13 +213,13 @@ namespace SourceGit.ViewModels
                                 var bitmap = fileSize > 0 ? new Bitmap(stream) : null;
                                 var imageType = ext!.Substring(1).ToUpper(CultureInfo.CurrentCulture);
                                 var image = new Models.RevisionImageFile() { Image = bitmap, FileSize = fileSize, ImageType = imageType };
-                                Dispatcher.UIThread.Invoke(() => ViewRevisionFileContent = image);
+                                Dispatcher.UIThread.Invoke(() => ViewRevisionFileContent = new FileContent(file.Path, image));
                             }
                             else
                             {
                                 var size = new Commands.QueryFileSize(_repo.FullPath, file.Path, _commit.SHA).Result();
                                 var binary = new Models.RevisionBinaryFile() { Size = size };
-                                Dispatcher.UIThread.Invoke(() => ViewRevisionFileContent = binary);
+                                Dispatcher.UIThread.Invoke(() => ViewRevisionFileContent = new FileContent(file.Path, binary));
                             }
 
                             return;
@@ -233,12 +233,12 @@ namespace SourceGit.ViewModels
                             var obj = new Models.RevisionLFSObject() { Object = new Models.LFSObject() };
                             obj.Object.Oid = matchLFS.Groups[1].Value;
                             obj.Object.Size = long.Parse(matchLFS.Groups[2].Value);
-                            Dispatcher.UIThread.Invoke(() => ViewRevisionFileContent = obj);
+                            Dispatcher.UIThread.Invoke(() => ViewRevisionFileContent = new FileContent(file.Path, obj));
                         }
                         else
                         {
                             var txt = new Models.RevisionTextFile() { FileName = file.Path, Content = content };
-                            Dispatcher.UIThread.Invoke(() => ViewRevisionFileContent = txt);
+                            Dispatcher.UIThread.Invoke(() => ViewRevisionFileContent = new FileContent(file.Path, txt));
                         }
                     });
                     break;
@@ -256,17 +256,17 @@ namespace SourceGit.ViewModels
                                 FullMessage = new Models.CommitFullMessage { Message = body }
                             };
 
-                            Dispatcher.UIThread.Invoke(() => ViewRevisionFileContent = submodule);
+                            Dispatcher.UIThread.Invoke(() => ViewRevisionFileContent = new FileContent(file.Path, submodule));
                         }
                         else
                         {
                             Dispatcher.UIThread.Invoke(() =>
                             {
-                                ViewRevisionFileContent = new Models.RevisionSubmodule()
+                                ViewRevisionFileContent = new FileContent(file.Path, new Models.RevisionSubmodule()
                                 {
                                     Commit = new Models.Commit() { SHA = file.SHA },
                                     FullMessage = null,
-                                };
+                                });
                             });
                         }
                     });

--- a/src/ViewModels/FileContent.cs
+++ b/src/ViewModels/FileContent.cs
@@ -1,0 +1,8 @@
+﻿namespace SourceGit.ViewModels
+{
+    public class FileContent(string path, object content)
+    {
+        public string Path { get; set; } = path;
+        public object Content { get; set; } = content;
+    }
+}

--- a/src/ViewModels/FileHistories.cs
+++ b/src/ViewModels/FileHistories.cs
@@ -12,12 +12,6 @@ using CommunityToolkit.Mvvm.ComponentModel;
 
 namespace SourceGit.ViewModels
 {
-    public class FileHistoriesRevisionFile(string path, object content)
-    {
-        public string Path { get; set; } = path;
-        public object Content { get; set; } = content;
-    }
-
     public partial class FileHistoriesSingleRevision : ObservableObject
     {
         public bool IsDiffMode
@@ -65,7 +59,7 @@ namespace SourceGit.ViewModels
             var objs = new Commands.QueryRevisionObjects(_repo.FullPath, _revision.SHA, _file).Result();
             if (objs.Count == 0)
             {
-                ViewContent = new FileHistoriesRevisionFile(_file, null);
+                ViewContent = new FileContent(_file, null);
                 return;
             }
 
@@ -86,13 +80,13 @@ namespace SourceGit.ViewModels
                                 var bitmap = fileSize > 0 ? new Bitmap(stream) : null;
                                 var imageType = Path.GetExtension(_file)!.TrimStart('.').ToUpper(CultureInfo.CurrentCulture);
                                 var image = new Models.RevisionImageFile() { Image = bitmap, FileSize = fileSize, ImageType = imageType };
-                                Dispatcher.UIThread.Invoke(() => ViewContent = new FileHistoriesRevisionFile(_file, image));
+                                Dispatcher.UIThread.Invoke(() => ViewContent = new FileContent(_file, image));
                             }
                             else
                             {
                                 var size = new Commands.QueryFileSize(_repo.FullPath, _file, _revision.SHA).Result();
                                 var binaryFile = new Models.RevisionBinaryFile() { Size = size };
-                                Dispatcher.UIThread.Invoke(() => ViewContent = new FileHistoriesRevisionFile(_file, binaryFile));
+                                Dispatcher.UIThread.Invoke(() => ViewContent = new FileContent(_file, binaryFile));
                             }
 
                             return;
@@ -106,12 +100,12 @@ namespace SourceGit.ViewModels
                             var lfs = new Models.RevisionLFSObject() { Object = new() };
                             lfs.Object.Oid = matchLFS.Groups[1].Value;
                             lfs.Object.Size = long.Parse(matchLFS.Groups[2].Value);
-                            Dispatcher.UIThread.Invoke(() => ViewContent = new FileHistoriesRevisionFile(_file, lfs));
+                            Dispatcher.UIThread.Invoke(() => ViewContent = new FileContent(_file, lfs));
                         }
                         else
                         {
                             var txt = new Models.RevisionTextFile() { FileName = obj.Path, Content = content };
-                            Dispatcher.UIThread.Invoke(() => ViewContent = new FileHistoriesRevisionFile(_file, txt));
+                            Dispatcher.UIThread.Invoke(() => ViewContent = new FileContent(_file, txt));
                         }
                     });
                     break;
@@ -128,7 +122,7 @@ namespace SourceGit.ViewModels
                                 Commit = commit,
                                 FullMessage = new Models.CommitFullMessage { Message = message }
                             };
-                            Dispatcher.UIThread.Invoke(() => ViewContent = new FileHistoriesRevisionFile(_file, module));
+                            Dispatcher.UIThread.Invoke(() => ViewContent = new FileContent(_file, module));
                         }
                         else
                         {
@@ -137,12 +131,12 @@ namespace SourceGit.ViewModels
                                 Commit = new Models.Commit() { SHA = obj.SHA },
                                 FullMessage = null
                             };
-                            Dispatcher.UIThread.Invoke(() => ViewContent = new FileHistoriesRevisionFile(_file, module));
+                            Dispatcher.UIThread.Invoke(() => ViewContent = new FileContent(_file, module));
                         }
                     });
                     break;
                 default:
-                    ViewContent = new FileHistoriesRevisionFile(_file, null);
+                    ViewContent = new FileContent(_file, null);
                     break;
             }
         }

--- a/src/Views/FileContentViewer.axaml
+++ b/src/Views/FileContentViewer.axaml
@@ -1,0 +1,30 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:m="using:SourceGit.Models"
+             xmlns:v="using:SourceGit.Views"
+             xmlns:vm="using:SourceGit.ViewModels"
+             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+             x:Class="SourceGit.Views.FileContentViewer"
+             x:DataType="vm:FileContent">
+  <Border BorderThickness="1" BorderBrush="{DynamicResource Brush.Border2}">
+    <Grid RowDefinitions="26,*">
+      <Border Grid.Row="0"
+              BorderThickness="0,0,0,1" BorderBrush="{DynamicResource Brush.Border2}"
+              Background="{DynamicResource Brush.Window}">
+        <Grid ColumnDefinitions="Auto,*">
+          <Path Grid.Column="0" Width="12" Height="12" Data="{StaticResource Icons.File}" Margin="8,0,0,0"/>
+          <TextBlock Grid.Column="1"
+                     Classes="primary"
+                     Margin="4,0,0,0"
+                     Text="{Binding Path}"
+                     FontSize="11"
+                     TextTrimming="CharacterEllipsis"/>
+        </Grid>
+      </Border>
+
+      <v:RevisionFileContentViewer Grid.Row="1" Content="{Binding Content}"/>
+    </Grid>
+  </Border>
+</UserControl>

--- a/src/Views/FileContentViewer.axaml.cs
+++ b/src/Views/FileContentViewer.axaml.cs
@@ -1,0 +1,12 @@
+using Avalonia.Controls;
+
+namespace SourceGit.Views
+{
+    public partial class FileContentViewer : UserControl
+    {
+        public FileContentViewer()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/src/Views/FileHistories.axaml
+++ b/src/Views/FileHistories.axaml
@@ -133,26 +133,8 @@
                     <v:DiffView/>
                   </DataTemplate>
 
-                  <DataTemplate DataType="vm:FileHistoriesRevisionFile">
-                    <Border BorderThickness="1" BorderBrush="{DynamicResource Brush.Border2}">
-                      <Grid RowDefinitions="26,*">
-                        <Border Grid.Row="0"
-                                BorderThickness="0,0,0,1" BorderBrush="{DynamicResource Brush.Border2}"
-                                Background="{DynamicResource Brush.Window}">
-                          <Grid ColumnDefinitions="Auto,*">
-                            <Path Grid.Column="0" Width="12" Height="12" Data="{StaticResource Icons.File}" Margin="8,0,0,0"/>
-                            <TextBlock Grid.Column="1"
-                                       Classes="primary"
-                                       Margin="4,0,0,0"
-                                       Text="{Binding Path}"
-                                       FontSize="11"
-                                       TextTrimming="CharacterEllipsis"/>
-                          </Grid>
-                        </Border>
-
-                        <v:RevisionFileContentViewer Grid.Row="1" Content="{Binding Content}"/>
-                      </Grid>
-                    </Border>
+                  <DataTemplate DataType="vm:FileContent">
+                    <v:FileContentViewer />
                   </DataTemplate>
                 </ContentControl.DataTemplates>
               </ContentControl>

--- a/src/Views/RevisionFiles.axaml
+++ b/src/Views/RevisionFiles.axaml
@@ -113,7 +113,7 @@
     <!-- Right: File Content Viewer -->
     <Grid Grid.Column="2">
       <Border BorderThickness="1" BorderBrush="{DynamicResource Brush.Border2}">
-        <v:RevisionFileContentViewer Content="{Binding ViewRevisionFileContent}"/>
+        <v:FileContentViewer DataContext="{Binding ViewRevisionFileContent}"/>
       </Border>
     </Grid>
   </Grid>


### PR DESCRIPTION
Currently there is a ui discrepancy in the files content viewer, compared to the changes and file history content viewers, in that it is missing a header bar with it's filename. I've tried to unify the looks of them by moving the header from the FileHistories content viewer to a new intermediate FileContentViewer.

One of the reasons I think it is nice to unify is that it enables the option of adding toggle buttons such as the ones in the changes view when viewing content in the different places. As an example, I'm looking into creating a PR with the option to turn of bitmap interpolation, which currently makes small images very blurry and it would be nice to have a toggle mode in each of the image viewers.

Here is some images of the current ui:
Files browser without the header
![image](https://github.com/user-attachments/assets/3f1f282d-007e-488c-9f08-1defabd7079f)

Files browser with my proposed changes:
![image](https://github.com/user-attachments/assets/fc3e5081-6464-4c9a-9435-e3f80c1805ff)

Changes tab and file history content with the header for reference:
![image](https://github.com/user-attachments/assets/f9d0e105-0dac-40b1-ad52-1673f2aa6bff)
![image](https://github.com/user-attachments/assets/951192c4-ff62-4044-a326-20275f4eb4ab)

My change does however introduce an empty field when no file is selected, which might be a personal preference if it's a bother or not.
![image](https://github.com/user-attachments/assets/90469cbd-da00-4aa5-901c-30a41a07b0cc)

