### PR TITLE
add click version to open release page

### DIFF
--- a/src/Views/About.axaml
+++ b/src/Views/About.axaml
@@ -45,7 +45,9 @@
       <StackPanel Grid.Column="1" Orientation="Vertical" VerticalAlignment="Center">
         <StackPanel Height="40" Orientation="Horizontal">
           <TextBlock Classes="bold" Text="SourceGit" FontSize="32" />
-          <Border Margin="12,0,0,0" Height="20" CornerRadius="10" Background="{DynamicResource Brush.Accent}" Effect="drop-shadow(0 0 6 #40000000)">
+          <Border Margin="12,0,0,0" Height="20" CornerRadius="10" Background="{DynamicResource Brush.Accent}" Effect="drop-shadow(0 0 6 #40000000)"
+                  Cursor="Hand"
+                  PointerPressed="OnVisitGithubRelease">
             <TextBlock x:Name="TxtVersion" Classes="primary" Margin="8,0" FontSize="12" Foreground="White"/>
           </Border>
         </StackPanel>

--- a/src/Views/About.axaml.cs
+++ b/src/Views/About.axaml.cs
@@ -20,6 +20,12 @@ namespace SourceGit.Views
                 TxtCopyright.Text = copyright.Copyright;
         }
 
+        private void OnVisitGithubRelease(object _, RoutedEventArgs e)
+        {
+            Native.OS.OpenBrowser($"https://github.com/sourcegit-scm/sourcegit/releases/tag/v{TxtVersion.Text}");
+            e.Handled = true;
+        }
+
         private void OnVisitWebsite(object _, RoutedEventArgs e)
         {
             Native.OS.OpenBrowser("https://sourcegit-scm.github.io/");


### PR DESCRIPTION
- Add clickable version badge with GitHub release link in About view.
- Add GitHub version release link handler to open browser with specific release tag.