### PR TITLE
refactor: move I/O operations out of constructors

### DIFF
--- a/src/Commands/Command.cs
+++ b/src/Commands/Command.cs
@@ -32,7 +32,7 @@ namespace SourceGit.Commands
         public bool RaiseError { get; set; } = true;
         public Models.ICommandLog Log { get; set; } = null;
 
-        public bool Exec()
+        public virtual bool Exec()
         {
             Log?.AppendLine($"$ git {Args}\n");
 

--- a/src/Commands/Fetch.cs
+++ b/src/Commands/Fetch.cs
@@ -6,7 +6,7 @@
         {
             WorkingDirectory = repo;
             Context = repo;
-            SSHKey = new Config(repo).Get($"remote.{remote}.sshkey");
+            _remote = remote;
             Args = "fetch --progress --verbose ";
 
             if (noTags)
@@ -24,8 +24,16 @@
         {
             WorkingDirectory = repo;
             Context = repo;
-            SSHKey = new Config(repo).Get($"remote.{remote.Remote}.sshkey");
+            _remote = remote.Remote;
             Args = $"fetch --progress --verbose {remote.Remote} {remote.Name}:{local.Name}";
         }
+
+        public override bool Exec()
+        {
+            SSHKey = new Config(Context).Get($"remote.{_remote}.sshkey");
+            return base.Exec();
+        }
+
+        private readonly string _remote;
     }
 }

--- a/src/Commands/Pull.cs
+++ b/src/Commands/Pull.cs
@@ -6,7 +6,7 @@
         {
             WorkingDirectory = repo;
             Context = repo;
-            SSHKey = new Config(repo).Get($"remote.{remote}.sshkey");
+            _remote = remote;
             Args = "pull --verbose --progress ";
 
             if (useRebase)
@@ -14,5 +14,13 @@
 
             Args += $"{remote} {branch}";
         }
+
+        public override bool Exec()
+        {
+            SSHKey = new Config(Context).Get($"remote.{_remote}.sshkey");
+            return base.Exec();
+        }
+
+        private readonly string _remote;
     }
 }

--- a/src/Commands/Push.cs
+++ b/src/Commands/Push.cs
@@ -6,7 +6,7 @@
         {
             WorkingDirectory = repo;
             Context = repo;
-            SSHKey = new Config(repo).Get($"remote.{remote}.sshkey");
+            _remote = remote;
             Args = "push --progress --verbose ";
 
             if (withTags)
@@ -25,7 +25,7 @@
         {
             WorkingDirectory = repo;
             Context = repo;
-            SSHKey = new Config(repo).Get($"remote.{remote}.sshkey");
+            _remote = remote;
             Args = "push ";
 
             if (isDelete)
@@ -33,5 +33,13 @@
 
             Args += $"{remote} {refname}";
         }
+
+        public override bool Exec()
+        {
+            SSHKey = new Config(Context).Get($"remote.{_remote}.sshkey");
+            return base.Exec();
+        }
+
+        private readonly string _remote;
     }
 }

--- a/src/ViewModels/AIAssistant.cs
+++ b/src/ViewModels/AIAssistant.cs
@@ -30,8 +30,6 @@ namespace SourceGit.ViewModels
             _changes = changes;
             _onApply = onApply;
             _cancel = new CancellationTokenSource();
-
-            Gen();
         }
 
         public void Regen()
@@ -52,7 +50,7 @@ namespace SourceGit.ViewModels
             _cancel?.Cancel();
         }
 
