### PR TITLE
code_style: use switch expressions for simple value mapping

### DIFF
--- a/src/Commands/CompareRevisions.cs
+++ b/src/Commands/CompareRevisions.cs
@@ -63,26 +63,8 @@ namespace SourceGit.Commands
 
             var change = new Models.Change() { Path = match.Groups[2].Value };
             var status = match.Groups[1].Value;
-
-            switch (status[0])
-            {
-                case 'M':
-                    change.Set(Models.ChangeState.Modified);
-                    outs.Add(change);
-                    break;
-                case 'A':
-                    change.Set(Models.ChangeState.Added);
-                    outs.Add(change);
-                    break;
-                case 'D':
-                    change.Set(Models.ChangeState.Deleted);
-                    outs.Add(change);
-                    break;
-                case 'C':
-                    change.Set(Models.ChangeState.Copied);
-                    outs.Add(change);
-                    break;
-            }
+            change.Set(Models.Change.ChangeStateFromCode(status[0]));
+            outs.Add(change);
         }
     }
 }

--- a/src/Commands/GitFlow.cs
+++ b/src/Commands/GitFlow.cs
@@ -30,21 +30,13 @@ namespace SourceGit.Commands
             start.WorkingDirectory = repo;
             start.Context = repo;
 
-            switch (type)
+            var typeStr = BranchTypeToString(type);
+            if (typeStr == null)
             {
-                case Models.GitFlowBranchType.Feature:
-                    start.Args = $"flow feature start {name}";
-                    break;
-                case Models.GitFlowBranchType.Release:
-                    start.Args = $"flow release start {name}";
-                    break;
-                case Models.GitFlowBranchType.Hotfix:
-                    start.Args = $"flow hotfix start {name}";
-                    break;
-                default:
-                    App.RaiseException(repo, "Bad git-flow branch type!!!");
-                    return false;
+                App.RaiseException(repo, "Bad git-flow branch type!!!");
+                return false;
             }
+            start.Args = $"flow {typeStr} start {name}";
 
             return await start.Use(log).ExecAsync().ConfigureAwait(false);
         }
@@ -54,21 +46,13 @@ namespace SourceGit.Commands
             var builder = new StringBuilder();
             builder.Append("flow ");
 
-            switch (type)
+            var typeStr = BranchTypeToString(type);
+            if (typeStr == null)
             {
-                case Models.GitFlowBranchType.Feature:
-                    builder.Append("feature");
-                    break;
-                case Models.GitFlowBranchType.Release:
-                    builder.Append("release");
-                    break;
-                case Models.GitFlowBranchType.Hotfix:
-                    builder.Append("hotfix");
-                    break;
-                default:
-                    App.RaiseException(repo, "Bad git-flow branch type!!!");
-                    return false;
+                App.RaiseException(repo, "Bad git-flow branch type!!!");
+                return false;
             }
+            builder.Append(typeStr);
 
             builder.Append(" finish ");
             if (squash)
@@ -85,5 +69,14 @@ namespace SourceGit.Commands
             finish.Args = builder.ToString();
             return await finish.Use(log).ExecAsync().ConfigureAwait(false);
         }
+
+        private static string BranchTypeToString(Models.GitFlowBranchType type) =>
+            type switch
+            {
+                Models.GitFlowBranchType.Feature => "feature",
+                Models.GitFlowBranchType.Release => "release",
+                Models.GitFlowBranchType.Hotfix => "hotfix",
+                _ => null
+            };
     }
 }

--- a/src/Commands/QueryLocalChanges.cs
+++ b/src/Commands/QueryLocalChanges.cs
@@ -38,120 +38,26 @@ namespace SourceGit.Commands
                 var change = new Models.Change() { Path = match.Groups[2].Value };
                 var status = match.Groups[1].Value;
 
