### PR TITLE
ci:  code format check

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,7 +12,6 @@ indent_style = space
 indent_size = 4
 dotnet_style_operator_placement_when_wrapping = beginning_of_line
 tab_width = 4
-end_of_line = crlf
 dotnet_style_coalesce_expression = true:suggestion
 dotnet_style_null_propagation = true:suggestion
 dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggestion

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -1,0 +1,22 @@
+name: Format Check
+on:
+  push:
+    branches: [ develop ]
+  workflow_dispatch:
+  workflow_call:
+
+jobs:
+  format-check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 9.0.x
+
+      - name: Run formatting check
+        run: dotnet format --verify-no-changes

--- a/SourceGit.sln
+++ b/SourceGit.sln
@@ -18,6 +18,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "workflows", "workflows", "{
 		.github\workflows\package.yml = .github\workflows\package.yml
 		.github\workflows\release.yml = .github\workflows\release.yml
 		.github\workflows\localization-check.yml = .github\workflows\localization-check.yml
+		.github\workflows\format-check.yml = .github\workflows\format-check.yml
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{49A7C2D6-558C-4FAA-8F5D-EEE81497AED7}"

--- a/src/ViewModels/ExecuteCustomAction.cs
+++ b/src/ViewModels/ExecuteCustomAction.cs
@@ -77,7 +77,7 @@ namespace SourceGit.ViewModels
         public string Label { get; set; } = string.Empty;
         public string Description { get; set; } = string.Empty;
         public List<string> Options { get; set; } = [];
-        
+
         public string Value
         {
             get => _value;


### PR DESCRIPTION
I noticed that trailing whitespace often slips through and has to be fixed in a `code_style` commit.
This PR adds a GH actions workflow that runs `dotnet format` on push. This check will fail on trailing whitespace or any other code formatting violation.