-        private void Gen()
+        public void Gen()
         {
             Text = string.Empty;
             IsGenerating = true;

--- a/src/ViewModels/AssumeUnchangedManager.cs
+++ b/src/ViewModels/AssumeUnchangedManager.cs
@@ -13,7 +13,10 @@ namespace SourceGit.ViewModels
         {
             _repo = repo;
             Files = new AvaloniaList<string>();
+        }
 
+        public void Load()
+        {
             Task.Run(() =>
             {
                 var collect = new Commands.QueryAssumeUnchangedFiles(_repo.FullPath).Result();

--- a/src/ViewModels/BranchCompare.cs
+++ b/src/ViewModels/BranchCompare.cs
@@ -80,8 +80,6 @@ namespace SourceGit.ViewModels
             _repo = repo;
             _based = baseBranch;
             _to = toBranch;
-
-            Refresh();
         }
 
         public void NavigateTo(string commitSHA)
@@ -176,7 +174,7 @@ namespace SourceGit.ViewModels
             return menu;
         }
 
-        private void Refresh()
+        public void Refresh()
         {
             Task.Run(() =>
             {

--- a/src/ViewModels/Clone.cs
+++ b/src/ViewModels/Clone.cs
@@ -67,7 +67,10 @@ namespace SourceGit.ViewModels
             _parentFolder = activeWorkspace?.DefaultCloneDir;
             if (string.IsNullOrEmpty(ParentFolder))
                 _parentFolder = Preferences.Instance.GitDefaultCloneDir;
+        }
 
+        public void Load()
+        {
             Task.Run(async () =>
             {
                 try

--- a/src/ViewModels/CreateTag.cs
+++ b/src/ViewModels/CreateTag.cs
@@ -51,7 +51,6 @@ namespace SourceGit.ViewModels
             _basedOn = branch.Head;
 
             BasedOn = branch;
-            SignTag = new Commands.Config(repo.FullPath).Get("tag.gpgsign").Equals("true", StringComparison.OrdinalIgnoreCase);
         }
 
         public CreateTag(Repository repo, Models.Commit commit)
@@ -60,7 +59,11 @@ namespace SourceGit.ViewModels
             _basedOn = commit.SHA;
 
             BasedOn = commit;
-            SignTag = new Commands.Config(repo.FullPath).Get("tag.gpgsign").Equals("true", StringComparison.OrdinalIgnoreCase);
+        }
+
+        public void Load()
+        {
+            SignTag = new Commands.Config(_repo.FullPath).Get("tag.gpgsign").Equals("true", StringComparison.OrdinalIgnoreCase);
         }
 
         public static ValidationResult ValidateTagName(string name, ValidationContext ctx)

--- a/src/ViewModels/EditRemote.cs
+++ b/src/ViewModels/EditRemote.cs
@@ -51,10 +51,13 @@ namespace SourceGit.ViewModels
             _name = remote.Name;
             _url = remote.URL;
             _useSSH = Models.Remote.IsSSH(remote.URL);
+        }
 
+        public void Load()
+        {
             if (_useSSH)
             {
-                SSHKey = new Commands.Config(repo.FullPath).Get($"remote.{remote.Name}.sshkey");
+                SSHKey = new Commands.Config(_repo.FullPath).Get($"remote.{_remote.Name}.sshkey");
             }
         }
 

--- a/src/ViewModels/InProgressContexts.cs
+++ b/src/ViewModels/InProgressContexts.cs
@@ -71,10 +71,16 @@ namespace SourceGit.ViewModels
             get => GetFriendlyNameOfCommit(Head);
         }
 
-        public CherryPickInProgress(Repository repo) : base(repo.FullPath, "cherry-pick")
+        public static CherryPickInProgress Create(Repository repo)
         {
+            var ipc = new CherryPickInProgress(repo);
             var headSHA = File.ReadAllText(Path.Combine(repo.GitDir, "CHERRY_PICK_HEAD")).Trim();
-            Head = new Commands.QuerySingleCommit(repo.FullPath, headSHA).Result() ?? new Models.Commit() { SHA = headSHA };
+            ipc.Head = new Commands.QuerySingleCommit(repo.FullPath, headSHA).Result() ?? new Models.Commit() { SHA = headSHA };
+            return ipc;
+        }
+
+        private CherryPickInProgress(Repository repo) : base(repo.FullPath, "cherry-pick")
+        {
         }
     }
 
@@ -103,24 +109,30 @@ namespace SourceGit.ViewModels
             private set;
         }
 
-        public RebaseInProgress(Repository repo) : base(repo.FullPath, "rebase")
+        public static RebaseInProgress Create(Repository repo)
         {
-            HeadName = File.ReadAllText(Path.Combine(repo.GitDir, "rebase-merge", "head-name")).Trim();
-            if (HeadName.StartsWith("refs/heads/"))
-                HeadName = HeadName.Substring(11);
-            else if (HeadName.StartsWith("refs/tags/"))
-                HeadName = HeadName.Substring(10);
+            var ipc = new RebaseInProgress(repo);
+            ipc.HeadName = File.ReadAllText(Path.Combine(repo.GitDir, "rebase-merge", "head-name")).Trim();
+            if (ipc.HeadName.StartsWith("refs/heads/"))
+                ipc.HeadName = ipc.HeadName.Substring(11);
+            else if (ipc.HeadName.StartsWith("refs/tags/"))
+                ipc.HeadName = ipc.HeadName.Substring(10);
 
             var stoppedSHAPath = Path.Combine(repo.GitDir, "rebase-merge", "stopped-sha");
             var stoppedSHA = File.Exists(stoppedSHAPath)
                 ? File.ReadAllText(stoppedSHAPath).Trim()
-                : new Commands.QueryRevisionByRefName(repo.FullPath, HeadName).Result();
+                : new Commands.QueryRevisionByRefName(repo.FullPath, ipc.HeadName).Result();
 
             if (!string.IsNullOrEmpty(stoppedSHA))
-                StoppedAt = new Commands.QuerySingleCommit(repo.FullPath, stoppedSHA).Result() ?? new Models.Commit() { SHA = stoppedSHA };
+                ipc.StoppedAt = new Commands.QuerySingleCommit(repo.FullPath, stoppedSHA).Result() ?? new Models.Commit() { SHA = stoppedSHA };
 
             var ontoSHA = File.ReadAllText(Path.Combine(repo.GitDir, "rebase-merge", "onto")).Trim();
-            Onto = new Commands.QuerySingleCommit(repo.FullPath, ontoSHA).Result() ?? new Models.Commit() { SHA = ontoSHA };
+            ipc.Onto = new Commands.QuerySingleCommit(repo.FullPath, ontoSHA).Result() ?? new Models.Commit() { SHA = ontoSHA };
+            return ipc;
+        }
+
+        private RebaseInProgress(Repository repo) : base(repo.FullPath, "rebase")
+        {
         }
 
         public override bool Continue()
@@ -143,10 +155,16 @@ namespace SourceGit.ViewModels
             private set;
         }
 
