### PR TITLE
enhance: respect git config `merge.ff`

### DIFF
--- a/src/Models/MergeMode.cs
+++ b/src/Models/MergeMode.cs
@@ -2,13 +2,28 @@
 {
     public class MergeMode
     {
+        public static readonly MergeMode Default =
+            new MergeMode("Default", "Fast-forward if possible", "");
+
+        public static readonly MergeMode FastForward =
+            new MergeMode("Fast-forward", "Refuse to merge when fast-forward is not possible", "--ff-only");
+
+        public static readonly MergeMode NoFastForward =
+            new MergeMode("No Fast-forward", "Always create a merge commit", "--no-ff");
+
+        public static readonly MergeMode Squash =
+            new MergeMode("Squash", "Squash merge", "--squash");
+
+        public static readonly MergeMode DontCommit
+            = new MergeMode("Don't commit", "Merge without commit", "--no-ff --no-commit");
+
         public static readonly MergeMode[] Supported =
         [
-            new MergeMode("Default", "Fast-forward if possible", ""),
-            new MergeMode("Fast-forward", "Refuse to merge when fast-forward is not possible", "--ff-only"),
-            new MergeMode("No Fast-forward", "Always create a merge commit", "--no-ff"),
-            new MergeMode("Squash", "Squash merge", "--squash"),
-            new MergeMode("Don't commit", "Merge without commit", "--no-ff --no-commit"),
+            Default,
+            FastForward,
+            NoFastForward,
+            Squash,
+            DontCommit,
         ];
 
         public string Name { get; set; }


### PR DESCRIPTION
This adds another configuration possibility for the default merge mode to the already existing per branch git configuration `branch.<name>.mergeoptions` (#540) and the per repo preference "Preferred Merge Mode" (#1156).

Defined values:
 - `false`: do no fast-forward merge
 - `only`: do only a fast-forward merge

This is configurable by for example `git config set --global merge.ff <value>` for a global (meaning the current user) configuration.

The priority between these configurations/preferences is:

 - git configuration `branch.<name>.mergeoptions` (#540)
 - git configuration `merge.ff`
 - preference "Preferred Merge Mode" (#1156)