### PR TITLE
fix: deadlock on ctrl+N

### DIFF
--- a/src/ViewModels/Clone.cs
+++ b/src/ViewModels/Clone.cs
@@ -66,16 +66,19 @@ namespace SourceGit.ViewModels
             if (string.IsNullOrEmpty(ParentFolder))
                 _parentFolder = Preferences.Instance.GitDefaultCloneDir;
 
-            try
+            Task.Run(async () =>
             {
-                var text = App.GetClipboardTextAsync().Result;
-                if (Models.Remote.IsValidURL(text))
-                    Remote = text;
-            }
-            catch
-            {
-                // Ignore
-            }
+                try
+                {
+                    var text = await App.GetClipboardTextAsync();
+                    if (Models.Remote.IsValidURL(text))
+                        Remote = text;
+                }
+                catch
+                {
+                    // Ignore
+                }
+            });
         }
 
         public static ValidationResult ValidateRemote(string remote, ValidationContext _)


### PR DESCRIPTION
Discovered a deadlock on `ctrl+N`. Have to be very careful calling `Task.Result` or `Task.Wait()`, especially in constructors.