### PR TITLE
feature: double tap commit with tracked remote branch checks out loca…

### DIFF
--- a/src/ViewModels/Histories.cs
+++ b/src/ViewModels/Histories.cs
@@ -231,9 +231,24 @@ namespace SourceGit.ViewModels
                         return;
                     }
                 }
-                else if (d.Type == Models.DecoratorType.RemoteBranchHead && firstRemoteBranch == null)
+                else if (d.Type == Models.DecoratorType.RemoteBranchHead)
                 {
-                    firstRemoteBranch = _repo.Branches.Find(x => x.FriendlyName == d.Name);
+                    var remoteBranch = _repo.Branches.Find(x => x.FriendlyName == d.Name);
+                    if (remoteBranch != null)
+                    {
+                        var localBranch = _repo.Branches.Find(x => x.IsLocal && x.Upstream == remoteBranch.FullName);
+                        if (localBranch != null)
+                        {
+                            if (!localBranch.IsCurrent)
+                                _repo.CheckoutBranch(localBranch);
+                            return;
+                        }
+                    }
+                    
+                    if (firstRemoteBranch == null)
+                    {
+                        firstRemoteBranch = remoteBranch;
+                    }
                 }
             }
 


### PR DESCRIPTION
My first feature PR 🤞

Every so often I double click on an upstream branch tracked by a local branch that's a few commits behind. In this situation sourcegit prompts me to create a new branch, but it seems pretty rare that the user would actually want this.

Instead it should behave like double clicking on a remote branch in the branch tree - detect that a local tracking branch exists and check that out instead. This PR implements this behavior.

Might be even better to ask the user if they'd also like to fast-forward, but I'm keeping my first PR simple.