### PR TITLE
Add SimplifyByDecoration mode for commit filtering

### DIFF
--- a/src/Models/RepositorySettings.cs
+++ b/src/Models/RepositorySettings.cs
@@ -14,6 +14,12 @@ namespace SourceGit.Models
             set;
         } = string.Empty;
 
+        public bool SimplifyByDecoration
+        {
+            get;
+            set;
+        } = false;
+
         public bool EnableReflog
         {
             get;

--- a/src/Resources/Locales/en_US.axaml
+++ b/src/Resources/Locales/en_US.axaml
@@ -670,6 +670,7 @@
   <x:String x:Key="Text.Repository.Search.InCurrentBranch" xml:space="preserve">Current Branch</x:String>
   <x:String x:Key="Text.Repository.ShowFirstParentOnly" xml:space="preserve">Show first-parent only</x:String>
   <x:String x:Key="Text.Repository.ShowLostCommits" xml:space="preserve">Show lost commits</x:String>
+  <x:String x:Key="Text.Repository.SimplifyByDecoration" xml:space="preserve">Show Decorate Commits Only</x:String>
   <x:String x:Key="Text.Repository.ShowSubmodulesAsTree" xml:space="preserve">Show Submodules as Tree</x:String>
   <x:String x:Key="Text.Repository.ShowTagsAsTree" xml:space="preserve">Show Tags as Tree</x:String>
   <x:String x:Key="Text.Repository.Skip" xml:space="preserve">SKIP</x:String>

--- a/src/ViewModels/Repository.cs
+++ b/src/ViewModels/Repository.cs
@@ -91,6 +91,20 @@ namespace SourceGit.ViewModels
             set => SetProperty(ref _selectedView, value);
         }
 
