### PR TITLE
enhance: tweak `ToFileSize` for readability

### DIFF
--- a/.github/workflows/tests-check.yml
+++ b/.github/workflows/tests-check.yml
@@ -1,0 +1,24 @@
+name: Format Check
+on:
+  push:
+    branches: [develop]
+  pull_request:
+    branches: [develop]
+  workflow_dispatch:
+  workflow_call:
+
+jobs:
+  tests-check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 9.0.x
+
+      - name: Run unit tests
+        run: dotnet test

--- a/SourceGit.sln
+++ b/SourceGit.sln
@@ -86,6 +86,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "scripts", "scripts", "{C54D
 		build\scripts\package.windows.sh = build\scripts\package.windows.sh
 	EndProjectSection
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{0AB3BF05-4346-4AA6-1389-037BE0695223}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SourceGit.Tests", "tests\SourceGit.Tests.csproj", "{6BE6CF5B-2F49-4AA3-99D6-54701196B2DC}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -96,6 +100,10 @@ Global
 		{2091C34D-4A17-4375-BEF3-4D60BE8113E4}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2091C34D-4A17-4375-BEF3-4D60BE8113E4}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2091C34D-4A17-4375-BEF3-4D60BE8113E4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6BE6CF5B-2F49-4AA3-99D6-54701196B2DC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6BE6CF5B-2F49-4AA3-99D6-54701196B2DC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6BE6CF5B-2F49-4AA3-99D6-54701196B2DC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6BE6CF5B-2F49-4AA3-99D6-54701196B2DC}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -116,6 +124,7 @@ Global
 		{7802CD7A-591B-4EDD-96F8-9BF3F61692E4} = {9BA0B044-0CC9-46F8-B551-204F149BF45D}
 		{5D125DD9-B48A-491F-B2FB-D7830D74C4DC} = {FD384607-ED99-47B7-AF31-FB245841BC92}
 		{C54D4001-9940-477C-A0B6-E795ED0A3209} = {773082AC-D9C8-4186-8521-4B6A7BEE6158}
+		{6BE6CF5B-2F49-4AA3-99D6-54701196B2DC} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {7FF1B9C6-B5BF-4A50-949F-4B407A0E31C9}

--- a/src/Converters/LongConverters.cs
+++ b/src/Converters/LongConverters.cs
@@ -6,20 +6,24 @@ namespace SourceGit.Converters
     {
         public static readonly FuncValueConverter<long, string> ToFileSize = new(bytes =>
         {
+            var full = $"{bytes:N0} B";
             if (bytes < KB)
-                return $"{bytes} B";
+                return full;
 
             if (bytes < MB)
-                return $"{(bytes / KB):F3} KB ({bytes} B)";
+                return $"{(bytes / KB):G3} KB ({full})";
 
             if (bytes < GB)
-                return $"{(bytes / MB):F3} MB ({bytes} B)";
+                return $"{(bytes / MB):G3} MB ({full})";
 
-            return $"{(bytes / GB):F3} GB ({bytes} B)";
+            if (bytes < 1000 * GB)
+                return $"{(bytes / GB):G3} GB ({full})";
+
+            return $"{(bytes / GB):N0} GB ({full})";
         });
 
         private const double KB = 1024;
-        private const double MB = 1024 * 1024;
-        private const double GB = 1024 * 1024 * 1024;
+        private const double MB = 1024 * KB;
+        private const double GB = 1024 * MB;
     }
 }

--- a/tests/Converters/LongConvertersTests.cs
+++ b/tests/Converters/LongConvertersTests.cs
@@ -1,0 +1,31 @@
+using System.Globalization;
+using SourceGit.Converters;
+
+namespace SourceGit.Tests.Converters
+{
+    public class LongConvertersTests
+    {
+        [Theory]
+        [InlineData(4, "4 B")]
+        [InlineData(44, "44 B")]
+        [InlineData(444, "444 B")]
+        [InlineData(4444, "4.34 KB (4,444 B)")]
+        [InlineData(44444, "43.4 KB (44,444 B)")]
+        [InlineData(444444, "434 KB (444,444 B)")]
+        [InlineData(4444444, "4.24 MB (4,444,444 B)")]
+        [InlineData(44444444, "42.4 MB (44,444,444 B)")]
+        [InlineData(444444444, "424 MB (444,444,444 B)")]
+        [InlineData(4444444444, "4.14 GB (4,444,444,444 B)")]
+        [InlineData(44444444444, "41.4 GB (44,444,444,444 B)")]
+        [InlineData(444444444444, "414 GB (444,444,444,444 B)")]
+        [InlineData(4444444444444, "4,139 GB (4,444,444,444,444 B)")]
+        [InlineData(long.MinValue, "-9,223,372,036,854,775,808 B")]
+        [InlineData(0, "0 B")]
+        [InlineData(long.MaxValue, "8,589,934,592 GB (9,223,372,036,854,775,807 B)")]
+        public void ToFileSize_ShouldReturnCorrectFormat(long bytes, string expected)
+        {
+            var actual = LongConverters.ToFileSize.Convert(bytes, typeof(string), null, CultureInfo.CurrentCulture) as string;
+            Assert.Equal(expected, actual);
+        }
+    }
+}

--- a/tests/SourceGit.Tests.csproj
+++ b/tests/SourceGit.Tests.csproj
@@ -1,0 +1,19 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\src\SourceGit.csproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
The new file size format has too many significant digits for good readability, plus thousands separators would help for the raw byte count.
Also, is now a good time to start adding some unit tests?

```
Before: 15.103 KB (15465 B)
After:  15.1 KB (15,465 B)

Before: 491.268 KB (503058 B)
After:  491 KB (503,058 B)

Before: 1.465 MB (1536332 B)
After:  1.46 MB (1,536,332 B)
```