-        public RevertInProgress(Repository repo) : base(repo.FullPath, "revert")
+        public static RevertInProgress Create(Repository repo)
         {
+            var ipc = new RevertInProgress(repo);
             var headSHA = File.ReadAllText(Path.Combine(repo.GitDir, "REVERT_HEAD")).Trim();
-            Head = new Commands.QuerySingleCommit(repo.FullPath, headSHA).Result() ?? new Models.Commit() { SHA = headSHA };
+            ipc.Head = new Commands.QuerySingleCommit(repo.FullPath, headSHA).Result() ?? new Models.Commit() { SHA = headSHA };
+            return ipc;
+        }
+
+        private RevertInProgress(Repository repo) : base(repo.FullPath, "revert")
+        {
         }
     }
 
@@ -169,12 +187,18 @@ namespace SourceGit.ViewModels
             get => GetFriendlyNameOfCommit(Source);
         }
 
-        public MergeInProgress(Repository repo) : base(repo.FullPath, "merge")
+        public static MergeInProgress Create(Repository repo)
         {
-            Current = Commands.Branch.ShowCurrent(repo.FullPath);
+            var ipc = new MergeInProgress(repo);
+            ipc.Current = Commands.Branch.ShowCurrent(repo.FullPath);
 
             var sourceSHA = File.ReadAllText(Path.Combine(repo.GitDir, "MERGE_HEAD")).Trim();
-            Source = new Commands.QuerySingleCommit(repo.FullPath, sourceSHA).Result() ?? new Models.Commit() { SHA = sourceSHA };
+            ipc.Source = new Commands.QuerySingleCommit(repo.FullPath, sourceSHA).Result() ?? new Models.Commit() { SHA = sourceSHA };
+            return ipc;
+        }
+
+        private MergeInProgress(Repository repo) : base(repo.FullPath, "merge")
+        {
         }
 
         public override bool Skip()