-                switch (status)
+                change.ConflictReason = status switch
                 {
-                    case " M":
-                        change.Set(Models.ChangeState.None, Models.ChangeState.Modified);
-                        break;
-                    case " T":
-                        change.Set(Models.ChangeState.None, Models.ChangeState.TypeChanged);
-                        break;
-                    case " A":
-                        change.Set(Models.ChangeState.None, Models.ChangeState.Added);
-                        break;
-                    case " D":
-                        change.Set(Models.ChangeState.None, Models.ChangeState.Deleted);
-                        break;
-                    case " R":
-                        change.Set(Models.ChangeState.None, Models.ChangeState.Renamed);
-                        break;
-                    case " C":
-                        change.Set(Models.ChangeState.None, Models.ChangeState.Copied);
-                        break;
-                    case "M":
-                        change.Set(Models.ChangeState.Modified);
-                        break;
-                    case "MM":
-                        change.Set(Models.ChangeState.Modified, Models.ChangeState.Modified);
-                        break;
-                    case "MT":
-                        change.Set(Models.ChangeState.Modified, Models.ChangeState.TypeChanged);
-                        break;
-                    case "MD":
-                        change.Set(Models.ChangeState.Modified, Models.ChangeState.Deleted);
-                        break;
-                    case "T":
-                        change.Set(Models.ChangeState.TypeChanged);
-                        break;
-                    case "TM":
-                        change.Set(Models.ChangeState.TypeChanged, Models.ChangeState.Modified);
-                        break;
-                    case "TT":
-                        change.Set(Models.ChangeState.TypeChanged, Models.ChangeState.TypeChanged);
-                        break;
-                    case "TD":
-                        change.Set(Models.ChangeState.TypeChanged, Models.ChangeState.Deleted);
-                        break;
-                    case "A":
-                        change.Set(Models.ChangeState.Added);
-                        break;
-                    case "AM":
-                        change.Set(Models.ChangeState.Added, Models.ChangeState.Modified);
-                        break;
-                    case "AT":
-                        change.Set(Models.ChangeState.Added, Models.ChangeState.TypeChanged);
-                        break;
-                    case "AD":
-                        change.Set(Models.ChangeState.Added, Models.ChangeState.Deleted);
-                        break;
-                    case "D":
-                        change.Set(Models.ChangeState.Deleted);
-                        break;
-                    case "R":
-                        change.Set(Models.ChangeState.Renamed);
-                        break;
-                    case "RM":
-                        change.Set(Models.ChangeState.Renamed, Models.ChangeState.Modified);
-                        break;
-                    case "RT":
-                        change.Set(Models.ChangeState.Renamed, Models.ChangeState.TypeChanged);
-                        break;
-                    case "RD":
-                        change.Set(Models.ChangeState.Renamed, Models.ChangeState.Deleted);
-                        break;
-                    case "C":
-                        change.Set(Models.ChangeState.Copied);
-                        break;
-                    case "CM":
-                        change.Set(Models.ChangeState.Copied, Models.ChangeState.Modified);
-                        break;
-                    case "CT":
-                        change.Set(Models.ChangeState.Copied, Models.ChangeState.TypeChanged);
-                        break;
-                    case "CD":
-                        change.Set(Models.ChangeState.Copied, Models.ChangeState.Deleted);
-                        break;
-                    case "DD":
-                        change.ConflictReason = Models.ConflictReason.BothDeleted;
-                        change.Set(Models.ChangeState.None, Models.ChangeState.Conflicted);
-                        break;
-                    case "AU":
-                        change.ConflictReason = Models.ConflictReason.AddedByUs;
-                        change.Set(Models.ChangeState.None, Models.ChangeState.Conflicted);
-                        break;
-                    case "UD":
-                        change.ConflictReason = Models.ConflictReason.DeletedByThem;
-                        change.Set(Models.ChangeState.None, Models.ChangeState.Conflicted);
-                        break;
-                    case "UA":
-                        change.ConflictReason = Models.ConflictReason.AddedByThem;
-                        change.Set(Models.ChangeState.None, Models.ChangeState.Conflicted);
-                        break;
-                    case "DU":
-                        change.ConflictReason = Models.ConflictReason.DeletedByUs;
-                        change.Set(Models.ChangeState.None, Models.ChangeState.Conflicted);
-                        break;
-                    case "AA":
-                        change.ConflictReason = Models.ConflictReason.BothAdded;
-                        change.Set(Models.ChangeState.None, Models.ChangeState.Conflicted);
-                        break;
-                    case "UU":
-                        change.ConflictReason = Models.ConflictReason.BothModified;
-                        change.Set(Models.ChangeState.None, Models.ChangeState.Conflicted);
-                        break;
-                    case "??":
-                        change.Set(Models.ChangeState.None, Models.ChangeState.Untracked);
-                        break;
+                    "DD" => Models.ConflictReason.BothDeleted,
+                    "AU" => Models.ConflictReason.AddedByUs,
+                    "UD" => Models.ConflictReason.DeletedByThem,
+                    "UA" => Models.ConflictReason.AddedByThem,
+                    "DU" => Models.ConflictReason.DeletedByUs,
+                    "AA" => Models.ConflictReason.BothAdded,
+                    "UU" => Models.ConflictReason.BothModified,
+                    _ => Models.ConflictReason.None
+                };
+                if (change.ConflictReason != Models.ConflictReason.None)
+                    change.Set(Models.ChangeState.None, Models.ChangeState.Conflicted);
+                else if (status == "??")
+                    change.Set(Models.ChangeState.None, Models.ChangeState.Untracked);
+                else
+                {
+                    var indexStatus = Models.Change.ChangeStateFromCode(status[0]);
+                    var worktreeStatus = status.Length > 1 ? Models.Change.ChangeStateFromCode(status[1]) : Models.ChangeState.None;
+                    change.Set(indexStatus, worktreeStatus);
                 }
 
                 if (change.Index != Models.ChangeState.None || change.WorkTree != Models.ChangeState.None)

