### PR TITLE
refactor: collecting inlines for subjects

### DIFF
--- a/src/Models/Commit.cs
+++ b/src/Models/Commit.cs
@@ -121,6 +121,6 @@ namespace SourceGit.Models
     public class CommitFullMessage
     {
         public string Message { get; set; } = string.Empty;
-        public List<InlineElement> Inlines { get; set; } = [];
+        public InlineElementCollector Inlines { get; set; } = [];
     }
 }

--- a/src/Models/InlineElementCollector.cs
+++ b/src/Models/InlineElementCollector.cs
@@ -1,0 +1,85 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace SourceGit.Models
+{
+    public class InlineElementCollector : IEnumerable<InlineElement>
+    {
+        private readonly List<InlineElement> _implementation = [];
+
+        public void Clear()
+        {
+            _implementation.Clear();
+
+            AssertInvariant();
+        }
+
+        public int Count => _implementation.Count;
+
+        public void Add(InlineElement element)
+        {
+
+            var index = FindIndex(element.Start);
+            if (!IsIntersection(index, element.Start, element.Length))
+                _implementation.Insert(index, element);
+
+            AssertInvariant();
+        }
+
+        [Conditional("DEBUG")]
+        private void AssertInvariant()
+        {
+            if (_implementation.Count == 0)
+                return;
+
+            for (var index = 1; index < _implementation.Count; index++)
+            {
+                var prev = _implementation[index - 1];
+                var curr = _implementation[index];
+
+                Debug.Assert(prev.Start + prev.Length <= curr.Start);
+            }
+        }
+
+        public InlineElement Lookup(int position)
+        {
+            var index = FindIndex(position);
+            return IsIntersection(index, position, 1)
+                ? _implementation[index]
+                : null;
+        }
+
+        private int FindIndex(int start)
+        {
+            var index = 0;
+            while (index < _implementation.Count && _implementation[index].Start <= start)
+                index++;
+
+            return index;
+        }
+
+        private bool IsIntersection(int index, int start, int length)
+        {
+            if (index > 0)
+            {
+                var predecessor = _implementation[index - 1];
+                if (predecessor.Start + predecessor.Length >= start)
+                    return true;
+            }
+
+            if (index < _implementation.Count)
+            {
+                var successor = _implementation[index];
+                if (start + length >= successor.Start)
+                    return true;
+            }
+
+            return false;
+        }
+
+        public IEnumerator<InlineElement> GetEnumerator() => _implementation.GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+}

--- a/src/Models/IssueTrackerRule.cs
+++ b/src/Models/IssueTrackerRule.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Text.RegularExpressions;
+﻿using System.Text.RegularExpressions;
 
 using CommunityToolkit.Mvvm.ComponentModel;
 
@@ -46,7 +45,7 @@ namespace SourceGit.Models
             set => SetProperty(ref _urlTemplate, value);
         }
 
-        public void Matches(List<InlineElement> outs, string message)
+        public void Matches(InlineElementCollector outs, string message)
         {
             if (_regex == null || string.IsNullOrEmpty(_urlTemplate))
                 return;
@@ -60,18 +59,6 @@ namespace SourceGit.Models
 
                 var start = match.Index;
                 var len = match.Length;
-                var intersect = false;
-                foreach (var exist in outs)
-                {
-                    if (exist.Intersect(start, len))
-                    {
-                        intersect = true;
-                        break;
-                    }
-                }
-
-                if (intersect)
-                    continue;
 
                 var link = _urlTemplate;
                 for (var j = 1; j < match.Groups.Count; j++)

--- a/src/ViewModels/CommitDetail.cs
+++ b/src/ViewModels/CommitDetail.cs
@@ -620,9 +620,9 @@ namespace SourceGit.ViewModels
             });
         }
 
