### PR TITLE
feat: Add blame visibility condition and file size formatting

### DIFF
--- a/src/Views/Blame.axaml
+++ b/src/Views/Blame.axaml
@@ -92,7 +92,8 @@
                          FontFamily="{DynamicResource Fonts.Monospace}"
                          FontSize="{Binding Source={x:Static vm:Preferences.Instance}, Path=EditorFontSize}"
                          TabWidth="{Binding Source={x:Static vm:Preferences.Instance}, Path=EditorTabWidth}"
-                         BlameData="{Binding Data}">
+                         BlameData="{Binding Data}"
+                         IsVisible="{Binding IsBinary, Converter={x:Static BoolConverters.Not}}">
         <ToolTip.IsOpen>
           <MultiBinding Converter="{x:Static BoolConverters.And}">
             <Binding Path="$self.IsPointerOver"/>

--- a/src/Views/RevisionFileContentViewer.axaml
+++ b/src/Views/RevisionFileContentViewer.axaml
@@ -14,7 +14,7 @@
         <Path Width="64" Height="64" Data="{StaticResource Icons.Error}" Fill="{DynamicResource Brush.FG2}"/>
         <TextBlock Margin="0,16,0,0" Text="{DynamicResource Text.BinaryNotSupported}" FontSize="18" FontWeight="Bold" HorizontalAlignment="Center" Foreground="{DynamicResource Brush.FG2}"/>
         <StackPanel Margin="0,8,0,0" Orientation="Horizontal" HorizontalAlignment="Center">
-          <TextBlock Classes="primary" Text="{Binding Size}" Foreground="{DynamicResource Brush.FG2}"/>
+          <TextBlock Classes="primary" Text="{Binding Size, Converter={x:Static c:LongConverters.ToFileSize}}" Foreground="{DynamicResource Brush.FG2}"/>
         </StackPanel>
       </StackPanel>
     </DataTemplate>


### PR DESCRIPTION
- Add conditional visibility binding to blame data display using a negated binary file flag converter.
- Format size property as human-readable file size using LongConverters.ToFileSize converter in UI display.

Before:
![image](https://github.com/user-attachments/assets/2f762052-34ff-430a-9a03-7fbf8736057e)
![image](https://github.com/user-attachments/assets/3f4b7724-5c84-4298-b032-980d2fa4c09b)


After:
![image](https://github.com/user-attachments/assets/e9511e5e-46c9-4222-84d4-ac391dcf5dab)
![image](https://github.com/user-attachments/assets/388fd759-e550-458f-bf38-5cf035a7d940)
