### PR TITLE
enhance: support `--autostash` on interactive rebase

### DIFF
--- a/src/Commands/Rebase.cs
+++ b/src/Commands/Rebase.cs
@@ -15,12 +15,15 @@
 
     public class InteractiveRebase : Command
     {
-        public InteractiveRebase(string repo, string basedOn)
+        public InteractiveRebase(string repo, string basedOn, bool autoStash)
         {
             WorkingDirectory = repo;
             Context = repo;
             Editor = EditorType.RebaseEditor;
-            Args = $"rebase -i --autosquash {basedOn}";
+            Args = "rebase -i --autosquash ";
+            if (autoStash)
+                Args += "--autostash ";
+            Args += basedOn;
         }
     }
 }

--- a/src/Resources/Locales/de_DE.axaml
+++ b/src/Resources/Locales/de_DE.axaml
@@ -441,6 +441,7 @@
   <x:String x:Key="Text.InProgress.Revert" xml:space="preserve">Revert wird durchgeführt.</x:String>
   <x:String x:Key="Text.InProgress.Revert.Head" xml:space="preserve">Reverte Commit</x:String>
   <x:String x:Key="Text.InteractiveRebase" xml:space="preserve">Interaktiver Rebase</x:String>
+  <x:String x:Key="Text.InteractiveRebase.AutoStash" xml:space="preserve">Lokale Änderungen stashen &amp; wieder anwenden</x:String>
   <x:String x:Key="Text.InteractiveRebase.On" xml:space="preserve">Auf:</x:String>
   <x:String x:Key="Text.InteractiveRebase.Target" xml:space="preserve">Ziel Branch:</x:String>
   <x:String x:Key="Text.IssueLinkCM.CopyLink" xml:space="preserve">Link kopieren</x:String>

--- a/src/Resources/Locales/en_US.axaml
+++ b/src/Resources/Locales/en_US.axaml
@@ -452,6 +452,7 @@
   <x:String x:Key="Text.InProgress.Revert" xml:space="preserve">Revert in progress.</x:String>
   <x:String x:Key="Text.InProgress.Revert.Head" xml:space="preserve">Reverting commit</x:String>
   <x:String x:Key="Text.InteractiveRebase" xml:space="preserve">Interactive Rebase</x:String>
+  <x:String x:Key="Text.InteractiveRebase.AutoStash" xml:space="preserve">Stash &amp; reapply local changes</x:String>
   <x:String x:Key="Text.InteractiveRebase.On" xml:space="preserve">On:</x:String>
   <x:String x:Key="Text.InteractiveRebase.ReorderTip" xml:space="preserve">Drag-drop to reorder commits</x:String>
   <x:String x:Key="Text.InteractiveRebase.Target" xml:space="preserve">Target Branch:</x:String>

--- a/src/Resources/Locales/es_ES.axaml
+++ b/src/Resources/Locales/es_ES.axaml
@@ -438,6 +438,7 @@
   <x:String x:Key="Text.InProgress.Revert" xml:space="preserve">Revert en progreso.</x:String>
   <x:String x:Key="Text.InProgress.Revert.Head" xml:space="preserve">Haciendo revert del commit</x:String>
   <x:String x:Key="Text.InteractiveRebase" xml:space="preserve">Rebase Interactivo</x:String>
+  <x:String x:Key="Text.InteractiveRebase.AutoStash" xml:space="preserve">Stash &amp; reaplicar cambios locales</x:String>
   <x:String x:Key="Text.InteractiveRebase.On" xml:space="preserve">En:</x:String>
   <x:String x:Key="Text.InteractiveRebase.Target" xml:space="preserve">Rama Objetivo:</x:String>
   <x:String x:Key="Text.IssueLinkCM.CopyLink" xml:space="preserve">Copiar Enlace</x:String>

--- a/src/Resources/Locales/fr_FR.axaml
+++ b/src/Resources/Locales/fr_FR.axaml
@@ -386,6 +386,7 @@
   <x:String x:Key="Text.InProgress.Revert" xml:space="preserve">Annulation en cours.</x:String>
   <x:String x:Key="Text.InProgress.Revert.Head" xml:space="preserve">Annulation du commit</x:String>
   <x:String x:Key="Text.InteractiveRebase" xml:space="preserve">Rebase interactif</x:String>
