### PR TITLE
enhance: close all windows with `ESC`

### DIFF
--- a/src/Views/ChromelessWindow.cs
+++ b/src/Views/ChromelessWindow.cs
@@ -73,5 +73,13 @@ namespace SourceGit.Views
             if (sender is Border { Tag: WindowEdge edge } && CanResize)
                 BeginResizeDrag(edge, e);
         }
+
+        protected override void OnKeyDown(KeyEventArgs e)
+        {
+            base.OnKeyDown(e);
+
+            if (e is { Handled: false, Key: Key.Escape })
+                Close();
+        }
     }
 }

--- a/src/Views/Hotkeys.axaml.cs
+++ b/src/Views/Hotkeys.axaml.cs
@@ -1,5 +1,3 @@
-using Avalonia.Input;
-
 namespace SourceGit.Views
 {
     public partial class Hotkeys : ChromelessWindow
@@ -7,14 +5,6 @@ namespace SourceGit.Views
         public Hotkeys()
         {
             InitializeComponent();
-        }
-
-        protected override void OnKeyDown(KeyEventArgs e)
-        {
-            base.OnKeyDown(e);
-
-            if (!e.Handled && e.Key == Key.Escape)
-                Close();
         }
     }
 }

--- a/src/Views/RepositoryConfigure.axaml.cs
+++ b/src/Views/RepositoryConfigure.axaml.cs
@@ -12,14 +12,6 @@ namespace SourceGit.Views
             InitializeComponent();
         }
 
-        protected override void OnKeyDown(KeyEventArgs e)
-        {
-            base.OnKeyDown(e);
-
-            if (!e.Handled && e.Key == Key.Escape)
-                Close();
-        }
-
         protected override async void OnClosing(WindowClosingEventArgs e)
         {
             base.OnClosing(e);


### PR DESCRIPTION
My muscle memory expects dialogs to be easily dismissed with `ESC`, so it's quite jarring when it doesn't work.
This PR ensures all chromeless windows close when escape is pressed.