--- a/src/Commands/QueryStagedChangesWithAmend.cs
+++ b/src/Commands/QueryStagedChangesWithAmend.cs
@@ -63,24 +63,7 @@ namespace SourceGit.Commands
                     };
 
                     var type = match.Groups[3].Value;
-                    switch (type)
-                    {
-                        case "A":
-                            change.Set(Models.ChangeState.Added);
-                            break;
-                        case "C":
-                            change.Set(Models.ChangeState.Copied);
-                            break;
-                        case "D":
-                            change.Set(Models.ChangeState.Deleted);
-                            break;
-                        case "M":
-                            change.Set(Models.ChangeState.Modified);
-                            break;
-                        case "T":
-                            change.Set(Models.ChangeState.TypeChanged);
-                            break;
-                    }
+                    change.Set(Models.Change.ChangeStateFromCode(type[0]));
                     changes.Add(change);
                 }
             }

--- a/src/Commands/QuerySubmodules.cs
+++ b/src/Commands/QuerySubmodules.cs
@@ -40,22 +40,15 @@ namespace SourceGit.Commands
                     var path = match.Groups[3].Value;
 
                     var module = new Models.Submodule() { Path = path, SHA = sha };
-                    switch (stat[0])
+                    module.Status = stat[0] switch
                     {
-                        case '-':
-                            module.Status = Models.SubmoduleStatus.NotInited;
-                            break;
-                        case '+':
-                            module.Status = Models.SubmoduleStatus.RevisionChanged;
-                            break;
-                        case 'U':
-                            module.Status = Models.SubmoduleStatus.Unmerged;
-                            break;
-                        default:
-                            module.Status = Models.SubmoduleStatus.Normal;
-                            needCheckLocalChanges = true;
-                            break;
-                    }
+                        '-' => Models.SubmoduleStatus.NotInited,
+                        '+' => Models.SubmoduleStatus.RevisionChanged,
+                        'U' => Models.SubmoduleStatus.Unmerged,
+                        _ => Models.SubmoduleStatus.Normal
+                    };
+                    if (module.Status == Models.SubmoduleStatus.Normal)
+                        needCheckLocalChanges = true;
 
                     map.Add(path, module);
                     submodules.Add(module);

--- a/src/Models/Change.cs
+++ b/src/Models/Change.cs
@@ -113,5 +113,18 @@
             "Both added",
             "Both modified"
         ];
+
+        public static ChangeState ChangeStateFromCode(char code) =>
+            code switch
+            {
+                'M' => ChangeState.Modified,
+                'T' => ChangeState.TypeChanged,
+                'A' => ChangeState.Added,
+                'D' => ChangeState.Deleted,
+                'R' => ChangeState.Renamed,
+                'C' => ChangeState.Copied,
+                'U' => ChangeState.Untracked,
+                _ => ChangeState.None,
+            };
     }
 }