+  <x:String x:Key="Text.InteractiveRebase.AutoStash" xml:space="preserve">Stash &amp; réappliquer changements locaux</x:String>
   <x:String x:Key="Text.InteractiveRebase.On" xml:space="preserve">Sur :</x:String>
   <x:String x:Key="Text.InteractiveRebase.Target" xml:space="preserve">Branche cible :</x:String>
   <x:String x:Key="Text.IssueLinkCM.CopyLink" xml:space="preserve">Copier le lien</x:String>

--- a/src/Resources/Locales/it_IT.axaml
+++ b/src/Resources/Locales/it_IT.axaml
@@ -406,6 +406,7 @@
   <x:String x:Key="Text.InProgress.Revert" xml:space="preserve">Ripristino in corso.</x:String>
   <x:String x:Key="Text.InProgress.Revert.Head" xml:space="preserve">Ripristinando il commit</x:String>
   <x:String x:Key="Text.InteractiveRebase" xml:space="preserve">Riallinea Interattivamente</x:String>
+  <x:String x:Key="Text.InteractiveRebase.AutoStash" xml:space="preserve">Stasha e Riapplica modifiche locali</x:String>
   <x:String x:Key="Text.InteractiveRebase.On" xml:space="preserve">Su:</x:String>
   <x:String x:Key="Text.InteractiveRebase.Target" xml:space="preserve">Branch di destinazione:</x:String>
   <x:String x:Key="Text.IssueLinkCM.CopyLink" xml:space="preserve">Copia il Link</x:String>

--- a/src/Resources/Locales/ja_JP.axaml
+++ b/src/Resources/Locales/ja_JP.axaml
@@ -385,6 +385,7 @@
   <x:String x:Key="Text.InProgress.Revert" xml:space="preserve">元に戻す処理が進行中です。'中止'を押すと元のHEADが復元されます。</x:String>
   <x:String x:Key="Text.InProgress.Revert.Head" xml:space="preserve">コミットを元に戻しています</x:String>
   <x:String x:Key="Text.InteractiveRebase" xml:space="preserve">インタラクティブ リベース</x:String>
+  <x:String x:Key="Text.InteractiveRebase.AutoStash" xml:space="preserve">ローカルの変更をスタッシュして再適用</x:String>
   <x:String x:Key="Text.InteractiveRebase.On" xml:space="preserve">On:</x:String>
   <x:String x:Key="Text.InteractiveRebase.Target" xml:space="preserve">対象のブランチ:</x:String>
   <x:String x:Key="Text.IssueLinkCM.CopyLink" xml:space="preserve">リンクをコピー</x:String>

--- a/src/Resources/Locales/pt_BR.axaml
+++ b/src/Resources/Locales/pt_BR.axaml
@@ -353,6 +353,7 @@
   <x:String x:Key="Text.InProgress.Rebase" xml:space="preserve">Rebase em andamento.</x:String>
   <x:String x:Key="Text.InProgress.Revert" xml:space="preserve">Revert em andamento.</x:String>
   <x:String x:Key="Text.InteractiveRebase" xml:space="preserve">Rebase Interativo</x:String>
+  <x:String x:Key="Text.InteractiveRebase.AutoStash" xml:space="preserve">Guardar &amp; reaplicar alterações locais</x:String>
   <x:String x:Key="Text.InteractiveRebase.On" xml:space="preserve">Em:</x:String>
   <x:String x:Key="Text.InteractiveRebase.Target" xml:space="preserve">Ramo Alvo:</x:String>
   <x:String x:Key="Text.IssueLinkCM.CopyLink" xml:space="preserve">Copiar link</x:String>

--- a/src/Resources/Locales/ru_RU.axaml
+++ b/src/Resources/Locales/ru_RU.axaml
@@ -445,6 +445,7 @@
   <x:String x:Key="Text.InProgress.Revert" xml:space="preserve">Выполняется отмена ревизии.</x:String>
   <x:String x:Key="Text.InProgress.Revert.Head" xml:space="preserve">Выполняется отмена</x:String>
   <x:String x:Key="Text.InteractiveRebase" xml:space="preserve">Интерактивное перемещение</x:String>
