### PR TITLE
enhance: quickly drop single commits by prefilling interactive rebase

### DIFF
--- a/src/Resources/Locales/en_US.axaml
+++ b/src/Resources/Locales/en_US.axaml
@@ -123,6 +123,7 @@
   <x:String x:Key="Text.CommitCM.CopySHA" xml:space="preserve">SHA</x:String>
   <x:String x:Key="Text.CommitCM.CopySubject" xml:space="preserve">Subject</x:String>
   <x:String x:Key="Text.CommitCM.CustomAction" xml:space="preserve">Custom Action</x:String>
+  <x:String x:Key="Text.CommitCM.Drop" xml:space="preserve">Drop Commit</x:String>
   <x:String x:Key="Text.CommitCM.InteractiveRebase" xml:space="preserve">Interactively Rebase ${0}$ on ${1}$</x:String>
   <x:String x:Key="Text.CommitCM.Merge" xml:space="preserve">Merge to ${0}$</x:String>
   <x:String x:Key="Text.CommitCM.MergeMultiple" xml:space="preserve">Merge ...</x:String>

--- a/src/ViewModels/Histories.cs
+++ b/src/ViewModels/Histories.cs
@@ -617,6 +617,17 @@ namespace SourceGit.ViewModels
                         e.Handled = true;
                     };
                     menu.Items.Add(revert);
+
+                    var drop = new MenuItem();
+                    drop.Header = App.Text("CommitCM.Drop");
+                    drop.Icon = App.CreateMenuIcon("Icons.Clear");
+                    drop.Click += async (_, e) =>
+                    {
+                        var parent = await new Commands.QuerySingleCommit(_repo.FullPath, commit.Parents[0]).GetResultAsync();
+                        await App.ShowDialog(new InteractiveRebase(_repo, current, parent, Models.InteractiveRebaseAction.Drop));
+                        e.Handled = true;
+                    };
+                    menu.Items.Add(drop);
                 }
 
                 if (current.Head != commit.SHA)


### PR DESCRIPTION
I often find myself wanting to drop (not revert) a single commit. It would be nice if this could be streamlined - by launching the existing interactive rebase window with the relevant commit already marked as `Drop`.