--- a/src/ViewModels/InteractiveRebase.cs
+++ b/src/ViewModels/InteractiveRebase.cs
@@ -123,17 +123,19 @@ namespace SourceGit.ViewModels
 
         public InteractiveRebase(Repository repo, Models.Branch current, Models.Commit on)
         {
-            var repoPath = repo.FullPath;
             _repo = repo;
 
             Current = current;
             On = on;
             IsLoading = true;
             DetailContext = new CommitDetail(repo, false);
+        }
 
+        public void Load()
+        {
             Task.Run(() =>
             {
-                var commits = new Commands.QueryCommitsForInteractiveRebase(repoPath, on.SHA).Result();
+                var commits = new Commands.QueryCommitsForInteractiveRebase(_repo.FullPath, On.SHA).Result();
                 var list = new List<InteractiveRebaseItem>();
 
                 for (var i = 0; i < commits.Count; i++)

--- a/src/ViewModels/LFSLocks.cs
+++ b/src/ViewModels/LFSLocks.cs
@@ -41,7 +41,11 @@ namespace SourceGit.ViewModels
         {
             _repo = repo;
             _remote = remote;
-            _userName = new Commands.Config(repo.FullPath).Get("user.name");
+        }
+
+        public void Load()
+        {
+            _userName = new Commands.Config(_repo.FullPath).Get("user.name");
 
             HasValidUserName = !string.IsNullOrEmpty(_userName);
 

--- a/src/ViewModels/Launcher.cs
+++ b/src/ViewModels/Launcher.cs
@@ -53,13 +53,18 @@ namespace SourceGit.ViewModels
 
         public Launcher(string startupRepo)
         {
+            _startupRepo = startupRepo;
             _ignoreIndexChange = true;
 
             Pages = new AvaloniaList<LauncherPage>();
+        }
+
+        public void Load()
+        {
             AddNewTab();
 
             var pref = Preferences.Instance;
-            if (string.IsNullOrEmpty(startupRepo))
+            if (string.IsNullOrEmpty(_startupRepo))
             {
                 ActiveWorkspace = pref.GetActiveWorkspace();
 
@@ -96,13 +101,13 @@ namespace SourceGit.ViewModels
                 foreach (var w in pref.Workspaces)
                     w.IsActive = false;
 
-                var test = new Commands.QueryRepositoryRootPath(startupRepo).ReadToEnd();
+                var test = new Commands.QueryRepositoryRootPath(_startupRepo).ReadToEnd();
                 if (!test.IsSuccess || string.IsNullOrEmpty(test.StdOut))
                 {
                     Pages[0].Notifications.Add(new Models.Notification
                     {
                         IsError = true,
-                        Message = $"Given path: '{startupRepo}' is NOT a valid repository!"
+                        Message = $"Given path: '{_startupRepo}' is NOT a valid repository!"
                     });
                 }
                 else
@@ -607,6 +612,7 @@ namespace SourceGit.ViewModels
             }
         }
 
+        private readonly string _startupRepo;
         private Workspace _activeWorkspace = null;
         private LauncherPage _activePage = null;
         private bool _ignoreIndexChange = false;

--- a/src/ViewModels/Merge.cs
+++ b/src/ViewModels/Merge.cs
@@ -33,7 +33,9 @@ namespace SourceGit.ViewModels
 
             Source = source;
             Into = into;
-            Mode = forceFastForward ? Models.MergeMode.FastForward : AutoSelectMergeMode();
+
+            if (forceFastForward)
+                Mode = Models.MergeMode.FastForward;
         }
 
         public Merge(Repository repo, Models.Commit source, string into)
@@ -43,7 +45,6 @@ namespace SourceGit.ViewModels
 
             Source = source;
             Into = into;
-            Mode = AutoSelectMergeMode();
         }
 
         public Merge(Repository repo, Models.Tag source, string into)
@@ -53,7 +54,12 @@ namespace SourceGit.ViewModels
 
             Source = source;
             Into = into;
-            Mode = AutoSelectMergeMode();
+        }
+
+        public void Load()
+        {
+            if (Mode == null)
+                Mode = AutoSelectMergeMode();
         }
 
         public override Task<bool> Sure()

--- a/src/ViewModels/RepositoryConfigure.cs
+++ b/src/ViewModels/RepositoryConfigure.cs
@@ -158,8 +158,11 @@ namespace SourceGit.ViewModels
 
             if (!AvailableOpenAIServices.Contains(PreferredOpenAIService))
                 PreferredOpenAIService = "---";
+        }
 
