### PR TITLE
fix: `merge.ff` is ignored

### DIFF
--- a/src/ViewModels/Merge.cs
+++ b/src/ViewModels/Merge.cs
@@ -85,17 +85,17 @@ namespace SourceGit.ViewModels
             return
                 GetGitConfigBranchMergeOptions() // Branch
                 ?? GetSettingsPreferredMergeMode() // Repository
-                ?? GetGitConfigMergeFF(); // Global
+                ?? GetGitConfigMergeFF() // Global
+                ?? Models.MergeMode.Default; // Fallback
         }
 
         private Models.MergeMode GetSettingsPreferredMergeMode()
         {
             var preferredMergeModeIdx = _repo.Settings.PreferredMergeMode;
             if (preferredMergeModeIdx < 0 || preferredMergeModeIdx > Models.MergeMode.Supported.Length)
-                preferredMergeModeIdx = 0;
+                return Models.MergeMode.Supported[preferredMergeModeIdx];
 
-            var defaultMergeMode = Models.MergeMode.Supported[preferredMergeModeIdx];
-            return defaultMergeMode;
+            return Models.MergeMode.Default;
         }
 
         private Models.MergeMode GetGitConfigMergeFF()


### PR DESCRIPTION
After changing the priority of the preferences/configurations for the merge mode in #1495, the git configuration `merge.ff` was ignored.  The reason is, that `GetSettingsPreferredMergeMode()` does not return `null` in the default case.  This is now fixed.