### PR TITLE
refactor: remove anonymous function in `ShowWindow`

### DIFF
--- a/src/App.axaml.cs
+++ b/src/App.axaml.cs
@@ -108,24 +108,9 @@ namespace SourceGit
         #region Utility Functions
         public static void ShowWindow(object data, bool showAsDialog)
         {
-            var impl = (Views.ChromelessWindow target, bool isDialog) =>
-            {
-                if (Current?.ApplicationLifetime is IClassicDesktopStyleApplicationLifetime { MainWindow: { } owner })
-                {
-                    if (isDialog)
-                        target.ShowDialog(owner);
-                    else
-                        target.Show(owner);
-                }
-                else
-                {
-                    target.Show();
-                }
-            };
-
             if (data is Views.ChromelessWindow window)
             {
-                impl(window, showAsDialog);
+                Show(window, showAsDialog);
                 return;
             }
 
@@ -142,7 +127,22 @@ namespace SourceGit
             if (window != null)
             {
                 window.DataContext = data;
-                impl(window, showAsDialog);
+                Show(window, showAsDialog);
+            }
+        }
+
+        private static void Show(Views.ChromelessWindow target, bool showAsDialog)
+        {
+            if (Current?.ApplicationLifetime is IClassicDesktopStyleApplicationLifetime { MainWindow: { } owner })
+            {
+                if (showAsDialog)
+                    target.ShowDialog(owner);
+                else
+                    target.Show(owner);
+            }
+            else
+            {
+                target.Show();
             }
         }
 


### PR DESCRIPTION
Just a suggestion, but I find nested anonymous functions a little hard to read. This PR moves the one an only instance of this in `ShowWindow` to a private method. There are no closures, so a straightforward change.