### PR TITLE
Repo-search: apply filter also on Repos under matching Group-name

### DIFF
--- a/src/ViewModels/Welcome.cs
+++ b/src/ViewModels/Welcome.cs
@@ -295,22 +295,13 @@ namespace SourceGit.ViewModels
         {
             if (!node.IsRepository)
             {
-                if (node.Name.Contains(_searchFilter, StringComparison.OrdinalIgnoreCase))
+                bool hasVisibleSubNode = false;
+                foreach (var subNode in node.SubNodes)
                 {
-                    node.IsVisible = true;
-                    foreach (var subNode in node.SubNodes)
-                        ResetVisibility(subNode);
+                    SetVisibilityBySearch(subNode);
+                    hasVisibleSubNode |= subNode.IsVisible;
                 }
-                else
-                {
-                    bool hasVisibleSubNode = false;
-                    foreach (var subNode in node.SubNodes)
-                    {
-                        SetVisibilityBySearch(subNode);
-                        hasVisibleSubNode |= subNode.IsVisible;
-                    }
-                    node.IsVisible = hasVisibleSubNode;
-                }
+                node.IsVisible = hasVisibleSubNode || node.Name.Contains(_searchFilter, StringComparison.OrdinalIgnoreCase);
             }
             else
             {


### PR DESCRIPTION
Addresses part of the discussion in issue #1454.

Group and Repo nodes are now name-filtered the same way, while still recursing into Groups with matching sub-Nodes.

It makes filtering more effective, instead of favoring Group-matches over Item-matches.
