### PR TITLE
enhance: only navigate to upstream if current not ahead post-fetch

### DIFF
--- a/src/ViewModels/Fetch.cs
+++ b/src/ViewModels/Fetch.cs
@@ -80,7 +80,7 @@ namespace SourceGit.ViewModels
             log.Complete();
 
             var upstream = _repo.CurrentBranch?.Upstream;
-            if (!string.IsNullOrEmpty(upstream))
+            if (!string.IsNullOrEmpty(upstream) && _repo.CurrentBranch.TrackStatus.Ahead.Count == 0)
             {
                 var upstreamHead = await new Commands.QueryRevisionByRefName(_repo.FullPath, upstream.Substring(13)).GetResultAsync();
                 _repo.NavigateToCommit(upstreamHead, true);


### PR DESCRIPTION
#1127 and #1180 introduced an annoying behavior when working in a branch that tracks an inactive upstream fork. Whenever I fetch latest, the history list scrolls down to the tracking branch even when the local branch is way ahead and no new changes were found for that tracking branch.

I don't know the ideal permanent solution to this, but this PR introduces an extra check to bypass history navigation if the current branch is ahead of the tracking branch. I'm not sure what should be selected post-fetch if there's a mixture of local and remote changes (ie, `Ahead.Count` and `Behind.Count` are non-zero).