### PR TITLE
Add "Copy Message" to context-menu for Stash item

### DIFF
--- a/src/Resources/Locales/en_US.axaml
+++ b/src/Resources/Locales/en_US.axaml
@@ -697,6 +697,7 @@
   <x:String x:Key="Text.Stash.TipForSelectedFiles" xml:space="preserve">Both staged and unstaged changes of selected file(s) will be stashed!!!</x:String>
   <x:String x:Key="Text.Stash.Title" xml:space="preserve">Stash Local Changes</x:String>
   <x:String x:Key="Text.StashCM.Apply" xml:space="preserve">Apply</x:String>
+  <x:String x:Key="Text.StashCM.CopyMessage" xml:space="preserve">Copy Message</x:String>
   <x:String x:Key="Text.StashCM.Drop" xml:space="preserve">Drop</x:String>
   <x:String x:Key="Text.StashCM.SaveAsPatch" xml:space="preserve">Save as Patch...</x:String>
   <x:String x:Key="Text.StashDropConfirm" xml:space="preserve">Drop Stash</x:String>

--- a/src/ViewModels/StashesPage.cs
+++ b/src/ViewModels/StashesPage.cs
@@ -194,11 +194,21 @@ namespace SourceGit.ViewModels
                 e.Handled = true;
             };
 
+            var copy = new MenuItem();
+            copy.Header = App.Text("StashCM.CopyMessage");
+            copy.Icon = App.CreateMenuIcon("Icons.Copy");
+            copy.Click += (_, ev) =>
+            {
+                App.CopyText(stash.Message);
+                ev.Handled = true;
+            };
+
             var menu = new ContextMenu();
             menu.Items.Add(apply);
             menu.Items.Add(drop);
             menu.Items.Add(new MenuItem { Header = "-" });
             menu.Items.Add(patch);
+            menu.Items.Add(copy);
             return menu;
         }
 


### PR DESCRIPTION
This is a follow-up PR for #1426, adding the only missing piece for being able to re-use the Message from a Stash (by copying it to Clipboard). Also, it refactors the query-code from commit 6d682ac.
* Refactor: Simplify parsing in QueryStashes, by passing the `-z` argument to `git stash list` for item separation.
* Add "Copy Message" command in stash-item context-menu.