### PR TITLE
ux: show a few more shortcuts on menu items

### DIFF
--- a/src/ViewModels/Histories.cs
+++ b/src/ViewModels/Histories.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Text;
 
 using Avalonia.Controls;
+using Avalonia.Input;
 using Avalonia.Platform.Storage;
 
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -428,6 +429,7 @@ namespace SourceGit.ViewModels
                 var copyMultipleInfo = new MenuItem();
                 copyMultipleInfo.Header = App.Text("CommitCM.CopySHA") + " - " + App.Text("CommitCM.CopySubject");
                 copyMultipleInfo.Icon = App.CreateMenuIcon("Icons.Info");
+                copyMultipleInfo.InputGesture = new KeyGesture(Key.C, OperatingSystem.IsMacOS() ? KeyModifiers.Meta : KeyModifiers.Control);
                 copyMultipleInfo.Click += async (_, e) =>
                 {
                     var builder = new StringBuilder();
@@ -724,6 +726,7 @@ namespace SourceGit.ViewModels
             var createBranch = new MenuItem();
             createBranch.Icon = App.CreateMenuIcon("Icons.Branch.Add");
             createBranch.Header = App.Text("CreateBranch");
+            createBranch.InputGesture = new KeyGesture(Key.B, OperatingSystem.IsMacOS() ? KeyModifiers.Meta : KeyModifiers.Control);
             createBranch.Click += (_, e) =>
             {
                 if (_repo.CanCreatePopup())
@@ -839,6 +842,7 @@ namespace SourceGit.ViewModels
             var copyInfo = new MenuItem();
             copyInfo.Header = App.Text("CommitCM.CopySHA") + " - " + App.Text("CommitCM.CopySubject");
             copyInfo.Icon = App.CreateMenuIcon("Icons.Info");
+            copyInfo.InputGesture = new KeyGesture(Key.C, OperatingSystem.IsMacOS() ? KeyModifiers.Meta : KeyModifiers.Control);
             copyInfo.Click += async (_, e) =>
             {
                 await App.CopyTextAsync($"{commit.SHA.AsSpan(0, 10)} - {commit.Subject}");

--- a/src/ViewModels/WorkingCopy.cs
+++ b/src/ViewModels/WorkingCopy.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Threading.Tasks;
 
 using Avalonia.Controls;
+using Avalonia.Input;
 using Avalonia.Platform.Storage;
 using Avalonia.Threading;
 
@@ -676,6 +677,7 @@ namespace SourceGit.ViewModels
                     var stage = new MenuItem();
                     stage.Header = App.Text("FileCM.Stage");
                     stage.Icon = App.CreateMenuIcon("Icons.File.Add");
+                    stage.InputGesture = new KeyGesture(Key.Enter);
                     stage.Click += (_, e) =>
                     {
                         StageChanges(_selectedUnstaged, null);
@@ -685,6 +687,7 @@ namespace SourceGit.ViewModels
                     var discard = new MenuItem();
                     discard.Header = App.Text("FileCM.Discard");
                     discard.Icon = App.CreateMenuIcon("Icons.Undo");
+                    discard.InputGesture = new KeyGesture(Key.Delete);
                     discard.Click += (_, e) =>
                     {
                         Discard(_selectedUnstaged);
@@ -1079,6 +1082,7 @@ namespace SourceGit.ViewModels
                 var stage = new MenuItem();
                 stage.Header = App.Text("FileCM.StageMulti", _selectedUnstaged.Count);
                 stage.Icon = App.CreateMenuIcon("Icons.File.Add");
+                stage.InputGesture = new KeyGesture(Key.Enter);
                 stage.Click += (_, e) =>
                 {
                     StageChanges(_selectedUnstaged, null);
@@ -1088,6 +1092,7 @@ namespace SourceGit.ViewModels
                 var discard = new MenuItem();
                 discard.Header = App.Text("FileCM.DiscardMulti", _selectedUnstaged.Count);
                 discard.Icon = App.CreateMenuIcon("Icons.Undo");
+                discard.InputGesture = new KeyGesture(Key.Delete);
                 discard.Click += (_, e) =>
                 {
                     Discard(_selectedUnstaged);
@@ -1263,6 +1268,7 @@ namespace SourceGit.ViewModels
                 var unstage = new MenuItem();
                 unstage.Header = App.Text("FileCM.Unstage");
                 unstage.Icon = App.CreateMenuIcon("Icons.File.Remove");
+                unstage.InputGesture = new KeyGesture(Key.Enter);
                 unstage.Click += (_, e) =>
                 {
                     UnstageChanges(_selectedStaged, null);
@@ -1466,6 +1472,7 @@ namespace SourceGit.ViewModels
                 var unstage = new MenuItem();
                 unstage.Header = App.Text("FileCM.UnstageMulti", _selectedStaged.Count);
                 unstage.Icon = App.CreateMenuIcon("Icons.File.Remove");
+                unstage.InputGesture = new KeyGesture(Key.Enter);
                 unstage.Click += (_, e) =>
                 {
                     UnstageChanges(_selectedStaged, null);


### PR DESCRIPTION
Added some missing keyboard shortcut hints in a couple of menus. There are probably more missing but these are the ones I noticed.
I went with `Key.Enter` and `Key.Delete` in the (un)stash menus. `Key.Space` and `Key.Back` are also supported but I don't see any way to show two key hints on a single menu item.