### PR TITLE
enhance: use commit friendly name in context menus

### DIFF
--- a/src/Resources/Locales/en_US.axaml
+++ b/src/Resources/Locales/en_US.axaml
@@ -123,17 +123,17 @@
   <x:String x:Key="Text.CommitCM.CopySHA" xml:space="preserve">SHA</x:String>
   <x:String x:Key="Text.CommitCM.CopySubject" xml:space="preserve">Subject</x:String>
   <x:String x:Key="Text.CommitCM.CustomAction" xml:space="preserve">Custom Action</x:String>
-  <x:String x:Key="Text.CommitCM.InteractiveRebase" xml:space="preserve">Interactively Rebase ${0}$ on Here</x:String>
+  <x:String x:Key="Text.CommitCM.InteractiveRebase" xml:space="preserve">Interactively Rebase ${0}$ on ${1}$</x:String>
   <x:String x:Key="Text.CommitCM.Merge" xml:space="preserve">Merge to ${0}$</x:String>
   <x:String x:Key="Text.CommitCM.MergeMultiple" xml:space="preserve">Merge ...</x:String>
   <x:String x:Key="Text.CommitCM.PushRevision" xml:space="preserve">Push ${0}$ to ${1}$</x:String>
-  <x:String x:Key="Text.CommitCM.Rebase" xml:space="preserve">Rebase ${0}$ on Here</x:String>
-  <x:String x:Key="Text.CommitCM.Reset" xml:space="preserve">Reset ${0}$ to Here</x:String>
+  <x:String x:Key="Text.CommitCM.Rebase" xml:space="preserve">Rebase ${0}$ on ${1}$</x:String>
+  <x:String x:Key="Text.CommitCM.Reset" xml:space="preserve">Reset ${0}$ to ${1}$</x:String>
   <x:String x:Key="Text.CommitCM.Revert" xml:space="preserve">Revert Commit</x:String>
   <x:String x:Key="Text.CommitCM.Reword" xml:space="preserve">Reword</x:String>
   <x:String x:Key="Text.CommitCM.SaveAsPatch" xml:space="preserve">Save as Patch...</x:String>
   <x:String x:Key="Text.CommitCM.Squash" xml:space="preserve">Squash into Parent</x:String>
-  <x:String x:Key="Text.CommitCM.SquashCommitsSinceThis" xml:space="preserve">Squash Children into Here</x:String>
+  <x:String x:Key="Text.CommitCM.SquashCommitsSinceThis" xml:space="preserve">Squash Children into ${0}$</x:String>
   <x:String x:Key="Text.CommitDetail.Changes" xml:space="preserve">CHANGES</x:String>
   <x:String x:Key="Text.CommitDetail.Changes.Count" xml:space="preserve">changed file(s)</x:String>
   <x:String x:Key="Text.CommitDetail.Changes.Search" xml:space="preserve">Search Changes...</x:String>

--- a/src/ViewModels/Histories.cs
+++ b/src/ViewModels/Histories.cs
@@ -483,10 +483,12 @@ namespace SourceGit.ViewModels
 
             if (!_repo.IsBare)
             {
+                var target = GetFriendlyNameOfCommit(commit);
+
                 if (current.Head != commit.SHA)
                 {
                     var reset = new MenuItem();
-                    reset.Header = App.Text("CommitCM.Reset", current.Name);
+                    reset.Header = App.Text("CommitCM.Reset", current.Name, target);
                     reset.Icon = App.CreateMenuIcon("Icons.Reset");
                     reset.Click += (_, e) =>
                     {
@@ -499,7 +501,7 @@ namespace SourceGit.ViewModels
                     if (commit.IsMerged)
                     {
                         var squash = new MenuItem();
-                        squash.Header = App.Text("CommitCM.SquashCommitsSinceThis");
+                        squash.Header = App.Text("CommitCM.SquashCommitsSinceThis", target);
                         squash.Icon = App.CreateMenuIcon("Icons.SquashIntoParent");
                         squash.Click += (_, e) =>
                         {
@@ -545,7 +547,7 @@ namespace SourceGit.ViewModels
                 if (!commit.IsMerged)
                 {
                     var rebase = new MenuItem();
-                    rebase.Header = App.Text("CommitCM.Rebase", current.Name);
+                    rebase.Header = App.Text("CommitCM.Rebase", current.Name, target);
                     rebase.Icon = App.CreateMenuIcon("Icons.Rebase");
                     rebase.Click += (_, e) =>
                     {
@@ -630,7 +632,7 @@ namespace SourceGit.ViewModels
                     };
 
                     var interactiveRebase = new MenuItem();
-                    interactiveRebase.Header = App.Text("CommitCM.InteractiveRebase", current.Name);
+                    interactiveRebase.Header = App.Text("CommitCM.InteractiveRebase", current.Name, target);
                     interactiveRebase.Icon = App.CreateMenuIcon("Icons.InteractiveRebase");
                     interactiveRebase.Click += async (_, e) =>
                     {
@@ -869,6 +871,19 @@ namespace SourceGit.ViewModels
             menu.Items.Add(copy);
 
             return menu;
+        }
+
+        private static string GetFriendlyNameOfCommit(Models.Commit commit)
+        {
+            var branchDecorator = commit.Decorators.Find(x => x.Type is Models.DecoratorType.LocalBranchHead or Models.DecoratorType.RemoteBranchHead);
+            if (branchDecorator != null)
+                return branchDecorator.Name;
+
+            var tagDecorator = commit.Decorators.Find(x => x.Type is Models.DecoratorType.Tag);
+            if (tagDecorator != null)
+                return tagDecorator.Name;
+
+            return commit.SHA[..10];
         }
 
         private void FillCurrentBranchMenu(ContextMenu menu, Models.Branch current)


### PR DESCRIPTION
Minor change to use "friendly" commit name in context menus.