### PR TITLE
feat: remember fetch all remotes property(fixes #1647)

### DIFF
--- a/src/Models/RepositorySettings.cs
+++ b/src/Models/RepositorySettings.cs
@@ -62,6 +62,12 @@ namespace SourceGit.Models
             set;
         } = false;
 
+        public bool FetchAllRemotes
+        {
+            get;
+            set;
+        } = false;
+
         public bool FetchWithoutTags
         {
             get;

--- a/src/ViewModels/Fetch.cs
+++ b/src/ViewModels/Fetch.cs
@@ -18,9 +18,13 @@ namespace SourceGit.ViewModels
 
         public bool FetchAllRemotes
         {
-            get;
-            set;
-        } = false;
+            get => _fetchAllRemotes;
+            set
+            {
+                _repo.Settings.FetchAllRemotes = value;
+                SetProperty(ref _fetchAllRemotes, value);
+            }
+        }
 
         public Models.Remote SelectedRemote
         {
@@ -44,6 +48,7 @@ namespace SourceGit.ViewModels
         {
             _repo = repo;
             IsFetchAllRemoteVisible = repo.Remotes.Count > 1 && preferredRemote == null;
+            _fetchAllRemotes = _repo.Settings.FetchAllRemotes;
 
             if (preferredRemote != null)
             {
@@ -66,10 +71,11 @@ namespace SourceGit.ViewModels
 
             var notags = _repo.Settings.FetchWithoutTags;
             var force = _repo.Settings.EnableForceOnFetch;
+            var all = _repo.Settings.FetchAllRemotes;
             var log = _repo.CreateLog("Fetch");
             Use(log);
 
-            if (FetchAllRemotes)
+            if (all)
             {
                 foreach (var remote in _repo.Remotes)
                     await new Commands.Fetch(_repo.FullPath, remote.Name, notags, force)
@@ -98,5 +104,6 @@ namespace SourceGit.ViewModels
         }
 
         private readonly Repository _repo = null;
+        private bool _fetchAllRemotes;
     }
 }


### PR DESCRIPTION
- Add a new property to enable fetching all remotes by default.
- Refactor fetch logic to use repository settings directly instead of local properties.