-            _cached = new Commands.Config(repo.FullPath).ListAll();
+        public void Load()
+        {
+            _cached = new Commands.Config(_repo.FullPath).ListAll();
             if (_cached.TryGetValue("user.name", out var name))
                 UserName = name;
             if (_cached.TryGetValue("user.email", out var email))
@@ -346,7 +349,7 @@ namespace SourceGit.ViewModels
         }
 
         private readonly Repository _repo = null;
-        private readonly Dictionary<string, string> _cached = null;
+        private Dictionary<string, string> _cached = null;
         private string _httpProxy;
         private Models.CommitTemplate _selectedCommitTemplate = null;
         private Models.IssueTrackerRule _selectedIssueTrackerRule = null;

--- a/src/ViewModels/RevisionCompare.cs
+++ b/src/ViewModels/RevisionCompare.cs
@@ -76,8 +76,6 @@ namespace SourceGit.ViewModels
             _startPoint = (object)startPoint ?? new Models.Null();
             _endPoint = (object)endPoint ?? new Models.Null();
             CanSaveAsPatch = startPoint != null && endPoint != null;
-
-            Task.Run(Refresh);
         }
 
         public void Dispose()
@@ -212,7 +210,7 @@ namespace SourceGit.ViewModels
             }
         }
 
-        private void Refresh()
+        public void Refresh()
         {
             _changes = new Commands.CompareRevisions(_repo, GetSHA(_startPoint), GetSHA(_endPoint)).Result();
 

--- a/src/ViewModels/Reword.cs
+++ b/src/ViewModels/Reword.cs
@@ -21,9 +21,13 @@ namespace SourceGit.ViewModels
         public Reword(Repository repo, Models.Commit head)
         {
             _repo = repo;
-            _oldMessage = new Commands.QueryCommitFullMessage(_repo.FullPath, head.SHA).Result();
-            _message = _oldMessage;
             Head = head;
+        }
+
+        public void Load()
+        {
+            _oldMessage = new Commands.QueryCommitFullMessage(_repo.FullPath, Head.SHA).Result();
+            _message = _oldMessage;
         }
 
         public override Task<bool> Sure()
@@ -49,7 +53,7 @@ namespace SourceGit.ViewModels
         }
 
         private readonly Repository _repo;
-        private readonly string _oldMessage;
+        private string _oldMessage;
         private string _message;
     }
 }

--- a/src/ViewModels/Squash.cs
+++ b/src/ViewModels/Squash.cs
@@ -20,8 +20,13 @@ namespace SourceGit.ViewModels
         public Squash(Repository repo, Models.Commit target, string shaToGetPreferMessage)
         {
             _repo = repo;
-            _message = new Commands.QueryCommitFullMessage(_repo.FullPath, shaToGetPreferMessage).Result();
             Target = target;
+            _shaToGetPreferMessage = shaToGetPreferMessage;
+        }
+
+        public void Load()
+        {
+            _message = new Commands.QueryCommitFullMessage(_repo.FullPath, _shaToGetPreferMessage).Result();
         }
 
         public override Task<bool> Sure()
@@ -66,5 +71,6 @@ namespace SourceGit.ViewModels
 
         private readonly Repository _repo;
         private string _message;
+        private readonly string _shaToGetPreferMessage;
     }
 }

