### PR TITLE
refactor: auto dispatch notifications to UI thread in `Launcher`

### DIFF
--- a/src/Commands/Command.cs
+++ b/src/Commands/Command.cs
@@ -5,8 +5,6 @@ using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading;
 
-using Avalonia.Threading;
-
 namespace SourceGit.Commands
 {
     public partial class Command
@@ -68,7 +66,7 @@ namespace SourceGit.Commands
             catch (Exception e)
             {
                 if (RaiseError)
-                    Dispatcher.UIThread.Post(() => App.RaiseException(Context, e.Message));
+                    App.RaiseException(Context, e.Message);
 
                 Log?.AppendLine(string.Empty);
                 return false;
@@ -96,7 +94,7 @@ namespace SourceGit.Commands
                 {
                     var errMsg = string.Join("\n", errs).Trim();
                     if (!string.IsNullOrEmpty(errMsg))
-                        Dispatcher.UIThread.Post(() => App.RaiseException(Context, errMsg));
+                        App.RaiseException(Context, errMsg);
                 }
 
                 return false;

--- a/src/Commands/Discard.cs
+++ b/src/Commands/Discard.cs
@@ -2,8 +2,6 @@
 using System.Collections.Generic;
 using System.IO;
 
-using Avalonia.Threading;
-
 namespace SourceGit.Commands
 {
     public static class Discard
@@ -36,10 +34,7 @@ namespace SourceGit.Commands
             }
             catch (Exception e)
             {
-                Dispatcher.UIThread.Invoke(() =>
-                {
-                    App.RaiseException(repo, $"Failed to discard changes. Reason: {e.Message}");
-                });
+                App.RaiseException(repo, $"Failed to discard changes. Reason: {e.Message}");
             }
 
             new Reset(repo, "HEAD", "--hard") { Log = log }.Exec();
@@ -78,10 +73,7 @@ namespace SourceGit.Commands
             }
             catch (Exception e)
             {
-                Dispatcher.UIThread.Invoke(() =>
-                {
-                    App.RaiseException(repo, $"Failed to discard changes. Reason: {e.Message}");
-                });
+                App.RaiseException(repo, $"Failed to discard changes. Reason: {e.Message}");
             }
 
             if (restores.Count > 0)

--- a/src/Commands/GenerateCommitMessage.cs
+++ b/src/Commands/GenerateCommitMessage.cs
@@ -3,8 +3,6 @@ using System.Collections.Generic;
 using System.Text;
 using System.Threading;
 
-using Avalonia.Threading;
-
 namespace SourceGit.Commands
 {
     /// <summary>
@@ -86,7 +84,7 @@ namespace SourceGit.Commands
             }
             catch (Exception e)
             {
-                Dispatcher.UIThread.Post(() => App.RaiseException(_repo, $"Failed to generate commit message: {e}"));
+                App.RaiseException(_repo, $"Failed to generate commit message: {e}");
             }
         }
 

--- a/src/Commands/GitFlow.cs
+++ b/src/Commands/GitFlow.cs
@@ -1,5 +1,4 @@
 ﻿using System.Text;
-using Avalonia.Threading;
 
 namespace SourceGit.Commands
 {
@@ -43,7 +42,7 @@ namespace SourceGit.Commands
                     start.Args = $"flow hotfix start {name}";
                     break;
                 default:
-                    Dispatcher.UIThread.Invoke(() => App.RaiseException(repo, "Bad git-flow branch type!!!"));
+                    App.RaiseException(repo, "Bad git-flow branch type!!!");
                     return false;
             }
 
@@ -68,7 +67,7 @@ namespace SourceGit.Commands
                     builder.Append("hotfix");
                     break;
                 default:
-                    Dispatcher.UIThread.Invoke(() => App.RaiseException(repo, "Bad git-flow branch type!!!"));
+                    App.RaiseException(repo, "Bad git-flow branch type!!!");
                     return false;
             }
 

--- a/src/Commands/MergeTool.cs
+++ b/src/Commands/MergeTool.cs
@@ -1,7 +1,5 @@
 ﻿using System.IO;
 