--- a/src/Models/DiffOption.cs
+++ b/src/Models/DiffOption.cs
@@ -34,13 +34,10 @@ namespace SourceGit.Models
 
             if (isUnstaged)
             {
-                switch (change.WorkTree)
+                if (change.WorkTree is ChangeState.Added or ChangeState.Untracked)
                 {
-                    case ChangeState.Added:
-                    case ChangeState.Untracked:
-                        _extra = "--no-index";
-                        _orgPath = "/dev/null";
-                        break;
+                    _extra = "--no-index";
+                    _orgPath = "/dev/null";
                 }
             }
             else

--- a/src/ViewModels/Conflict.cs
+++ b/src/ViewModels/Conflict.cs
@@ -71,33 +71,24 @@ namespace SourceGit.ViewModels
                 IsResolved = new Commands.IsConflictResolved(repo.FullPath, change).GetResultAsync().Result;
             }
 
-            switch (wc.InProgressContext)
+            if (wc.InProgressContext is RebaseInProgress rebase)
             {
-                case CherryPickInProgress cherryPick:
-                    Theirs = cherryPick.Head;
-                    Mine = new ConflictSourceBranch(repo, repo.CurrentBranch);
-                    break;
-                case RebaseInProgress rebase:
-                    var b = repo.Branches.Find(x => x.IsLocal && x.Name == rebase.HeadName);
-                    if (b != null)
-                        Theirs = new ConflictSourceBranch(b.Name, b.Head, rebase.StoppedAt);
-                    else
-                        Theirs = new ConflictSourceBranch(rebase.HeadName, rebase.StoppedAt?.SHA ?? "----------", rebase.StoppedAt);
-
-                    Mine = rebase.Onto;
-                    break;
-                case RevertInProgress revert:
-                    Theirs = revert.Head;
-                    Mine = new ConflictSourceBranch(repo, repo.CurrentBranch);
-                    break;
-                case MergeInProgress merge:
-                    Theirs = merge.Source;
-                    Mine = new ConflictSourceBranch(repo, repo.CurrentBranch);
-                    break;
-                default:
-                    Theirs = "Stash or Patch";
-                    Mine = new ConflictSourceBranch(repo, repo.CurrentBranch);
-                    break;
+                var b = repo.Branches.Find(x => x.IsLocal && x.Name == rebase.HeadName);
+                Theirs = b != null
+                    ? new ConflictSourceBranch(b.Name, b.Head, rebase.StoppedAt)
+                    : new ConflictSourceBranch(rebase.HeadName, rebase.StoppedAt?.SHA ?? "----------", rebase.StoppedAt);
+                Mine = rebase.Onto;
+            }
+            else
+            {
+                Theirs = wc.InProgressContext switch
+                {
+                    CherryPickInProgress cherryPick => cherryPick.Head,
+                    RevertInProgress revert => revert.Head,
+                    MergeInProgress merge => merge.Source,
+                    _ => "Stash or Patch"
+                };
+                Mine = new ConflictSourceBranch(repo, repo.CurrentBranch);
             }
         }
 

