### PR TITLE
Allow drag-drop of item (or folder) anywhere in repo-list

### DIFF
--- a/src/ViewModels/Welcome.cs
+++ b/src/ViewModels/Welcome.cs
@@ -173,6 +173,25 @@ namespace SourceGit.ViewModels
                 activePage.Popup = new CreateGroup(null);
         }
 
+        public RepositoryNode FindParentGroup(RepositoryNode node, RepositoryNode group = null)
+        {
+            var collection = (group == null) ? Preferences.Instance.RepositoryNodes : group.SubNodes;
+            if (collection.Contains(node))
+                return group;
+
+            foreach (var item in collection)
+            {
+                if (!item.IsRepository)
+                {
+                    var parent = FindParentGroup(node, item);
+                    if (parent != null)
+                        return parent;
+                }
+            }
+
+            return null;
+        }
+
         public void MoveNode(RepositoryNode from, RepositoryNode to)
         {
             Preferences.Instance.MoveNode(from, to, true);

--- a/src/Views/Welcome.axaml.cs
+++ b/src/Views/Welcome.axaml.cs
@@ -215,7 +215,7 @@ namespace SourceGit.Views
                 if (to == null)
                     return;
 
-                e.DragEffects = to.IsRepository ? DragDropEffects.None : DragDropEffects.Move;
+                e.DragEffects = DragDropEffects.Move;
                 e.Handled = true;
             }
         }
@@ -226,11 +226,14 @@ namespace SourceGit.Views
                 return;
 
             var to = grid.DataContext as ViewModels.RepositoryNode;
-            if (to == null || to.IsRepository)
+            if (to == null)
             {
                 e.Handled = true;
                 return;
             }
+
+            if (to.IsRepository)
+                to = ViewModels.Welcome.Instance.FindParentGroup(to);
 
             if (e.Data.Contains("MovedRepositoryTreeNode") &&
                 e.Data.Get("MovedRepositoryTreeNode") is ViewModels.RepositoryNode moved)


### PR DESCRIPTION
Addresses part of the discussion in #1454.

Dropping on a non-Group item was not allowed earlier, but now it adds/moves the dragged item into the parent Group (possibly "root") of the drop-target item.

This makes drag-drop much easier when there are lots of items in expanded Groups. Also, it now makes it possible to drop into the "root" Group which was not possible earlier (it could be achieved via "Move to Another Group" in context-menu, but not by drag-drop).