### PR TITLE
fix: searching for tree/blob hash never-ending

### DIFF
--- a/src/Commands/QuerySingleCommit.cs
+++ b/src/Commands/QuerySingleCommit.cs
@@ -6,6 +6,9 @@ namespace SourceGit.Commands
     {
         public QuerySingleCommit(string repo, string sha)
         {
+            _repo = repo;
+            _sha = sha;
+
             WorkingDirectory = repo;
             Context = repo;
             Args = $"show --no-show-signature --decorate=full --format=%H%n%P%n%D%n%aN±%aE%n%at%n%cN±%cE%n%ct%n%s -s {sha}";
@@ -13,6 +16,10 @@ namespace SourceGit.Commands
 
         public Models.Commit Result()
         {
+            var isCommitSHA = new IsCommitSHA(_repo, _sha).Result();
+            if (!isCommitSHA)
+                return null;
+
             var rs = ReadToEnd();
             if (rs.IsSuccess && !string.IsNullOrEmpty(rs.StdOut))
             {
@@ -37,5 +44,8 @@ namespace SourceGit.Commands
 
             return null;
         }
+
+        private readonly string _repo;
+        private readonly string _sha;
     }
 }


### PR DESCRIPTION
Searching for a tree or blob hash instead of a commit hash created a seemingly never-ending search (internally an exception was thrown).

Examples for non-ending searches in the SourceGit repository itself are searching for 6b83a0a (that is the tree "src" of commit 190d2ee) or e686a53 (that is the file ".gitignore" in the tree of commit 190d2ee).