+  <x:String x:Key="Text.InteractiveRebase.AutoStash" xml:space="preserve">Отложить и применить повторно локальные изменения</x:String>
   <x:String x:Key="Text.InteractiveRebase.On" xml:space="preserve">На:</x:String>
   <x:String x:Key="Text.InteractiveRebase.ReorderTip" xml:space="preserve">Перетаскивайте для переупорядочивания ревизий</x:String>
   <x:String x:Key="Text.InteractiveRebase.Target" xml:space="preserve">Целевая ветка:</x:String>

--- a/src/Resources/Locales/ta_IN.axaml
+++ b/src/Resources/Locales/ta_IN.axaml
@@ -385,6 +385,7 @@
   <x:String x:Key="Text.InProgress.Revert" xml:space="preserve">திரும்ப்பெறும் செயல்பாட்டில் உள்ளது.</x:String>
   <x:String x:Key="Text.InProgress.Revert.Head" xml:space="preserve">திரும்பபெறும் உறுதிமொழி</x:String>
   <x:String x:Key="Text.InteractiveRebase" xml:space="preserve">ஊடாடும் மறுதளம்</x:String>
+  <x:String x:Key="Text.InteractiveRebase.AutoStash" xml:space="preserve">உள்ளக மாற்றங்களை பதுக்கிவை &amp; மீண்டும் இடு</x:String>
   <x:String x:Key="Text.InteractiveRebase.On" xml:space="preserve">மேல்:</x:String>
   <x:String x:Key="Text.InteractiveRebase.Target" xml:space="preserve">இலக்கு கிளை:</x:String>
   <x:String x:Key="Text.IssueLinkCM.CopyLink" xml:space="preserve">இணைப்பை நகலெடு</x:String>

--- a/src/Resources/Locales/uk_UA.axaml
+++ b/src/Resources/Locales/uk_UA.axaml
@@ -390,6 +390,7 @@
   <x:String x:Key="Text.InProgress.Revert" xml:space="preserve">Скасування в процесі.</x:String>
   <x:String x:Key="Text.InProgress.Revert.Head" xml:space="preserve">Скасування коміту</x:String>
   <x:String x:Key="Text.InteractiveRebase" xml:space="preserve">Інтерактивне перебазування</x:String>
+  <x:String x:Key="Text.InteractiveRebase.AutoStash" xml:space="preserve">Сховати та застосувати локальні зміни</x:String>
   <x:String x:Key="Text.InteractiveRebase.On" xml:space="preserve">На:</x:String>
   <x:String x:Key="Text.InteractiveRebase.Target" xml:space="preserve">Цільова гілка:</x:String>
   <x:String x:Key="Text.IssueLinkCM.CopyLink" xml:space="preserve">Копіювати посилання</x:String>

--- a/src/Resources/Locales/zh_CN.axaml
+++ b/src/Resources/Locales/zh_CN.axaml
@@ -456,6 +456,7 @@
   <x:String x:Key="Text.InProgress.Revert" xml:space="preserve">回滚提交操作进行中。</x:String>
   <x:String x:Key="Text.InProgress.Revert.Head" xml:space="preserve">正在回滚提交</x:String>
   <x:String x:Key="Text.InteractiveRebase" xml:space="preserve">交互式变基</x:String>
+  <x:String x:Key="Text.InteractiveRebase.AutoStash" xml:space="preserve">自动贮藏并恢复本地变更</x:String>
   <x:String x:Key="Text.InteractiveRebase.On" xml:space="preserve">起始提交 ：</x:String>
   <x:String x:Key="Text.InteractiveRebase.ReorderTip" xml:space="preserve">拖拽以便对提交重新排序</x:String>
   <x:String x:Key="Text.InteractiveRebase.Target" xml:space="preserve">目标分支 ：</x:String>

--- a/src/Resources/Locales/zh_TW.axaml
+++ b/src/Resources/Locales/zh_TW.axaml
@@ -456,6 +456,7 @@
   <x:String x:Key="Text.InProgress.Revert" xml:space="preserve">復原提交操作進行中。</x:String>
   <x:String x:Key="Text.InProgress.Revert.Head" xml:space="preserve">正在復原提交</x:String>
   <x:String x:Key="Text.InteractiveRebase" xml:space="preserve">互動式重定基底</x:String>
