### PR TITLE
Add bare-minimum support for multi-line stash-message

### DIFF
--- a/src/Resources/Locales/en_US.axaml
+++ b/src/Resources/Locales/en_US.axaml
@@ -697,6 +697,7 @@
   <x:String x:Key="Text.Stash.TipForSelectedFiles" xml:space="preserve">Both staged and unstaged changes of selected file(s) will be stashed!!!</x:String>
   <x:String x:Key="Text.Stash.Title" xml:space="preserve">Stash Local Changes</x:String>
   <x:String x:Key="Text.StashCM.Apply" xml:space="preserve">Apply</x:String>
+  <x:String x:Key="Text.StashCM.CopyMessage" xml:space="preserve">Copy Message</x:String>
   <x:String x:Key="Text.StashCM.Drop" xml:space="preserve">Drop</x:String>
   <x:String x:Key="Text.StashCM.SaveAsPatch" xml:space="preserve">Save as Patch...</x:String>
   <x:String x:Key="Text.StashDropConfirm" xml:space="preserve">Drop Stash</x:String>

--- a/src/ViewModels/StashesPage.cs
+++ b/src/ViewModels/StashesPage.cs
@@ -194,11 +194,21 @@ namespace SourceGit.ViewModels
                 e.Handled = true;
             };
 
+            var copy = new MenuItem();
+            copy.Header = App.Text("StashCM.CopyMessage");
+            copy.Icon = App.CreateMenuIcon("Icons.Copy");
+            copy.Click += (_, ev) =>
+            {
+                App.CopyText(stash.Message);
+                ev.Handled = true;
+            };
+
             var menu = new ContextMenu();
             menu.Items.Add(apply);
             menu.Items.Add(drop);
             menu.Items.Add(new MenuItem { Header = "-" });
             menu.Items.Add(patch);
+            menu.Items.Add(copy);
             return menu;
         }
 

--- a/src/Views/StashChanges.axaml
+++ b/src/Views/StashChanges.axaml
@@ -20,6 +20,7 @@
       <TextBox Grid.Row="0" Grid.Column="1"
                Height="26"
                CornerRadius="3"
+               AcceptsReturn="True"
                Text="{Binding Message, Mode=TwoWay}"
                Watermark="{DynamicResource Text.Stash.Message.Placeholder}"
                v:AutoFocusBehaviour.IsEnabled="True"/>


### PR DESCRIPTION
With these changes, a multi-line message can now be copied-into, viewed and copied-out-of a Stash:
* Simplify parsing in QueryStashes, by passing the `-z` argument to `git stash list` for item separation.
* Query full Message (`%B`) from stash.
* Add "Copy Message" command in stash-item context-menu.
* Make the "Message:" text-box in StashChanges dialog support multiple lines, without changing the layout.

NOTE: Stash-item in list still shows only the first line (Subject) of Message, while tooltip shows the full (multi-line) Message.

This PR addresses the minimum request in #1426 and the follow-up request in #1419. Both issues can be closed if this PR gets merged.