### PR TITLE
Support Delete key everywhere

### DIFF
--- a/src/ViewModels/Repository.cs
+++ b/src/ViewModels/Repository.cs
@@ -1358,6 +1358,18 @@ namespace SourceGit.ViewModels
             }
         }
 
+        public void DeleteBranch(Models.Branch branch)
+        {
+            if (CanCreatePopup())
+                ShowPopup(new DeleteBranch(this, branch));
+        }
+
+        public void DeleteRemote(Models.Remote remote)
+        {
+            if (CanCreatePopup())
+                ShowPopup(new DeleteRemote(this, remote));
+        }
+
         public void DeleteMultipleBranches(List<Models.Branch> branches, bool isLocal)
         {
             if (CanCreatePopup())
@@ -1380,6 +1392,12 @@ namespace SourceGit.ViewModels
 
             if (CanCreatePopup())
                 ShowPopup(new CreateTag(this, _currentBranch));
+        }
+
+        public void DeleteTag(Models.Tag tag)
+        {
+            if (CanCreatePopup())
+                ShowPopup(new DeleteTag(this, tag));
         }
 
         public void AddRemote()

--- a/src/ViewModels/StashesPage.cs
+++ b/src/ViewModels/StashesPage.cs
@@ -314,6 +314,12 @@ namespace SourceGit.ViewModels
             }
         }
 
+        public void Drop(Models.Stash stash)
+        {
+            if (_repo.CanCreatePopup())
+                _repo.ShowPopup(new DropStash(_repo, stash));
+        }
+
         private Repository _repo = null;
         private List<Models.Stash> _stashes = [];
         private List<Models.Stash> _visibleStashes = [];

--- a/src/Views/BranchTree.axaml
+++ b/src/Views/BranchTree.axaml
@@ -13,6 +13,7 @@
            ItemsSource="{Binding #ThisControl.Rows}"
            SelectionMode="Multiple"
            SelectionChanged="OnNodesSelectionChanged"
+           KeyDown="OnListKeyDown"
            ContextRequested="OnTreeContextRequested">
     <ListBox.ItemsPanel>
       <ItemsPanelTemplate>

--- a/src/Views/BranchTree.axaml.cs
+++ b/src/Views/BranchTree.axaml.cs
@@ -450,6 +450,44 @@ namespace SourceGit.Views
             }
         }
 
+        private void OnListKeyDown(object _, KeyEventArgs e)
+        {
+            if (e.Key is not (Key.Delete or Key.Back))
+                return;
+
+            var repo = DataContext as ViewModels.Repository;
+            if (repo?.Settings == null)
+                return;
+
+            var selected = BranchesPresenter.SelectedItems;
+            if (selected == null || selected.Count == 0)
+                return;
+
+            if (selected is [ViewModels.BranchTreeNode { Backend: Models.Remote remote }])
+            {
+                repo.DeleteRemote(remote);
+                e.Handled = true;
+                return;
+            }
+
+            var branches = new List<Models.Branch>();
+            foreach (var item in selected)
+            {
+                if (item is ViewModels.BranchTreeNode node)
+                    CollectBranchesInNode(branches, node);
+            }
+
+            if (branches.Find(x => x.IsCurrent) != null)
+                return;
+            
+            if (branches.Count == 1)
+                repo.DeleteBranch(branches[0]);
+            else
+                repo.DeleteMultipleBranches(branches, branches[0].IsLocal);
+            
+            e.Handled = true;
+        }
+
         private void OnDoubleTappedBranchNode(object sender, TappedEventArgs _)
         {
             if (sender is Grid { DataContext: ViewModels.BranchTreeNode node })

--- a/src/Views/StashesPage.axaml
+++ b/src/Views/StashesPage.axaml
@@ -65,6 +65,7 @@
                ItemsSource="{Binding VisibleStashes}"
                SelectedItem="{Binding SelectedStash, Mode=TwoWay}"
                SelectionMode="Single"
+               KeyDown="OnStashKeyDown"
                ScrollViewer.HorizontalScrollBarVisibility="Disabled"
                ScrollViewer.VerticalScrollBarVisibility="Auto">
         <ListBox.Styles>

--- a/src/Views/StashesPage.axaml.cs
+++ b/src/Views/StashesPage.axaml.cs
@@ -1,4 +1,5 @@
 using Avalonia.Controls;
+using Avalonia.Input;
 
 namespace SourceGit.Views
 {
@@ -30,6 +31,21 @@ namespace SourceGit.Views
                 var menu = vm.MakeContextMenu(border.DataContext as Models.Stash);
                 menu?.Open(border);
             }
+            e.Handled = true;
+        }
+
+        private void OnStashKeyDown(object sender, KeyEventArgs e)
+        {
+            if (e.Key is not (Key.Delete or Key.Back))
+                return;
+
+            if (DataContext is not ViewModels.StashesPage vm)
+                return;
+
+            if (sender is not ListBox { SelectedValue: Models.Stash stash })
+                return;
+
+            vm.Drop(stash);
             e.Handled = true;
         }
 