--- a/src/ViewModels/ExecuteCustomAction.cs
+++ b/src/ViewModels/ExecuteCustomAction.cs
@@ -182,21 +182,13 @@ namespace SourceGit.ViewModels
         {
             foreach (var ctl in CustomAction.Controls)
             {
-                switch (ctl.Type)
+                ControlParameters.Add(ctl.Type switch
                 {
-                    case Models.CustomActionControlType.TextBox:
-                        ControlParameters.Add(new CustomActionControlTextBox(ctl.Label, ctl.Description, PrepareStringByTarget(ctl.StringValue)));
-                        break;
-                    case Models.CustomActionControlType.PathSelector:
-                        ControlParameters.Add(new CustomActionControlPathSelector(ctl.Label, ctl.Description, ctl.BoolValue, PrepareStringByTarget(ctl.StringValue)));
-                        break;
-                    case Models.CustomActionControlType.CheckBox:
-                        ControlParameters.Add(new CustomActionControlCheckBox(ctl.Label, ctl.Description, ctl.StringValue, ctl.BoolValue));
-                        break;
-                    case Models.CustomActionControlType.ComboBox:
-                        ControlParameters.Add(new CustomActionControlComboBox(ctl.Label, ctl.Description, PrepareStringByTarget(ctl.StringValue)));
-                        break;
-                }
+                    Models.CustomActionControlType.PathSelector => new CustomActionControlPathSelector(ctl.Label, ctl.Description, ctl.BoolValue, PrepareStringByTarget(ctl.StringValue)),
+                    Models.CustomActionControlType.CheckBox => new CustomActionControlCheckBox(ctl.Label, ctl.Description, ctl.StringValue, ctl.BoolValue),
+                    Models.CustomActionControlType.ComboBox => new CustomActionControlComboBox(ctl.Label, ctl.Description, PrepareStringByTarget(ctl.StringValue)),
+                    _ => new CustomActionControlTextBox(ctl.Label, ctl.Description, PrepareStringByTarget(ctl.StringValue))
+                });
             }
         }
 

--- a/src/ViewModels/Repository.cs
+++ b/src/ViewModels/Repository.cs
@@ -2849,15 +2849,10 @@ namespace SourceGit.ViewModels
 
         private object BuildVisibleTags()
         {
-            switch (_settings.TagSortMode)
-            {
-                case Models.TagSortMode.CreatorDate:
-                    _tags.Sort((l, r) => r.CreatorDate.CompareTo(l.CreatorDate));
-                    break;
-                default:
-                    _tags.Sort((l, r) => Models.NumericSort.Compare(l.Name, r.Name));
-                    break;
-            }
+            if (_settings.TagSortMode == Models.TagSortMode.CreatorDate)
+                _tags.Sort((l, r) => r.CreatorDate.CompareTo(l.CreatorDate));
+            else
+                _tags.Sort((l, r) => Models.NumericSort.Compare(l.Name, r.Name));
 
             var visible = new List<Models.Tag>();
             if (string.IsNullOrEmpty(_filter))

--- a/src/Views/CommitRefsPresenter.cs
+++ b/src/Views/CommitRefsPresenter.cs
@@ -208,30 +208,19 @@ namespace SourceGit.Views
                     var item = new RenderItem()
                     {
                         Label = label,
-                        Brush = normalBG,
+                        Brush = decorator.Type == Models.DecoratorType.Tag ? Brushes.Gray : normalBG,
                         IsHead = isHead,
                         Decorator = decorator,
                     };
 
-                    StreamGeometry geo;
-                    switch (decorator.Type)
+                    var key = decorator.Type switch
                     {
-                        case Models.DecoratorType.CurrentBranchHead:
-                        case Models.DecoratorType.CurrentCommitHead:
-                            geo = this.FindResource("Icons.Head") as StreamGeometry;
-                            break;
-                        case Models.DecoratorType.RemoteBranchHead:
-                            geo = this.FindResource("Icons.Remote") as StreamGeometry;
-                            break;
-                        case Models.DecoratorType.Tag:
-                            item.Brush = Brushes.Gray;
-                            geo = this.FindResource("Icons.Tag") as StreamGeometry;
-                            break;
-                        default:
-                            geo = this.FindResource("Icons.Branch") as StreamGeometry;
-                            break;
-                    }
-
+                        Models.DecoratorType.CurrentBranchHead or Models.DecoratorType.CurrentCommitHead => "Icons.Head",
+                        Models.DecoratorType.RemoteBranchHead => "Icons.Remote",
+                        Models.DecoratorType.Tag => "Icons.Tag",
+                        _ => "Icons.Branch"
+                    };
+                    var geo = this.FindResource(key) as StreamGeometry;
                     var drawGeo = geo!.Clone();
                     var iconBounds = drawGeo.Bounds;
                     var translation = Matrix.CreateTranslation(-(Vector)iconBounds.Position);


### PR DESCRIPTION
Switch expressions provide a nice compact way to convert values, especially to/from enums.
This PR introduces switch expressions where they make sense, in particular a new `Models.Change.ChangeStateFromCode` function (feel free to rename) that dramatically simplifies the `QueryLocalChanges` command.