-        private List<Models.InlineElement> ParseInlinesInMessage(string message)
+        private Models.InlineElementCollector ParseInlinesInMessage(string message)
         {
-            var inlines = new List<Models.InlineElement>();
+            var inlines = new Models.InlineElementCollector();
             if (_repo.Settings.IssueTrackerRules is { Count: > 0 } rules)
             {
                 foreach (var rule in rules)
@@ -638,18 +638,6 @@ namespace SourceGit.ViewModels
 
                 var start = match.Index;
                 var len = match.Length;
-                var intersect = false;
-                foreach (var link in inlines)
-                {
-                    if (link.Intersect(start, len))
-                    {
-                        intersect = true;
-                        break;
-                    }
-                }
-
-                if (intersect)
-                    continue;
 
                 var url = message.Substring(start, len);
                 if (Uri.IsWellFormedUriString(url, UriKind.Absolute))
@@ -665,27 +653,12 @@ namespace SourceGit.ViewModels
 
                 var start = match.Index;
                 var len = match.Length;
-                var intersect = false;
-                foreach (var link in inlines)
-                {
-                    if (link.Intersect(start, len))
-                    {
-                        intersect = true;
-                        break;
-                    }
-                }
-
-                if (intersect)
-                    continue;
 
                 var sha = match.Groups[1].Value;
                 var isCommitSHA = new Commands.IsCommitSHA(_repo.FullPath, sha).Result();
                 if (isCommitSHA)
                     inlines.Add(new Models.InlineElement(Models.InlineElementType.CommitSHA, start, len, sha));
             }
-
-            if (inlines.Count > 0)
-                inlines.Sort((l, r) => l.Start - r.Start);
 
             return inlines;
         }

--- a/src/Views/CommitMessagePresenter.cs
+++ b/src/Views/CommitMessagePresenter.cs
@@ -95,26 +95,11 @@ namespace SourceGit.Views
                 point = new Point(x, y);
 
                 var pos = TextLayout.HitTestPoint(point).TextPosition;
-                foreach (var link in links)
-                {
-                    if (!link.Intersect(pos, 1))
-                        continue;
 
-                    if (link == _lastHover)
-                        return;
-
-                    SetCurrentValue(CursorProperty, Cursor.Parse("Hand"));
-
-                    _lastHover = link;
-                    if (link.Type == Models.InlineElementType.Link)
-                        ToolTip.SetTip(this, link.Link);
-                    else
-                        ProcessHoverCommitLink(link);
-
-                    return;
-                }
-
-                ClearHoveredIssueLink();
+                if (links.Lookup(pos) is { } link)
+                    SetHoveredIssueLink(link);
+                else
+                    ClearHoveredIssueLink();
             }
         }
 
@@ -289,6 +274,20 @@ namespace SourceGit.Views
                     });
                 });
             }
+        }
+
+        private void SetHoveredIssueLink(Models.InlineElement link)
+        {
+            if (link == _lastHover)
+                return;
+
+            SetCurrentValue(CursorProperty, Cursor.Parse("Hand"));
+
+            _lastHover = link;
+            if (link.Type == Models.InlineElementType.Link)
+                ToolTip.SetTip(this, link.Link);
+            else
+                ProcessHoverCommitLink(link);
         }
 
         private void ClearHoveredIssueLink()

--- a/src/Views/CommitSubjectPresenter.cs
+++ b/src/Views/CommitSubjectPresenter.cs
@@ -167,19 +167,6 @@ namespace SourceGit.Views
 
                     var start = match.Index;
                     var len = match.Length;
-                    var intersect = false;
-                    foreach (var exist in _elements)
-                    {
-                        if (exist.Intersect(start, len))
-                        {
-                            intersect = true;
-                            break;
-                        }
-                    }
-
-                    if (intersect)
-                        continue;
-
                     _elements.Add(new Models.InlineElement(Models.InlineElementType.Code, start, len, string.Empty));
                 }
 
@@ -187,7 +174,6 @@ namespace SourceGit.Views
                 foreach (var rule in rules)
                     rule.Matches(_elements, subject);
 
-                _elements.Sort((l, r) => l.Start - r.Start);
                 _needRebuildInlines = true;
                 InvalidateVisual();
             }
@@ -364,7 +350,7 @@ namespace SourceGit.Views
             }
         }
 
-        private List<Models.InlineElement> _elements = [];
+        private Models.InlineElementCollector _elements = [];
         private List<Inline> _inlines = [];
         private Models.InlineElement _lastHover = null;
         private bool _needRebuildInlines = false;


### PR DESCRIPTION
Instead of checking intersections of inline elements yourself before adding an inline element, the new class `InlineElementCollector` prevents intersections internally.

Additionally the inline elements are sorted by the new class, so it's no longer necessary to do this after adding the inline elements.