### PR TITLE
Refactor: Optimize the WorkingCopy.IsChanged() method

### DIFF
--- a/src/ViewModels/WorkingCopy.cs
+++ b/src/ViewModels/WorkingCopy.cs
@@ -1778,16 +1778,11 @@ namespace SourceGit.ViewModels
             if (old.Count != cur.Count)
                 return true;
 
-            var oldMap = new Dictionary<string, Models.Change>();
-            foreach (var c in old)
-                oldMap.Add(c.Path, c);
-
-            foreach (var c in cur)
+            for (int idx = 0; idx < old.Count; idx++)
             {
-                if (!oldMap.TryGetValue(c.Path, out var o))
-                    return true;
-
-                if (o.Index != c.Index || o.WorkTree != c.WorkTree)
+                var o = old[idx];
+                var c = cur[idx];
+                if (o.Path != c.Path || o.Index != c.Index || o.WorkTree != c.WorkTree)
                     return true;
             }
 


### PR DESCRIPTION
There's no need to populate a `Dictionary` just to diff the `old` and `cur` Lists of Changes (in the equal list-length case).

If there has been no changes in the working-copy between the two calls to `QueryLocalChanges`, we can assume that the items in the two lists are reported (by `git-status`) in equal sort-order. And consequently, if the `Path` value DOES differ between two items at equal index in the two equal-length lists, we can directly conclude that some change has occurred between these two calls.

Thus, we only need to loop through the successive list-indices (of the two equal-length lists), comparing the `Path`, `Index` and `WorkTree` values of the `o` and `c` items at each such index.

Loosely related to PR #1401 (where this refacoring was included but not merged).