### PR TITLE
[Feature] Update blame window when clicking/navigating commits

### DIFF
--- a/src/ViewModels/Blame.cs
+++ b/src/ViewModels/Blame.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+
 using Avalonia.Threading;
+
 using CommunityToolkit.Mvvm.ComponentModel;
 
 namespace SourceGit.ViewModels

--- a/src/Views/Blame.axaml
+++ b/src/Views/Blame.axaml
@@ -42,8 +42,24 @@
     </Grid>
 
     <!-- File -->
-    <Border Grid.Row="1" Padding="8,0">
-      <TextBlock Text="{Binding Title}" VerticalAlignment="Center"/>
+    <Border Grid.Row="1" Padding="8,0" >
+      <Grid>
+        <TextBlock Text="{Binding Title}" VerticalAlignment="Center"/>
+        <StackPanel HorizontalAlignment="Right" VerticalAlignment="Center" Orientation="Horizontal">
+          <Button Classes="icon_button"
+                  IsEnabled="{Binding CanMoveBack}"
+                  Width="28"
+                  Click="HistoryBack">
+            <Path Width="12" Height="12" Stretch="Uniform" Data="{StaticResource Icons.TriangleLeft}"/>
+          </Button>
+          <Button Classes="icon_button"
+                  IsEnabled="{Binding CanMoveForward}"
+                  Width="28"
+                  Click="HistoryForward">
+            <Path Width="12" Height="12" Stretch="Uniform" Data="{StaticResource Icons.TriangleRight}"/>
+          </Button>
+        </StackPanel>
+      </Grid>
     </Border>
 
     <!-- Body -->

--- a/src/Views/Blame.axaml.cs
+++ b/src/Views/Blame.axaml.cs
@@ -61,7 +61,6 @@ namespace SourceGit.Views
                             typeface,
                             _editor.FontSize,
                             Brushes.DarkOrange);
-
                         context.DrawText(shaLink, new Point(x, y));
                         context.DrawLine(underlinePen, new Point(x, y + shaLink.Baseline + 2), new Point(x + shaLink.Width, y + shaLink.Baseline + 2));
                         x += shaLink.Width + 8;

--- a/src/Views/Blame.axaml.cs
+++ b/src/Views/Blame.axaml.cs
@@ -61,6 +61,7 @@ namespace SourceGit.Views
                             typeface,
                             _editor.FontSize,
                             Brushes.DarkOrange);
+
                         context.DrawText(shaLink, new Point(x, y));
                         context.DrawLine(underlinePen, new Point(x, y + shaLink.Baseline + 2), new Point(x + shaLink.Width, y + shaLink.Baseline + 2));
                         x += shaLink.Width + 8;
@@ -225,7 +226,7 @@ namespace SourceGit.Views
                         {
                             if (DataContext is ViewModels.Blame blame)
                             {
-                                blame.NavigateToCommit(info.CommitSHA);
+                                blame.NavigateToCommit(info.CommitSHA, true);
                             }
 
                             e.Handled = true;
@@ -433,12 +434,41 @@ namespace SourceGit.Views
         public Blame()
         {
             InitializeComponent();
+
+            AddHandler(PointerReleasedEvent, MouseUpHandler, handledEventsToo: true);
         }
 
         protected override void OnClosed(EventArgs e)
         {
             base.OnClosed(e);
             GC.Collect();
+        }
+
+        private void HistoryBack(object _, RoutedEventArgs e)
+        {
+            if (DataContext is ViewModels.Blame blame)
+            {
+                blame.Back();
+            }
+        }
+        private void HistoryForward(object _, RoutedEventArgs e)
+        {
+            if (DataContext is ViewModels.Blame blame)
+            {
+                blame.Forward();
+            }
+        }
+
+        private void MouseUpHandler(object sender, PointerReleasedEventArgs e)
+        {
+            if (e.InitialPressMouseButton == MouseButton.XButton1)
+            {
+                HistoryBack(null, null);
+            }
+            else if (e.InitialPressMouseButton == MouseButton.XButton2)
+            {
+                HistoryForward(null, null);
+            }
         }
     }
 }


### PR DESCRIPTION
This PR aims to update the blame window with the commit you click on in the left column.
It also adds a history so you can go back and forward through commits with clickable buttons and Mouse4/5 for back and forward.