### PR TITLE
ux: hotkey tag on external merger menu items

### DIFF
--- a/src/ViewModels/BranchCompare.cs
+++ b/src/ViewModels/BranchCompare.cs
@@ -125,6 +125,7 @@ namespace SourceGit.ViewModels
             var openWithMerger = new MenuItem();
             openWithMerger.Header = App.Text("OpenInExternalMergeTool");
             openWithMerger.Icon = App.CreateMenuIcon("Icons.OpenWith");
+            openWithMerger.Tag = OperatingSystem.IsMacOS() ? "⌘+⇧+D" : "Ctrl+Shift+D";
             openWithMerger.Click += (_, ev) =>
             {
                 var toolType = Preferences.Instance.ExternalMergeToolType;

--- a/src/ViewModels/CommitDetail.cs
+++ b/src/ViewModels/CommitDetail.cs
@@ -325,6 +325,7 @@ namespace SourceGit.ViewModels
             var openWithMerger = new MenuItem();
             openWithMerger.Header = App.Text("OpenInExternalMergeTool");
             openWithMerger.Icon = App.CreateMenuIcon("Icons.OpenWith");
+            openWithMerger.Tag = OperatingSystem.IsMacOS() ? "⌘+⇧+D" : "Ctrl+Shift+D";
             openWithMerger.Click += (_, ev) =>
             {
                 var toolType = Preferences.Instance.ExternalMergeToolType;

--- a/src/ViewModels/RevisionCompare.cs
+++ b/src/ViewModels/RevisionCompare.cs
@@ -139,6 +139,7 @@ namespace SourceGit.ViewModels
             var openWithMerger = new MenuItem();
             openWithMerger.Header = App.Text("OpenInExternalMergeTool");
             openWithMerger.Icon = App.CreateMenuIcon("Icons.OpenWith");
+            openWithMerger.Tag = OperatingSystem.IsMacOS() ? "⌘+⇧+D" : "Ctrl+Shift+D";
             openWithMerger.Click += (_, ev) =>
             {
                 var opt = new Models.DiffOption(GetSHA(_startPoint), GetSHA(_endPoint), change);

--- a/src/ViewModels/StashesPage.cs
+++ b/src/ViewModels/StashesPage.cs
@@ -226,6 +226,7 @@ namespace SourceGit.ViewModels
             var openWithMerger = new MenuItem();
             openWithMerger.Header = App.Text("OpenInExternalMergeTool");
             openWithMerger.Icon = App.CreateMenuIcon("Icons.OpenWith");
+            openWithMerger.Tag = OperatingSystem.IsMacOS() ? "⌘+⇧+D" : "Ctrl+Shift+D";
             openWithMerger.Click += (_, ev) =>
             {
                 var toolType = Preferences.Instance.ExternalMergeToolType;

--- a/src/ViewModels/WorkingCopy.cs
+++ b/src/ViewModels/WorkingCopy.cs
@@ -587,6 +587,7 @@ namespace SourceGit.ViewModels
                 var openMerger = new MenuItem();
                 openMerger.Header = App.Text("OpenInExternalMergeTool");
                 openMerger.Icon = App.CreateMenuIcon("Icons.OpenWith");
+                openMerger.Tag = OperatingSystem.IsMacOS() ? "⌘+⇧+D" : "Ctrl+Shift+D";
                 openMerger.Click += async (_, e) =>
                 {
                     if (change.IsConflicted)
@@ -1275,6 +1276,7 @@ namespace SourceGit.ViewModels
                 var openWithMerger = new MenuItem();
                 openWithMerger.Header = App.Text("OpenInExternalMergeTool");
                 openWithMerger.Icon = App.CreateMenuIcon("Icons.OpenWith");
+                openWithMerger.Tag = OperatingSystem.IsMacOS() ? "⌘+⇧+D" : "Ctrl+Shift+D";
                 openWithMerger.Click += (_, ev) =>
                 {
                     var toolType = Preferences.Instance.ExternalMergeToolType;


### PR DESCRIPTION
I didn't realize there was a hotkey for launching the external merger. Added menu item tags to make this discoverable.