+        public bool SimplifyByDecoration
+        {
+            get => _settings.SimplifyByDecoration;
+            set
+            {
+                if (value != _settings.SimplifyByDecoration)
+                {
+                    _settings.SimplifyByDecoration = value;
+                    OnPropertyChanged();
+                    Task.Run(RefreshCommits);
+                }
+            }
+        }
+
         public bool EnableReflog
         {
             get => _settings.EnableReflog;
@@ -1271,6 +1285,9 @@ namespace SourceGit.ViewModels
                 builder.Append("--reflog ");
             if (_settings.EnableFirstParentInHistories)
                 builder.Append("--first-parent ");
+            // only show commits with decorators
+            if (_settings.SimplifyByDecoration)
+                builder.Append("--simplify-by-decoration ");
 
             var filters = _settings.BuildHistoriesFilter();
             if (string.IsNullOrEmpty(filters))

--- a/src/Views/Repository.axaml
+++ b/src/Views/Repository.axaml
@@ -83,7 +83,7 @@
               </ListBox.ItemsPanel>
 
               <ListBoxItem>
-                <Grid Classes="view_mode" ColumnDefinitions="Auto,*,Auto,Auto,Auto,Auto,Auto">
+                <Grid Classes="view_mode" ColumnDefinitions="Auto,*,Auto,Auto,Auto,Auto,Auto,Auto">
                   <Path Grid.Column="0" Classes="icon" Data="{StaticResource Icons.Histories}"/>
                   <TextBlock Grid.Column="1" Classes="header" Text="{DynamicResource Text.Histories}"/>
 
@@ -131,7 +131,21 @@
                                 ToolTip.Tip="{DynamicResource Text.Repository.UseRelativeTimeInGraph}">
                     <Path Width="12" Height="12" Data="{StaticResource Icons.Stopwatch}"/>
                   </ToggleButton>
-                  <Button Grid.Column="6"
+                  <ToggleButton Grid.Column="6"
+                                Classes="line_path"
+                                Width="26" Height="26"
+                                Background="Transparent"
+                                IsChecked="{Binding SimplifyByDecoration, Mode=TwoWay}">
+                      <ToolTip.Tip>
+                        <TextBlock>
+                          <Run Text="{DynamicResource Text.Repository.SimplifyByDecoration}"/>
+                          <Run Text=" "/>
+                          <Run Text="--simplify-by-decoration" FontSize="11" Foreground="{DynamicResource MenuFlyoutItemKeyboardAcceleratorTextForeground}"/>
+                        </TextBlock>
+                      </ToolTip.Tip>
+                      <Path Width="12" Height="12" Data="{StaticResource Icons.Tree}"/>
+                    </ToggleButton>
+                  <Button Grid.Column="7"
                           Classes="icon_button"
                           Width="26" Height="26"
                           Click="OnOpenAdvancedHistoriesOption">

--- a/src/Views/Repository.axaml
+++ b/src/Views/Repository.axaml
@@ -83,59 +83,14 @@
               </ListBox.ItemsPanel>
 
               <ListBoxItem>
-                <Grid Classes="view_mode" ColumnDefinitions="Auto,*,Auto,Auto,Auto,Auto,Auto,Auto">
+                <Grid Classes="view_mode" ColumnDefinitions="Auto,*,Auto,Auto">
                   <Path Grid.Column="0" Classes="icon" Data="{StaticResource Icons.Histories}"/>
                   <TextBlock Grid.Column="1" Classes="header" Text="{DynamicResource Text.Histories}"/>
-
-                  <ToggleButton Grid.Column="2"
-                                Classes="line_path"
-                                Width="26" Height="26"
-                                Background="Transparent"
-                                IsChecked="{Binding EnableReflog, Mode=TwoWay}">
-                    <ToolTip.Tip>
-                      <TextBlock>
-                        <Run Text="{DynamicResource Text.Repository.ShowLostCommits}"/>
-                        <Run Text=" "/>
-                        <Run Text="--reflog" FontSize="11" Foreground="{DynamicResource MenuFlyoutItemKeyboardAcceleratorTextForeground}"/>
-                      </TextBlock>
-                    </ToolTip.Tip>
-                    <Path Width="12" Height="12" Data="{StaticResource Icons.Reference}"/>
-                  </ToggleButton>
-                  <ToggleButton Grid.Column="3"
-                                Classes="line_path"
-                                Width="26" Height="26"
-                                Background="Transparent"
-                                IsChecked="{Binding EnableFirstParentInHistories, Mode=TwoWay}">
-                    <ToolTip.Tip>
-                      <TextBlock>
-                        <Run Text="{DynamicResource Text.Repository.ShowFirstParentOnly}"/>
-                        <Run Text=" "/>
-                        <Run Text="--first-parent" FontSize="11" Foreground="{DynamicResource MenuFlyoutItemKeyboardAcceleratorTextForeground}"/>
-                      </TextBlock>
-                    </ToolTip.Tip>
-                    <Path Width="12" Height="12" Data="{StaticResource Icons.FirstParentFilter}"/>
-                  </ToggleButton>
-                  <ToggleButton Grid.Column="4"
-                                Classes="line_path"
-                                Width="26" Height="26"
-                                Background="Transparent"
-                                IsChecked="{Binding OnlyHighlightCurrentBranchInHistories, Mode=TwoWay}"
-                                ToolTip.Tip="{DynamicResource Text.Repository.OnlyHighlightCurrentBranchInGraph}">
-                    <Path Width="12" Height="12" Data="{StaticResource Icons.LightOn}"/>
-                  </ToggleButton>
-                  <ToggleButton Grid.Column="5"
-                                Classes="line_path"
-                                Width="26" Height="26"
-                                Background="Transparent"
-                                IsChecked="{Binding Source={x:Static vm:Preferences.Instance}, Path=DisplayTimeAsPeriodInHistories, Mode=TwoWay}"
-                                ToolTip.Tip="{DynamicResource Text.Repository.UseRelativeTimeInGraph}">
-                    <Path Width="12" Height="12" Data="{StaticResource Icons.Stopwatch}"/>
-                  </ToggleButton>
-                  <ToggleButton Grid.Column="6"
-                                Classes="line_path"
-                                Width="26" Height="26"
-                                Background="Transparent"
-                                IsChecked="{Binding SimplifyByDecoration, Mode=TwoWay}">
+                  <StackPanel Grid.Column="2" Orientation="Horizontal">
+                    <ToggleButton Classes="line_path"
+                                  Width="26" Height="26"
+                                  Background="Transparent"
+                                  IsChecked="{Binding SimplifyByDecoration, Mode=TwoWay}">
                       <ToolTip.Tip>
                         <TextBlock>
                           <Run Text="{DynamicResource Text.Repository.SimplifyByDecoration}"/>
@@ -145,7 +100,48 @@
                       </ToolTip.Tip>
                       <Path Width="12" Height="12" Data="{StaticResource Icons.Tree}"/>
                     </ToggleButton>
-                  <Button Grid.Column="7"
+                    <ToggleButton Classes="line_path"
+                                  Width="26" Height="26"
+                                  Background="Transparent"
+                                  IsChecked="{Binding EnableReflog, Mode=TwoWay}">
+                      <ToolTip.Tip>
+                        <TextBlock>
+                          <Run Text="{DynamicResource Text.Repository.ShowLostCommits}"/>
+                          <Run Text=" "/>
+                          <Run Text="--reflog" FontSize="11" Foreground="{DynamicResource MenuFlyoutItemKeyboardAcceleratorTextForeground}"/>
+                        </TextBlock>
+                      </ToolTip.Tip>
+                      <Path Width="12" Height="12" Data="{StaticResource Icons.Reference}"/>
+                    </ToggleButton>
+                    <ToggleButton Classes="line_path"
+                                  Width="26" Height="26"
+                                  Background="Transparent"
+                                  IsChecked="{Binding EnableFirstParentInHistories, Mode=TwoWay}">
+                      <ToolTip.Tip>
+                        <TextBlock>
+                          <Run Text="{DynamicResource Text.Repository.ShowFirstParentOnly}"/>
+                          <Run Text=" "/>
+                          <Run Text="--first-parent" FontSize="11" Foreground="{DynamicResource MenuFlyoutItemKeyboardAcceleratorTextForeground}"/>
+                        </TextBlock>
+                      </ToolTip.Tip>
+                      <Path Width="12" Height="12" Data="{StaticResource Icons.FirstParentFilter}"/>
+                    </ToggleButton>
+                    <ToggleButton Classes="line_path"
+                                  Width="26" Height="26"
+                                  Background="Transparent"
+                                  IsChecked="{Binding OnlyHighlightCurrentBranchInHistories, Mode=TwoWay}"
+                                  ToolTip.Tip="{DynamicResource Text.Repository.OnlyHighlightCurrentBranchInGraph}">
+                      <Path Width="12" Height="12" Data="{StaticResource Icons.LightOn}"/>
+                    </ToggleButton>
+                    <ToggleButton Classes="line_path"
+                                  Width="26" Height="26"
+                                  Background="Transparent"
+                                  IsChecked="{Binding Source={x:Static vm:Preferences.Instance}, Path=DisplayTimeAsPeriodInHistories, Mode=TwoWay}"
+                                  ToolTip.Tip="{DynamicResource Text.Repository.UseRelativeTimeInGraph}">
+                      <Path Width="12" Height="12" Data="{StaticResource Icons.Stopwatch}"/>
+                    </ToggleButton>
+                  </StackPanel>
+                  <Button Grid.Column="3"
                           Classes="icon_button"
                           Width="26" Height="26"
                           Click="OnOpenAdvancedHistoriesOption">


### PR DESCRIPTION
Introduce a new mode to display only commits with decorators, enhancing the usability for large projects with numerous commits. This feature allows users to filter the commit graph, making it easier to manage and visualize relevant nodes, especially during version releases.

Fixes #1595