+  <x:String x:Key="Text.InteractiveRebase.AutoStash" xml:space="preserve">自動擱置變更並復原本機變更</x:String>
   <x:String x:Key="Text.InteractiveRebase.On" xml:space="preserve">起始提交:</x:String>
   <x:String x:Key="Text.InteractiveRebase.ReorderTip" xml:space="preserve">拖曳以重新排序提交</x:String>
   <x:String x:Key="Text.InteractiveRebase.Target" xml:space="preserve">目標分支:</x:String>

--- a/src/ViewModels/Histories.cs
+++ b/src/ViewModels/Histories.cs
@@ -640,12 +640,6 @@ namespace SourceGit.ViewModels
                     interactiveRebase.Icon = App.CreateMenuIcon("Icons.InteractiveRebase");
                     interactiveRebase.Click += async (_, e) =>
                     {
-                        if (_repo.LocalChangesCount > 0)
-                        {
-                            App.RaiseException(_repo.FullPath, "You have local changes. Please run stash or discard first.");
-                            return;
-                        }
-
                         await App.ShowDialog(new InteractiveRebase(_repo, current, commit));
                         e.Handled = true;
                     };

--- a/src/ViewModels/InteractiveRebase.cs
+++ b/src/ViewModels/InteractiveRebase.cs
@@ -84,6 +84,12 @@ namespace SourceGit.ViewModels
             private set;
         }
 
+        public bool AutoStash
+        {
+            get;
+            set;
+        } = true;
+
         public AvaloniaList<Models.IssueTrackerRule> IssueTrackerRules
         {
             get => _repo.Settings.IssueTrackerRules;
@@ -212,7 +218,7 @@ namespace SourceGit.ViewModels
             }
 
             var log = _repo.CreateLog("Interactive Rebase");
-            var succ = await new Commands.InteractiveRebase(_repo.FullPath, On.SHA)
+            var succ = await new Commands.InteractiveRebase(_repo.FullPath, On.SHA, AutoStash)
                 .Use(log)
                 .ExecAsync();
 

--- a/src/Views/InteractiveRebase.axaml
+++ b/src/Views/InteractiveRebase.axaml
@@ -38,7 +38,7 @@
     </Grid>
 
     <!-- Operation Information -->
-    <Grid Grid.Row="1" ColumnDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,*" Margin="8">
+    <Grid Grid.Row="1" ColumnDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,*" Margin="8">
       <TextBlock Grid.Column="0" Text="{DynamicResource Text.InteractiveRebase.Target}" Foreground="{DynamicResource Brush.FG2}" FontWeight="Bold"/>
       <Path Grid.Column="1" Width="14" Height="14" Margin="8,0,0,0" Data="{StaticResource Icons.Branch}"/>
       <TextBlock Grid.Column="2" VerticalAlignment="Center" Text="{Binding Current.FriendlyName}" Margin="8,0,0,0"/>
@@ -47,6 +47,8 @@
       <Path Grid.Column="4" Width="14" Height="14" Margin="8,0,0,0" Data="{StaticResource Icons.Commit}"/>
       <TextBlock Grid.Column="5" Classes="primary" VerticalAlignment="Center" Text="{Binding On.SHA, Converter={x:Static c:StringConverters.ToShortSHA}}" Foreground="DarkOrange" Margin="8,0,0,0"/>
       <TextBlock Grid.Column="6" VerticalAlignment="Center" Text="{Binding On.Subject}" Margin="4,0,0,0" TextTrimming="CharacterEllipsis"/>
+
+      <CheckBox Grid.Column="7" Content="{DynamicResource Text.InteractiveRebase.AutoStash}" IsChecked="{Binding AutoStash, Mode=TwoWay}" Margin="16,0,0,0"/>
     </Grid>
 
     <!-- Body -->


### PR DESCRIPTION
I often have minor patches in my workspace that I'd like to keep during interactive rebase. This PR adds the same autostash ability already available in non-interactive rebase.

It would also be nice to allow commit rename with pending changes so long as nothing is staged, however I couldn't find an easy way to determine this from the `Histories` view model.