### PR TITLE
feature: support `.issuetracker` file

### DIFF
--- a/.issuetracker
+++ b/.issuetracker
@@ -1,0 +1,7 @@
+# Integration with Issue Tracker
+#
+# (note that '\' need to be escaped).
+
+[issuetracker "GitHub"]
+	regex = "#(\\d+)"
+	url = https://github.com/sourcegit-scm/sourcegit/issues/$1

--- a/src/Commands/Config.cs
+++ b/src/Commands/Config.cs
@@ -20,9 +20,9 @@ namespace SourceGit.Commands
             }
         }
 
-        public async Task<Dictionary<string, string>> ReadAllAsync()
+        public async Task<Dictionary<string, string>> ReadAllAsync(string file = null)
         {
-            Args = "config -l";
+            Args = string.IsNullOrEmpty(file) ? "config -l" : $"config -l -f {file}";
 
             var output = await ReadToEndAsync().ConfigureAwait(false);
             var rs = new Dictionary<string, string>();

--- a/src/Models/IRepository.cs
+++ b/src/Models/IRepository.cs
@@ -4,6 +4,8 @@
     {
         bool MayHaveSubmodules();
 
+        void LoadSharedIssueTrackerRules();
+
         void RefreshBranches();
         void RefreshWorktrees();
         void RefreshTags();

--- a/src/Models/Watcher.cs
+++ b/src/Models/Watcher.cs
@@ -260,6 +260,12 @@ namespace SourceGit.Models
                 return;
             }
 
+            if (name == ".issuetracker")
+            {
+                _repo.LoadSharedIssueTrackerRules();
+                return;
+            }
+
             lock (_lockSubmodule)
             {
                 foreach (var submodule in _submodules)

--- a/src/ViewModels/CommitDetail.cs
+++ b/src/ViewModels/CommitDetail.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.IO;
 using System.Text.RegularExpressions;
 using System.Threading;
@@ -145,10 +146,12 @@ namespace SourceGit.ViewModels
             _repo = repo;
             _rememberActivePageIndex = rememberActivePageIndex;
             WebLinks = Models.CommitLink.Get(repo.Remotes);
+            _repo.PropertyChanged += OnRepoPropertyChanged;
         }
 
         public void Dispose()
         {
+            _repo.PropertyChanged -= OnRepoPropertyChanged;
             _repo = null;
             _commit = null;
             _changes = null;
@@ -666,6 +669,12 @@ namespace SourceGit.ViewModels
             return menu;
         }
 
+        private void OnRepoPropertyChanged(object sender, PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName == nameof(Repository.SharedIssueTrackerRules))
+                Refresh();
+        }
+
         private void Refresh()
         {
             _changes = null;
@@ -767,6 +776,12 @@ namespace SourceGit.ViewModels
             if (_repo.Settings.IssueTrackerRules is { Count: > 0 } rules)
             {
                 foreach (var rule in rules)
+                    rule.Matches(inlines, message);
+            }
+
+            if (_repo.SharedIssueTrackerRules is { Count: > 0 } sharedRules)
+            {
+                foreach (var rule in sharedRules)
                     rule.Matches(inlines, message);
             }
 

--- a/src/ViewModels/InteractiveRebase.cs
+++ b/src/ViewModels/InteractiveRebase.cs
@@ -102,6 +102,11 @@ namespace SourceGit.ViewModels
             get => _repo.Settings.IssueTrackerRules;
         }
 
+        public AvaloniaList<Models.IssueTrackerRule> SharedIssueTrackerRules
+        {
+            get => _repo.SharedIssueTrackerRules;
+        }
+
         public bool IsLoading
         {
             get => _isLoading;

--- a/src/Views/CommitSubjectPresenter.cs
+++ b/src/Views/CommitSubjectPresenter.cs
@@ -93,6 +93,15 @@ namespace SourceGit.Views
             set => SetValue(IssueTrackerRulesProperty, value);
         }
 