-using Avalonia.Threading;
-
 namespace SourceGit.Commands
 {
     public static class MergeTool
@@ -24,14 +22,14 @@ namespace SourceGit.Commands
 
             if (!File.Exists(toolPath))
             {
-                Dispatcher.UIThread.Post(() => App.RaiseException(repo, $"Can NOT find external merge tool in '{toolPath}'!"));
+                App.RaiseException(repo, $"Can NOT find external merge tool in '{toolPath}'!");
                 return false;
             }
 
             var supported = Models.ExternalMerger.Supported.Find(x => x.Type == toolType);
             if (supported == null)
             {
-                Dispatcher.UIThread.Post(() => App.RaiseException(repo, "Invalid merge tool in preference setting!"));
+                App.RaiseException(repo, "Invalid merge tool in preference setting!");
                 return false;
             }
 
@@ -54,14 +52,14 @@ namespace SourceGit.Commands
 
             if (!File.Exists(toolPath))
             {
-                Dispatcher.UIThread.Invoke(() => App.RaiseException(repo, $"Can NOT find external diff tool in '{toolPath}'!"));
+                App.RaiseException(repo, $"Can NOT find external diff tool in '{toolPath}'!");
                 return false;
             }
 
             var supported = Models.ExternalMerger.Supported.Find(x => x.Type == toolType);
             if (supported == null)
             {
-                Dispatcher.UIThread.Post(() => App.RaiseException(repo, "Invalid merge tool in preference setting!"));
+                App.RaiseException(repo, "Invalid merge tool in preference setting!");
                 return false;
             }
 

--- a/src/Commands/QueryLocalChanges.cs
+++ b/src/Commands/QueryLocalChanges.cs
@@ -2,8 +2,6 @@
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
 
-using Avalonia.Threading;
-
 namespace SourceGit.Commands
 {
     public partial class QueryLocalChanges : Command
@@ -25,7 +23,7 @@ namespace SourceGit.Commands
             var rs = ReadToEnd();
             if (!rs.IsSuccess)
             {
-                Dispatcher.UIThread.Post(() => App.RaiseException(Context, rs.StdErr));
+                App.RaiseException(Context, rs.StdErr);
                 return outs;
             }
 

--- a/src/Commands/SaveChangesAsPatch.cs
+++ b/src/Commands/SaveChangesAsPatch.cs
@@ -3,8 +3,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 
-using Avalonia.Threading;
-
 namespace SourceGit.Commands
 {
     public static class SaveChangesAsPatch
@@ -74,10 +72,7 @@ namespace SourceGit.Commands
             }
             catch (Exception e)
             {
-                Dispatcher.UIThread.Invoke(() =>
-                {
-                    App.RaiseException(repo, "Save change to patch failed: " + e.Message);
-                });
+                App.RaiseException(repo, "Save change to patch failed: " + e.Message);
                 return false;
             }
         }

--- a/src/Commands/SaveRevisionFile.cs
+++ b/src/Commands/SaveRevisionFile.cs
@@ -2,8 +2,6 @@
 using System.Diagnostics;
 using System.IO;
 
-using Avalonia.Threading;
-
 namespace SourceGit.Commands
 {
     public static class SaveRevisionFile
@@ -53,10 +51,7 @@ namespace SourceGit.Commands
                 }
                 catch (Exception e)
                 {
-                    Dispatcher.UIThread.Invoke(() =>
-                    {
-                        App.RaiseException(repo, "Save file failed: " + e.Message);
-                    });
+                    App.RaiseException(repo, "Save file failed: " + e.Message);
                 }
             }
         }

--- a/src/Commands/UnstageChangesForAmend.cs
+++ b/src/Commands/UnstageChangesForAmend.cs
@@ -3,8 +3,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Text;
 
-using Avalonia.Threading;
-
 namespace SourceGit.Commands
 {
     public class UnstageChangesForAmend
@@ -75,16 +73,13 @@ namespace SourceGit.Commands
                 proc.Close();
 
                 if (!rs)
-                    Dispatcher.UIThread.Invoke(() => App.RaiseException(_repo, err));
+                    App.RaiseException(_repo, err);
 
                 return rs;
             }
             catch (Exception e)
             {
-                Dispatcher.UIThread.Invoke(() =>
-                {
-                    App.RaiseException(_repo, "Failed to unstage changes: " + e.Message);
-                });
+                App.RaiseException(_repo, "Failed to unstage changes: " + e.Message);
                 return false;
             }
         }

--- a/src/ViewModels/ExecuteCustomAction.cs
+++ b/src/ViewModels/ExecuteCustomAction.cs
@@ -237,7 +237,7 @@ namespace SourceGit.ViewModels
             }
             catch (Exception e)
             {
-                CallUIThread(() => App.RaiseException(_repo.FullPath, e.Message));
+                App.RaiseException(_repo.FullPath, e.Message);
             }
         }
 
@@ -284,12 +284,12 @@ namespace SourceGit.ViewModels
                 {
                     var errMsg = builder.ToString().Trim();
                     if (!string.IsNullOrEmpty(errMsg))
-                        CallUIThread(() => App.RaiseException(_repo.FullPath, errMsg));
+                        App.RaiseException(_repo.FullPath, errMsg);
                 }
             }
             catch (Exception e)
             {
-                CallUIThread(() => App.RaiseException(_repo.FullPath, e.Message));
+                App.RaiseException(_repo.FullPath, e.Message);
             }
 
             proc.Close();

--- a/src/ViewModels/Launcher.cs
+++ b/src/ViewModels/Launcher.cs
@@ -4,6 +4,7 @@ using System.IO;
 using Avalonia.Collections;
 using Avalonia.Controls;
 using Avalonia.Input;
+using Avalonia.Threading;
 
 using CommunityToolkit.Mvvm.ComponentModel;
 
@@ -394,6 +395,12 @@ namespace SourceGit.ViewModels
 
         public void DispatchNotification(string pageId, string message, bool isError)
         {
+            if (!Dispatcher.UIThread.CheckAccess())
+            {
+                Dispatcher.UIThread.Invoke(() => DispatchNotification(pageId, message, isError));
+                return;
+            }
+
             var notification = new Models.Notification()
             {
                 IsError = isError,

--- a/src/ViewModels/RevisionCompare.cs
+++ b/src/ViewModels/RevisionCompare.cs
@@ -124,7 +124,7 @@ namespace SourceGit.ViewModels
             {
                 var succ = Commands.SaveChangesAsPatch.ProcessRevisionCompareChanges(_repo, _changes, GetSHA(_startPoint), GetSHA(_endPoint), saveTo);
                 if (succ)
-                    Dispatcher.UIThread.Invoke(() => App.SendNotification(_repo, App.Text("SaveAsPatchSuccess")));
+                    App.SendNotification(_repo, App.Text("SaveAsPatchSuccess"));
             });
         }
 


### PR DESCRIPTION
As part of my work on #1439 I'd like to remove any UI concerns from the `SourceGit.Commands` namespace.
I'm no Avalonia expert but it seems simple enough to detect the wrong thread in `Launcher` when processing notifications and dispatch to the UI thread as needed.
The only outstanding question is whether to use `UIThread.Post` or `UIThread.Invoke` as the existing code used a mixture of both.