--- a/src/ViewModels/Statistics.cs
+++ b/src/ViewModels/Statistics.cs
@@ -56,9 +56,14 @@ namespace SourceGit.ViewModels
 
         public Statistics(string repo)
         {
+            _repo = repo;
+        }
+
+        public void Load()
+        {
             Task.Run(() =>
             {
-                var result = new Commands.Statistics(repo, Preferences.Instance.MaxHistoryCommits).Result();
+                var result = new Commands.Statistics(_repo, Preferences.Instance.MaxHistoryCommits).Result();
                 Dispatcher.UIThread.Invoke(() =>
                 {
                     _data = result;
@@ -84,6 +89,7 @@ namespace SourceGit.ViewModels
             SelectedReport = report;
         }
 
+        private readonly string _repo;
         private bool _isLoading = true;
         private Models.Statistics _data = null;
         private Models.StatisticsReport _selectedReport = null;

--- a/src/ViewModels/WorkingCopy.cs
+++ b/src/ViewModels/WorkingCopy.cs
@@ -1746,11 +1746,11 @@ namespace SourceGit.ViewModels
 
             if (File.Exists(Path.Combine(_repo.GitDir, "CHERRY_PICK_HEAD")))
             {
-                InProgressContext = new CherryPickInProgress(_repo);
+                InProgressContext = CherryPickInProgress.Create(_repo);
             }
             else if (Directory.Exists(Path.Combine(_repo.GitDir, "rebase-merge")) || Directory.Exists(Path.Combine(_repo.GitDir, "rebase-apply")))
             {
-                var rebasing = new RebaseInProgress(_repo);
+                var rebasing = RebaseInProgress.Create(_repo);
                 InProgressContext = rebasing;
 
                 if (string.IsNullOrEmpty(_commitMessage))
@@ -1764,11 +1764,11 @@ namespace SourceGit.ViewModels
             }
             else if (File.Exists(Path.Combine(_repo.GitDir, "REVERT_HEAD")))
             {
-                InProgressContext = new RevertInProgress(_repo);
+                InProgressContext = RevertInProgress.Create(_repo);
             }
             else if (File.Exists(Path.Combine(_repo.GitDir, "MERGE_HEAD")))
             {
-                InProgressContext = new MergeInProgress(_repo);
+                InProgressContext = MergeInProgress.Create(_repo);
             }
             else
             {

--- a/src/Views/AIAssistant.axaml.cs
+++ b/src/Views/AIAssistant.axaml.cs
@@ -118,6 +118,13 @@ namespace SourceGit.Views
             InitializeComponent();
         }
 
+        protected override void OnLoaded(RoutedEventArgs e)
+        {
+            base.OnLoaded(e);
+            if (DataContext is ViewModels.AIAssistant vm)
+                vm.Gen();
+        }
+
         protected override void OnClosing(WindowClosingEventArgs e)
         {
             base.OnClosing(e);

--- a/src/Views/AssumeUnchangedManager.axaml.cs
+++ b/src/Views/AssumeUnchangedManager.axaml.cs
@@ -10,6 +10,13 @@ namespace SourceGit.Views
             InitializeComponent();
         }
 
+        protected override void OnLoaded(RoutedEventArgs e)
+        {
+            base.OnLoaded(e);
+            if (DataContext is ViewModels.AssumeUnchangedManager vm)
+                vm.Load();
+        }
+
         private void OnRemoveButtonClicked(object sender, RoutedEventArgs e)
         {
             if (DataContext is ViewModels.AssumeUnchangedManager vm && sender is Button button)

--- a/src/Views/BranchCompare.axaml.cs
+++ b/src/Views/BranchCompare.axaml.cs
@@ -1,5 +1,6 @@
 using Avalonia.Controls;
 using Avalonia.Input;
+using Avalonia.Interactivity;
 
 namespace SourceGit.Views
 {
@@ -8,6 +9,13 @@ namespace SourceGit.Views
         public BranchCompare()
         {
             InitializeComponent();
+        }
+
+        protected override void OnLoaded(RoutedEventArgs e)
+        {
+            base.OnLoaded(e);
+            if (DataContext is ViewModels.BranchCompare vm)
+                vm.Refresh();
         }
 
         private void OnChangeContextRequested(object sender, ContextRequestedEventArgs e)

--- a/src/Views/Clone.axaml.cs
+++ b/src/Views/Clone.axaml.cs
@@ -12,6 +12,13 @@ namespace SourceGit.Views
             InitializeComponent();
         }
 
+        protected override void OnLoaded(RoutedEventArgs e)
+        {
+            base.OnLoaded(e);
+            if (DataContext is ViewModels.Clone vm)
+                vm.Load();
+        }
+
         private async void SelectParentFolder(object _, RoutedEventArgs e)
         {
             var options = new FolderPickerOpenOptions() { AllowMultiple = false };

--- a/src/Views/Conflict.axaml.cs
+++ b/src/Views/Conflict.axaml.cs
@@ -1,5 +1,6 @@
 using Avalonia.Controls;
 using Avalonia.Input;
+using Avalonia.Interactivity;
 using Avalonia.VisualTree;
 
 namespace SourceGit.Views
@@ -9,6 +10,13 @@ namespace SourceGit.Views
         public Conflict()
         {
             InitializeComponent();
+        }
+
+        protected override void OnLoaded(RoutedEventArgs e)
+        {
+            base.OnLoaded(e);
+            if (DataContext is ViewModels.Conflict vm)
+                vm.Load();
         }
 
         private void OnPressedSHA(object sender, PointerPressedEventArgs e)

--- a/src/Views/CreateTag.axaml.cs
+++ b/src/Views/CreateTag.axaml.cs
@@ -1,4 +1,5 @@
 using Avalonia.Controls;
+using Avalonia.Interactivity;
 
 namespace SourceGit.Views
 {
@@ -7,6 +8,13 @@ namespace SourceGit.Views
         public CreateTag()
         {
             InitializeComponent();
+        }
+
+        protected override void OnLoaded(RoutedEventArgs e)
+        {
+            base.OnLoaded(e);
+            if (DataContext is ViewModels.CreateTag vm)
+                vm.Load();
         }
     }
 }

--- a/src/Views/EditRemote.axaml.cs
+++ b/src/Views/EditRemote.axaml.cs
@@ -11,6 +11,13 @@ namespace SourceGit.Views
             InitializeComponent();
         }
 
+        protected override void OnLoaded(RoutedEventArgs e)
+        {
+            base.OnLoaded(e);
+            if (DataContext is ViewModels.EditRemote vm)
+                vm.Load();
+        }
+
         private async void SelectSSHKey(object _, RoutedEventArgs e)
         {
             var toplevel = TopLevel.GetTopLevel(this);

--- a/src/Views/FileHistories.axaml.cs
+++ b/src/Views/FileHistories.axaml.cs
@@ -14,6 +14,13 @@ namespace SourceGit.Views
             InitializeComponent();
         }
 
+        protected override void OnLoaded(RoutedEventArgs e)
+        {
+            base.OnLoaded(e);
+            if (DataContext is ViewModels.FileHistories vm)
+                vm.Load();
+        }
+
         private void OnPressCommitSHA(object sender, PointerPressedEventArgs e)
         {
             if (sender is TextBlock { DataContext: Models.Commit commit } &&

--- a/src/Views/InteractiveRebase.axaml.cs
+++ b/src/Views/InteractiveRebase.axaml.cs
@@ -10,6 +10,13 @@ namespace SourceGit.Views
     {
         protected override Type StyleKeyOverride => typeof(ListBox);
 
+        protected override void OnLoaded(RoutedEventArgs e)
+        {
+            base.OnLoaded(e);
+            if (DataContext is ViewModels.InteractiveRebase vm)
+                vm.Load();
+        }
+
         /// <summary>
         ///     Prevent ListBox handle the arrow keys.
         /// </summary>
@@ -69,6 +76,13 @@ namespace SourceGit.Views
         public InteractiveRebase()
         {
             InitializeComponent();
+        }
+
+        protected override void OnLoaded(RoutedEventArgs e)
+        {
+            base.OnLoaded(e);
+            if (DataContext is ViewModels.InteractiveRebase vm)
+                vm.Load();
         }
 
         private void CloseWindow(object _1, RoutedEventArgs _2)

--- a/src/Views/LFSLocks.axaml.cs
+++ b/src/Views/LFSLocks.axaml.cs
@@ -10,6 +10,13 @@ namespace SourceGit.Views
             InitializeComponent();
         }
 
+        protected override void OnLoaded(RoutedEventArgs e)
+        {
+            base.OnLoaded(e);
+            if (DataContext is ViewModels.AssumeUnchangedManager vm)
+                vm.Load();
+        }
+
         private void OnUnlockButtonClicked(object sender, RoutedEventArgs e)
         {
             if (DataContext is ViewModels.LFSLocks vm && sender is Button button)

--- a/src/Views/Launcher.axaml.cs
+++ b/src/Views/Launcher.axaml.cs
@@ -85,6 +85,13 @@ namespace SourceGit.Views
             WindowStartupLocation = WindowStartupLocation.CenterScreen;
         }
 
+        protected override void OnLoaded(RoutedEventArgs e)
+        {
+            base.OnLoaded(e);
+            if (DataContext is ViewModels.Launcher vm)
+                vm.Load();
+        }
+
         public void BringToTop()
         {
             if (WindowState == WindowState.Minimized)

--- a/src/Views/Merge.axaml.cs
+++ b/src/Views/Merge.axaml.cs
@@ -1,4 +1,5 @@
 using Avalonia.Controls;
+using Avalonia.Interactivity;
 
 namespace SourceGit.Views
 {
@@ -7,6 +8,13 @@ namespace SourceGit.Views
         public Merge()
         {
             InitializeComponent();
+        }
+
+        protected override void OnLoaded(RoutedEventArgs e)
+        {
+            base.OnLoaded(e);
+            if (DataContext is ViewModels.Merge vm)
+                vm.Load();
         }
     }
 }

--- a/src/Views/RepositoryConfigure.axaml.cs
+++ b/src/Views/RepositoryConfigure.axaml.cs
@@ -12,6 +12,13 @@ namespace SourceGit.Views
             InitializeComponent();
         }
 
+        protected override void OnLoaded(RoutedEventArgs e)
+        {
+            base.OnLoaded(e);
+            if (DataContext is ViewModels.RepositoryConfigure vm)
+                vm.Load();
+        }
+
         protected override void OnKeyDown(KeyEventArgs e)
         {
             base.OnKeyDown(e);

--- a/src/Views/RevisionCompare.axaml.cs
+++ b/src/Views/RevisionCompare.axaml.cs
@@ -12,6 +12,13 @@ namespace SourceGit.Views
             InitializeComponent();
         }
 
+        protected override void OnLoaded(RoutedEventArgs e)
+        {
+            base.OnLoaded(e);
+            if (DataContext is ViewModels.RevisionCompare vm)
+                vm.Refresh();
+        }
+
         private void OnChangeContextRequested(object sender, ContextRequestedEventArgs e)
         {
             if (DataContext is ViewModels.RevisionCompare vm && sender is ChangeCollectionView view)

--- a/src/Views/Reword.axaml.cs
+++ b/src/Views/Reword.axaml.cs
@@ -1,4 +1,5 @@
 using Avalonia.Controls;
+using Avalonia.Interactivity;
 
 namespace SourceGit.Views
 {
@@ -7,6 +8,13 @@ namespace SourceGit.Views
         public Reword()
         {
             InitializeComponent();
+        }
+
+        protected override void OnLoaded(RoutedEventArgs e)
+        {
+            base.OnLoaded(e);
+            if (DataContext is ViewModels.Reword vm)
+                vm.Load();
         }
     }
 }

--- a/src/Views/Squash.axaml.cs
+++ b/src/Views/Squash.axaml.cs
@@ -1,4 +1,5 @@
 using Avalonia.Controls;
+using Avalonia.Interactivity;
 
 namespace SourceGit.Views
 {
@@ -7,6 +8,13 @@ namespace SourceGit.Views
         public Squash()
         {
             InitializeComponent();
+        }
+
+        protected override void OnLoaded(RoutedEventArgs e)
+        {
+            base.OnLoaded(e);
+            if (DataContext is ViewModels.Squash vm)
+                vm.Load();
         }
     }
 }

--- a/src/Views/Statistics.axaml.cs
+++ b/src/Views/Statistics.axaml.cs
@@ -1,3 +1,5 @@
+using Avalonia.Interactivity;
+
 namespace SourceGit.Views
 {
     public partial class Statistics : ChromelessWindow
@@ -5,6 +7,13 @@ namespace SourceGit.Views
         public Statistics()
         {
             InitializeComponent();
+        }
+
+        protected override void OnLoaded(RoutedEventArgs e)
+        {
+            base.OnLoaded(e);
+            if (DataContext is ViewModels.Statistics vm)
+                vm.Load();
         }
     }
 }


### PR DESCRIPTION
This is important because constructors cannot be made async. This PR moves I/O operations into static `Create` factory methods or instance `Load` methods that are called from `OnLoaded` view events.