### PR TITLE
fix: issue tracker rule over keyword in subject

### DIFF
--- a/src/Views/CommitSubjectPresenter.cs
+++ b/src/Views/CommitSubjectPresenter.cs
@@ -151,11 +151,15 @@ namespace SourceGit.Views
                     return;
                 }
 
+                var rules = IssueTrackerRules ?? [];
+                foreach (var rule in rules)
+                    rule.Matches(_elements, subject);
+
                 var keywordMatch = REG_KEYWORD_FORMAT1().Match(subject);
                 if (!keywordMatch.Success)
                     keywordMatch = REG_KEYWORD_FORMAT2().Match(subject);
 
-                if (keywordMatch.Success)
+                if (keywordMatch.Success && _elements.Intersect(0, keywordMatch.Length) == null)
                     _elements.Add(new Models.InlineElement(Models.InlineElementType.Keyword, 0, keywordMatch.Length, string.Empty));
 
                 var codeMatches = REG_INLINECODE_FORMAT().Matches(subject);
@@ -172,10 +176,6 @@ namespace SourceGit.Views
 
                     _elements.Add(new Models.InlineElement(Models.InlineElementType.Code, start, len, string.Empty));
                 }
-
-                var rules = IssueTrackerRules ?? [];
-                foreach (var rule in rules)
-                    rule.Matches(_elements, subject);
 
                 _elements.Sort();
                 _needRebuildInlines = true;


### PR DESCRIPTION
Some teams use issue tracker numbers in front of the commit message subject, followed by a colon.  It was not possible to use an issue tracker rule in such cases, since the issue tracker number would be interpreted as a keyword due to the colon and therefore displayed in bold face instead of as a link into the issue tracker.