### PR TITLE
fix: prevent staging conflicted files

### DIFF
--- a/src/ViewModels/WorkingCopy.cs
+++ b/src/ViewModels/WorkingCopy.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 
 using Avalonia.Controls;
@@ -1870,7 +1871,11 @@ namespace SourceGit.ViewModels
 
         private async void StageChanges(List<Models.Change> changes, Models.Change next)
         {
-            var count = changes.Count;
+            var nonConflictChanges = HasUnsolvedConflicts
+                ? changes.Where(c => !c.IsConflicted).ToList()
+                : changes;
+
+            var count = nonConflictChanges.Count;
             if (count == 0)
                 return;
 
@@ -1890,7 +1895,7 @@ namespace SourceGit.ViewModels
                 var pathSpecFile = Path.GetTempFileName();
                 await using (var writer = new StreamWriter(pathSpecFile))
                 {
-                    foreach (var c in changes)
+                    foreach (var c in nonConflictChanges)
                         await writer.WriteLineAsync(c.Path);
                 }
 

--- a/src/Views/ChangeCollectionView.axaml.cs
+++ b/src/Views/ChangeCollectionView.axaml.cs
@@ -186,7 +186,10 @@ namespace SourceGit.Views
 
             var set = new HashSet<string>();
             foreach (var c in selected)
-                set.Add(c.Path);
+            {
+                if (!c.IsConflicted)
+                    set.Add(c.Path);
+            }
 
             if (Content is ViewModels.ChangeCollectionAsTree tree)
             {


### PR DESCRIPTION
It was possible to stage a file with conflicts (double tap, space, enter, or a stage button).  As a result it would no longer be shown as conflicted, and the user could no longer solve the conflict in any way (use theirs, use mine, or execute merge tool), not even after unstaging again.

Now conflicted files are ignored when staging.