+        public static readonly StyledProperty<AvaloniaList<Models.IssueTrackerRule>> SharedIssueTrackerRulesProperty =
+            AvaloniaProperty.Register<CommitSubjectPresenter, AvaloniaList<Models.IssueTrackerRule>>(nameof(SharedIssueTrackerRules));
+
+        public AvaloniaList<Models.IssueTrackerRule> SharedIssueTrackerRules
+        {
+            get => GetValue(SharedIssueTrackerRulesProperty);
+            set => SetValue(SharedIssueTrackerRulesProperty, value);
+        }
+
         public override void Render(DrawingContext context)
         {
             if (_needRebuildInlines)
@@ -138,7 +147,9 @@ namespace SourceGit.Views
         {
             base.OnPropertyChanged(change);
 
-            if (change.Property == SubjectProperty || change.Property == IssueTrackerRulesProperty)
+            if (change.Property == SubjectProperty ||
+                change.Property == IssueTrackerRulesProperty ||
+                change.Property == SharedIssueTrackerRulesProperty)
             {
                 _elements.Clear();
                 ClearHoveredIssueLink();
@@ -153,6 +164,10 @@ namespace SourceGit.Views
 
                 var rules = IssueTrackerRules ?? [];
                 foreach (var rule in rules)
+                    rule.Matches(_elements, subject);
+
+                var sharedRules = SharedIssueTrackerRules ?? [];
+                foreach (var rule in sharedRules)
                     rule.Matches(_elements, subject);
 
                 var keywordMatch = REG_KEYWORD_FORMAT1().Match(subject);

--- a/src/Views/Histories.axaml
+++ b/src/Views/Histories.axaml
@@ -142,6 +142,7 @@
                                               LinkForeground="{DynamicResource Brush.Link}"
                                               Subject="{Binding Subject}"
                                               IssueTrackerRules="{Binding $parent[v:Histories].IssueTrackerRules}"
+                                              SharedIssueTrackerRules="{Binding $parent[v:Histories].SharedIssueTrackerRules}"
                                               FontWeight="{Binding FontWeight}"
                                               Opacity="{Binding Opacity}"/>
                   </Grid>

--- a/src/Views/Histories.axaml.cs
+++ b/src/Views/Histories.axaml.cs
@@ -103,6 +103,15 @@ namespace SourceGit.Views
             set => SetValue(IssueTrackerRulesProperty, value);
         }
 
+        public static readonly StyledProperty<AvaloniaList<Models.IssueTrackerRule>> SharedIssueTrackerRulesProperty =
+            AvaloniaProperty.Register<Histories, AvaloniaList<Models.IssueTrackerRule>>(nameof(SharedIssueTrackerRules));
+
+        public AvaloniaList<Models.IssueTrackerRule> SharedIssueTrackerRules
+        {
+            get => GetValue(SharedIssueTrackerRulesProperty);
+            set => SetValue(SharedIssueTrackerRulesProperty, value);
+        }
+
         public static readonly StyledProperty<bool> OnlyHighlightCurrentBranchProperty =
             AvaloniaProperty.Register<Histories, bool>(nameof(OnlyHighlightCurrentBranch), true);
 

--- a/src/Views/InteractiveRebase.axaml
+++ b/src/Views/InteractiveRebase.axaml
@@ -136,6 +136,7 @@
                                             LinkForeground="{DynamicResource Brush.Link}"
                                             Subject="{Binding Subject}"
                                             IssueTrackerRules="{Binding $parent[v:InteractiveRebase].((vm:InteractiveRebase)DataContext).IssueTrackerRules}"
+                                            SharedIssueTrackerRules="{Binding $parent[v:InteractiveRebase].((vm:InteractiveRebase)DataContext).SharedIssueTrackerRules}"
                                             FontWeight="Normal"/>
                 </Grid>
 

--- a/src/Views/Repository.axaml
+++ b/src/Views/Repository.axaml
@@ -844,6 +844,7 @@
             <v:Histories CurrentBranch="{Binding $parent[v:Repository].((vm:Repository)DataContext).CurrentBranch}"
                          Bisect="{Binding Bisect}"
                          IssueTrackerRules="{Binding $parent[v:Repository].((vm:Repository)DataContext).Settings.IssueTrackerRules}"
+                         SharedIssueTrackerRules="{Binding $parent[v:Repository].((vm:Repository)DataContext).SharedIssueTrackerRules}"
                          OnlyHighlightCurrentBranch="{Binding $parent[v:Repository].((vm:Repository)DataContext).OnlyHighlightCurrentBranchInHistories}"
                          NavigationId="{Binding NavigationId}"/>
           </DataTemplate>


### PR DESCRIPTION
Beforehand issue trackers could be defined in the repository configuration only.  They were stored in the `.git` directory.  As a consequence each SourceGit user had to configure issue trackers for himself.

Now additional issue tracker rules are read from an existing `.issuetracker` file (#1424).  An issue tracker configured by a user has a higher priority than an issue tracker read from `.issuetracker`.

This allows to share issue trackers between team members.

SourceGit does not (yet?) write into the `.issuetracker` file.  But using `git config` allows the user to easily construct issue tracker rules for the `.issuetracker` file, where even the escaping of the backslash in '#(\d+)' is done correctly.

A `.issuetracker` file was added to SourceGit.  It was created by executing the following commands in a bash shell, where the current directory was the repository root:

```bash
cat >.issuetracker <<EOF
# Integration with Issue Tracker
#
# (note that '\' need to be escaped).

EOF
git config set --file .issuetracker issuetracker.GitHub.regex '#(\d+)'
git config set --file .issuetracker issuetracker.GitHub.url \
  'https://github.com/sourcegit-scm/sourcegit/issues/$1'
```