### PR TITLE
fix: discard null process output data

### DIFF
--- a/src/Commands/Command.cs
+++ b/src/Commands/Command.cs
@@ -204,7 +204,9 @@ namespace SourceGit.Commands
 
         private void HandleOutput(string line, List<string> errs)
         {
-            line ??= string.Empty;
+            if (line == null)
+                return;
+
             Log?.AppendLine(line);
 
             // Lines to hide in error message.


### PR DESCRIPTION
Intermittent extra new lines in git command logs due to `null` output event data. Looks much better if these are discarded.