### PR TITLE
fix: fix working tree folder path detection error

### DIFF
--- a/src/Views/AddWorktree.axaml.cs
+++ b/src/Views/AddWorktree.axaml.cs
@@ -26,7 +26,7 @@ namespace SourceGit.Views
                 {
                     var folder = selected[0];
                     var folderPath = folder is { Path: { IsAbsoluteUri: true } path } ? path.LocalPath : folder?.Path.ToString();
-                    TxtLocation.Text = folderPath;
+                    TxtLocation.Text = folderPath.TrimEnd('\\');
                 }
             }
             catch (Exception exception)


### PR DESCRIPTION
Fix the error of adding an extra slash when selecting a working tree directory.

![worktree-old-folder-path](https://github.com/user-attachments/assets/067e7262-dde3-4284-a709-57ed24a9c43e)