--- a/src/Views/TagsView.axaml
+++ b/src/Views/TagsView.axaml
@@ -23,6 +23,7 @@
       <ListBox Classes="repo_left_content_list"
                ItemsSource="{Binding Rows}"
                SelectionMode="Single"
+               KeyDown="OnKeyDown"
                SelectionChanged="OnSelectionChanged">
 
         <ListBox.DataTemplates>
@@ -88,6 +89,7 @@
                Margin="8,0,0,0"
                ItemsSource="{Binding Tags}"
                SelectionMode="Single"
+               KeyDown="OnKeyDown"
                SelectionChanged="OnSelectionChanged">
         <ListBox.ItemTemplate>
           <DataTemplate DataType="m:Tag">

--- a/src/Views/TagsView.axaml.cs
+++ b/src/Views/TagsView.axaml.cs
@@ -214,6 +214,18 @@ namespace SourceGit.Views
             if (selectedTag != null)
                 RaiseEvent(new RoutedEventArgs(SelectionChangedEvent));
         }
+
+        private void OnKeyDown(object sender, KeyEventArgs e)
+        {
+            if (sender is not ListBox { SelectedValue: Models.Tag tag })
+                return;
+
+            if (DataContext is not ViewModels.Repository repo)
+                return;
+         
+            repo.DeleteTag(tag);
+            e.Handled = true;
+        }
     }
 }
 

--- a/src/Views/ViewLogs.axaml
+++ b/src/Views/ViewLogs.axaml
@@ -53,6 +53,7 @@
                ItemsSource="{Binding Logs}"
                SelectedItem="{Binding SelectedLog, Mode=TwoWay}"
                SelectionMode="Single"
+               KeyDown="OnLogKeyDown"
                Grid.IsSharedSizeScope="True"
                ScrollViewer.HorizontalScrollBarVisibility="Disabled"
                ScrollViewer.VerticalScrollBarVisibility="Auto">

--- a/src/Views/ViewLogs.axaml.cs
+++ b/src/Views/ViewLogs.axaml.cs
@@ -1,4 +1,5 @@
 using Avalonia.Controls;
+using Avalonia.Input;
 
 namespace SourceGit.Views
 {
@@ -37,6 +38,18 @@ namespace SourceGit.Views
             menu.Items.Add(rm);
             menu.Open(grid);
 
+            e.Handled = true;
+        }
+
+        private void OnLogKeyDown(object _, KeyEventArgs e)
+        {
+            if (e.Key is not (Key.Delete or Key.Back))
+                return;
+            
+            if (DataContext is not ViewModels.ViewLogs vm)
+                return;
+
+            vm.Logs.Remove(vm.SelectedLog);
             e.Handled = true;
         }
     }

--- a/src/Views/Welcome.axaml.cs
+++ b/src/Views/Welcome.axaml.cs
@@ -94,20 +94,28 @@ namespace SourceGit.Views
 
         private void OnTreeViewKeyDown(object _, KeyEventArgs e)
         {
-            if (TreeContainer.SelectedItem is ViewModels.RepositoryNode node && e.Key == Key.Enter)
+            if (TreeContainer.SelectedItem is ViewModels.RepositoryNode node)
             {
-                if (node.IsRepository)
+                if (e.Key == Key.Enter)
                 {
-                    var parent = this.FindAncestorOfType<Launcher>();
-                    if (parent is { DataContext: ViewModels.Launcher launcher })
-                        launcher.OpenRepositoryInTab(node, null);
-                }
-                else
-                {
-                    ViewModels.Welcome.Instance.ToggleNodeIsExpanded(node);
-                }
+                    if (node.IsRepository)
+                    {
+                        var parent = this.FindAncestorOfType<Launcher>();
+                        if (parent is { DataContext: ViewModels.Launcher launcher })
+                            launcher.OpenRepositoryInTab(node, null);
+                    }
+                    else
+                    {
+                        ViewModels.Welcome.Instance.ToggleNodeIsExpanded(node);
+                    }
 
-                e.Handled = true;
+                    e.Handled = true;
+                }
+                else if (e.Key is Key.Delete or Key.Back)
+                {
+                    node.Delete();
+                    e.Handled = true;
+                }
             }
         }
 


### PR DESCRIPTION
I keep trying to delete/remove things with the `del` key and nothing happens. Currently the only place this works is for reverting unstaged changes. This PR adds support for keyboard delete in the following places:

1. delete remote
2. delete branch (local, remote, grouped)
3. delete tag
4. drop stash
5. delete git log
6. delete repo (from welcome screen) 

This is the first time I've ever used Avalonia so please feel free to treat this PR as a functional WIP.

Future places `del` could also be used:
1. to un-stage staged changes
2. minus button in main preference lists (custom action, AI)
3. minus button on project preference lists (commit template, issue tracker, custom action)
4. minus button on workspaces list