### PR TITLE
fix: do NOT reuse CommitDetail across commit

### DIFF
--- a/src/ViewModels/Histories.cs
+++ b/src/ViewModels/Histories.cs
@@ -150,16 +150,9 @@ namespace SourceGit.ViewModels
 
             if (commit != null)
             {
-                if (_detailContext is CommitDetail detail)
-                {
-                    detail.Commit = commit;
-                }
-                else
-                {
-                    var commitDetail = new CommitDetail(_repo, true);
-                    commitDetail.Commit = commit;
-                    DetailContext = commitDetail;
-                }
+                var commitDetail = new CommitDetail(_repo, true);
+                commitDetail.Commit = commit;
+                DetailContext = commitDetail;
             }
             else
             {
@@ -183,16 +176,9 @@ namespace SourceGit.ViewModels
                 AutoSelectedCommit = commit;
                 NavigationId = _navigationId + 1;
 
-                if (_detailContext is CommitDetail detail)
-                {
-                    detail.Commit = commit;
-                }
-                else
-                {
-                    var commitDetail = new CommitDetail(_repo, true);
-                    commitDetail.Commit = commit;
-                    DetailContext = commitDetail;
-                }
+                var commitDetail = new CommitDetail(_repo, true);
+                commitDetail.Commit = commit;
+                DetailContext = commitDetail;
             }
             else if (commits.Count == 2)
             {


### PR DESCRIPTION
CommitDetail reuse may cause CommitDetail being updated by other Repository tab



https://github.com/user-attachments/assets/2080f786-7900-4385-b129-c6b71e825e93