### PR TITLE
Solo commits filter

### DIFF
--- a/src/Commands/QueryCommits.cs
+++ b/src/Commands/QueryCommits.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -7,12 +8,13 @@ namespace SourceGit.Commands
 {
     public class QueryCommits : Command
     {
-        public QueryCommits(string repo, string limits, bool needFindHead = true)
+        public QueryCommits(string repo, string limits, bool needFindHead = true, List<string> patterns = null)
         {
             WorkingDirectory = repo;
             Context = repo;
             Args = $"log --no-show-signature --decorate=full --format=%H%n%P%n%D%n%aN±%aE%n%at%n%cN±%cE%n%ct%n%s {limits}";
             _findFirstMerged = needFindHead;
+            _patterns = patterns ?? new List<string>();
         }
 
         public QueryCommits(string repo, string filter, Models.CommitSearchMethod method, bool onlyCurrentBranch)
@@ -70,6 +72,7 @@ namespace SourceGit.Commands
                 {
                     case 0:
                         _current = new Models.Commit() { SHA = line };
+                        _current.IsCommitFilterHead = _patterns.Count > 0 && _patterns.Any(f => line.StartsWith(f));
                         _commits.Add(_current);
                         break;
                     case 1:
@@ -143,6 +146,7 @@ namespace SourceGit.Commands
         }
 
         private List<Models.Commit> _commits = new List<Models.Commit>();
+        private List<string> _patterns = new List<string>();
         private Models.Commit _current = null;
         private bool _findFirstMerged = false;
         private bool _isHeadFound = false;

--- a/src/Models/Commit.cs
+++ b/src/Models/Commit.cs
@@ -42,6 +42,7 @@ namespace SourceGit.Models
         public string AuthorTimeShortStr => DateTime.UnixEpoch.AddSeconds(AuthorTime).ToLocalTime().ToString(DateTimeFormat.Active.DateOnly);
         public string CommitterTimeShortStr => DateTime.UnixEpoch.AddSeconds(CommitterTime).ToLocalTime().ToString(DateTimeFormat.Active.DateOnly);
 
+        public bool IsCommitFilterHead { get; set; } = false;
         public bool IsMerged { get; set; } = false;
         public bool IsCommitterVisible => !Author.Equals(Committer) || AuthorTime != CommitterTime;
         public bool IsCurrentHead => Decorators.Find(x => x.Type is DecoratorType.CurrentBranchHead or DecoratorType.CurrentCommitHead) != null;

--- a/src/Models/CommitGraph.cs
+++ b/src/Models/CommitGraph.cs
@@ -53,6 +53,7 @@ namespace SourceGit.Models
             Default,
             Head,
             Merge,
+            Filter,
         }
 
         public class Dot
@@ -157,7 +158,9 @@ namespace SourceGit.Models
                 var position = new Point(major?.LastX ?? offsetX, offsetY);
                 var dotColor = major?.Path.Color ?? 0;
                 var anchor = new Dot() { Center = position, Color = dotColor, IsMerged = isMerged };
-                if (commit.IsCurrentHead)
+                if (commit.IsCommitFilterHead)
+                    anchor.Type = DotType.Filter;
+                else if (commit.IsCurrentHead)
                     anchor.Type = DotType.Head;
                 else if (commit.Parents.Count > 1)
                     anchor.Type = DotType.Merge;

--- a/src/Models/Filter.cs
+++ b/src/Models/Filter.cs
@@ -9,6 +9,7 @@ namespace SourceGit.Models
         RemoteBranch,
         RemoteBranchFolder,
         Tag,
+        SoloCommits,
     }
 
     public enum FilterMode

--- a/src/Models/RepositorySettings.cs
+++ b/src/Models/RepositorySettings.cs
@@ -306,7 +306,7 @@ namespace SourceGit.Models
                 HistoriesFilters.Remove(filter);
         }
 
-        public string BuildHistoriesFilter()
+        public string BuildHistoriesFilter(SourceGit.ViewModels.Repository repo)
         {
             var includedRefs = new List<string>();
             var excludedBranches = new List<string>();
@@ -348,6 +348,34 @@ namespace SourceGit.Models
                         includedRefs.Add($"refs/tags/{filter.Pattern}");
                     else if (filter.Mode == FilterMode.Excluded)
                         excludedTags.Add($"--exclude=\"{filter.Pattern}\" --decorate-refs-exclude=\"refs/tags/{filter.Pattern}\"");
+                }
+                else if (filter.Type == FilterType.SoloCommits)
+                {
+                    var allRefs = repo.GetRefsContainsThisCommit(filter.Pattern);
+                    if (filter.Mode == FilterMode.Included)
+                    {
+                        foreach (var refItem in allRefs)
+                        {
+                            if (refItem.Type == Models.DecoratorType.LocalBranchHead)
+                                includedRefs.Add($"{refItem.Name}");
+                            else if (refItem.Type == Models.DecoratorType.RemoteBranchHead)
+                                includedRefs.Add($"{refItem.Name}");
+                            else if (refItem.Type == Models.DecoratorType.Tag)
+                                includedRefs.Add($"refs/tags/{refItem.Name}");
+                        }
+                    }
+                    else if (filter.Mode == FilterMode.Excluded)
+                    {
+                        foreach (var refItem in allRefs)
+                        {
+                            if (refItem.Type == Models.DecoratorType.LocalBranchHead)
+                                excludedBranches.Add($"--exclude=\"{refItem.Name}\" --decorate-refs-exclude=\"refs/heads/{refItem.Name}\"");
+                            else if (refItem.Type == Models.DecoratorType.RemoteBranchHead)
+                                excludedRemotes.Add($"--exclude=\"{refItem.Name}\" --decorate-refs-exclude=\"refs/remotes/{refItem.Name}\"");
+                            else if (refItem.Type == Models.DecoratorType.Tag)
+                                excludedTags.Add($"--exclude=\"refs/tags/{refItem.Name}\" --decorate-refs-exclude=\"refs/tags/{refItem.Name}\"");
+                        }
+                    }
                 }
             }
 

--- a/src/Resources/Locales/en_US.axaml
+++ b/src/Resources/Locales/en_US.axaml
@@ -126,6 +126,7 @@
   <x:String x:Key="Text.CommitCM.CopySHA" xml:space="preserve">SHA</x:String>
   <x:String x:Key="Text.CommitCM.CopySubject" xml:space="preserve">Subject</x:String>
   <x:String x:Key="Text.CommitCM.CustomAction" xml:space="preserve">Custom Action</x:String>
+  <x:String x:Key="Text.CommitCM.SoloCommits" xml:space="preserve">Solo on Current Commit</x:String>
   <x:String x:Key="Text.CommitCM.InteractiveRebase" xml:space="preserve">Interactive Rebase</x:String>
   <x:String x:Key="Text.CommitCM.InteractiveRebase.Drop" xml:space="preserve">Drop...</x:String>
   <x:String x:Key="Text.CommitCM.InteractiveRebase.Edit" xml:space="preserve">Edit...</x:String>

--- a/src/Resources/Locales/en_US.axaml
+++ b/src/Resources/Locales/en_US.axaml
@@ -655,6 +655,7 @@
   <x:String x:Key="Text.Repository.LocalBranches" xml:space="preserve">LOCAL BRANCHES</x:String>
   <x:String x:Key="Text.Repository.MoreOptions" xml:space="preserve">More options...</x:String>
   <x:String x:Key="Text.Repository.NavigateToCurrentHead" xml:space="preserve">Navigate to HEAD</x:String>
+  <x:String x:Key="Text.Repository.SoloModeOnCurrentHead" xml:space="preserve">Solo On HEAD</x:String>
   <x:String x:Key="Text.Repository.NewBranch" xml:space="preserve">Create Branch</x:String>
   <x:String x:Key="Text.Repository.Notifications.Clear" xml:space="preserve">CLEAR NOTIFICATIONS</x:String>
   <x:String x:Key="Text.Repository.OnlyHighlightCurrentBranchInGraph" xml:space="preserve">Only highlight current branch</x:String>

--- a/src/ViewModels/Checkout.cs
+++ b/src/ViewModels/Checkout.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System.Linq;
+using System.Threading.Tasks;
 
 namespace SourceGit.ViewModels
 {
@@ -102,7 +103,8 @@ namespace SourceGit.ViewModels
             log.Complete();
 
             var b = _repo.Branches.Find(x => x.IsLocal && x.Name == Branch);
-            if (b != null && _repo.HistoriesFilterMode == Models.FilterMode.Included)
+            if (b != null && _repo.HistoriesFilterMode == Models.FilterMode.Included
+                && !_repo.Settings.HistoriesFilters.Any(f => f.Pattern == "HEAD"))
                 _repo.SetBranchFilterMode(b, Models.FilterMode.Included, true, false);
 
             _repo.MarkBranchesDirtyManually();

--- a/src/ViewModels/Histories.cs
+++ b/src/ViewModels/Histories.cs
@@ -2,6 +2,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 
 using Avalonia.Controls;
@@ -42,6 +43,12 @@ namespace SourceGit.ViewModels
         {
             get => _autoSelectedCommit;
             set => SetProperty(ref _autoSelectedCommit, value);
+        }
+
+        public List<Models.Commit> LastSelectedCommits
+        {
+            get => _lastSelectedCommits;
+            private set => SetProperty(ref _lastSelectedCommits, value);
         }
 
         public long NavigationId
@@ -191,6 +198,13 @@ namespace SourceGit.ViewModels
                 _repo.SelectedSearchedCommit = null;
                 DetailContext = new Models.Count(commits.Count);
             }
+
+            _repo.SelectedCommits = commits.Cast<Models.Commit>().ToList();
+        }
+
+        public void MarkCommitsAsSelected(IList<Models.Commit> commits)
+        {
+            LastSelectedCommits = _commits.Where(x => commits.Any(y => y.SHA == x.SHA)).ToList();
         }
 
         public bool CheckoutBranchByDecorator(Models.Decorator decorator)
@@ -402,6 +416,7 @@ namespace SourceGit.ViewModels
         private Repository _repo = null;
         private bool _isLoading = true;
         private List<Models.Commit> _commits = new List<Models.Commit>();
+        private List<Models.Commit> _lastSelectedCommits = [];
         private Models.CommitGraph _graph = null;
         private Models.Commit _autoSelectedCommit = null;
         private Models.Bisect _bisect = null;

--- a/src/ViewModels/Repository.cs
+++ b/src/ViewModels/Repository.cs
@@ -1062,6 +1062,17 @@ namespace SourceGit.ViewModels
             if (changed)
                 RefreshHistoriesFilters(true);
         }
+        public void SetSoloCommitFilterMode(Models.Commit commit, Models.FilterMode mode)
+        {
+            SetSoloCommitFilterMode(commit.SHA[..10], mode);
+        }
+
+        public void SetSoloCommitFilterMode(string sha, Models.FilterMode mode)
+        {
+            var changed = _settings.UpdateHistoriesFilter(sha, Models.FilterType.SoloCommits, mode);
+            if (changed)
+                RefreshHistoriesFilters(true);
+        }
 
         public void SetBranchFilterMode(Models.Branch branch, Models.FilterMode mode, bool clearExists, bool refresh)
         {
@@ -1257,6 +1268,13 @@ namespace SourceGit.ViewModels
             });
         }
 
+        public List<Models.Decorator> GetRefsContainsThisCommit(string hash = null)
+        {
+            var a = new Commands.QueryRefsContainsCommit(FullPath, hash ?? "HEAD")
+                .GetResultAsync();
+            return a.Result;
+        }
+
         public void RefreshCommits()
         {
             Dispatcher.UIThread.Invoke(() => _histories.IsLoading = true);
@@ -1278,7 +1296,7 @@ namespace SourceGit.ViewModels
             if (_settings.HistoryShowFlags.HasFlag(Models.HistoryShowFlags.SimplifyByDecoration))
                 builder.Append("--simplify-by-decoration ");
 
-            var filters = _settings.BuildHistoriesFilter();
+            var filters = _settings.BuildHistoriesFilter(this);
             if (string.IsNullOrEmpty(filters))
                 builder.Append("--branches --remotes --tags HEAD");
             else

--- a/src/ViewModels/Repository.cs
+++ b/src/ViewModels/Repository.cs
@@ -1124,8 +1124,10 @@ namespace SourceGit.ViewModels
 
             if (clearExists)
             {
-                _settings.HistoriesFilters.Clear();
-                HistoriesFilterMode = Models.FilterMode.None;
+                _settings.HistoriesFilters.RemoveAll(_settings.HistoriesFilters
+                                                     .Where(f => f.Type != Models.FilterType.SoloCommits).ToArray());
+                if (_settings.HistoriesFilters.Count <= 0)
+                    HistoriesFilterMode = Models.FilterMode.None;
             }
 
             if (node.Backend is Models.Branch branch)

--- a/src/ViewModels/Repository.cs
+++ b/src/ViewModels/Repository.cs
@@ -1342,7 +1342,9 @@ namespace SourceGit.ViewModels
             else
                 builder.Append(filters);
 
-            var commits = new Commands.QueryCommits(_fullpath, builder.ToString()).GetResultAsync().Result;
+            var patterns = _settings.HistoriesFilters.Where(f => f.Type == Models.FilterType.SoloCommits).Select(f => f.Pattern).ToList();
+
+            var commits = new Commands.QueryCommits(_fullpath, builder.ToString(), true, patterns).GetResultAsync().Result;
             var graph = Models.CommitGraph.Parse(commits, _settings.HistoryShowFlags.HasFlag(Models.HistoryShowFlags.FirstParentOnly));
 
             Dispatcher.UIThread.Invoke(() =>

--- a/src/ViewModels/Repository.cs
+++ b/src/ViewModels/Repository.cs
@@ -1006,8 +1006,24 @@ namespace SourceGit.ViewModels
             else if (_histories != null)
             {
                 SelectedViewIndex = 0;
+                if (sha == "HEAD")
+                    sha = _currentBranch.Head;
                 _histories.NavigateTo(sha);
             }
+        }
+
+        public void NavigateToBranch(string branch, bool isDelayMode = false)
+        {
+            var b = _branches.Find(b => b.FullName.Equals(branch, StringComparison.Ordinal));
+            if (b != null)
+                NavigateToCommit(b.Head);
+        }
+
+        public void NavigateToTag(string tag, bool isDelayMode = false)
+        {
+            var t = _tags.Find(t => t.Name.Equals(tag, StringComparison.Ordinal));
+            if (t != null)
+                NavigateToCommit(t.SHA);
         }
 
         public void ClearCommitMessage()

--- a/src/ViewModels/Repository.cs
+++ b/src/ViewModels/Repository.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text;
 using System.Text.Json;
 using System.Threading;
@@ -1062,14 +1063,27 @@ namespace SourceGit.ViewModels
             if (changed)
                 RefreshHistoriesFilters(true);
         }
+
         public void SetSoloCommitFilterMode(Models.Commit commit, Models.FilterMode mode)
-        {
-            SetSoloCommitFilterMode(commit.SHA[..10], mode);
-        }
+                    => SetSoloCommitFilterMode(commit.SHA[..10], mode);
+
+
+        public void SetSoloCommitFilterMode(IEnumerable<Models.Commit> commits, Models.FilterMode mode)
+                    => SetSoloCommitFilterMode(commits.Select(x => x.SHA[..10]).ToList(), mode);
 
         public void SetSoloCommitFilterMode(string sha, Models.FilterMode mode)
         {
             var changed = _settings.UpdateHistoriesFilter(sha, Models.FilterType.SoloCommits, mode);
+            if (changed)
+                RefreshHistoriesFilters(true);
+        }
+
+        public void SetSoloCommitFilterMode(IEnumerable<string> shas, Models.FilterMode mode)
+        {
+            bool changed = false;
+            foreach (var sha in shas)
+                changed |= _settings.UpdateHistoriesFilter(sha, Models.FilterType.SoloCommits, mode);
+
             if (changed)
                 RefreshHistoriesFilters(true);
         }

--- a/src/ViewModels/Repository.cs
+++ b/src/ViewModels/Repository.cs
@@ -349,6 +349,12 @@ namespace SourceGit.ViewModels
             set => SetProperty(ref _searchedCommits, value);
         }
 
+        public List<Models.Commit> SelectedCommits
+        {
+            get => _selectCommits;
+            set => SetProperty(ref _selectCommits, value);
+        }
+
         public Models.Commit SelectedSearchedCommit
         {
             get => _selectedSearchedCommit;
@@ -1307,6 +1313,8 @@ namespace SourceGit.ViewModels
 
         public void RefreshCommits()
         {
+            var oldSelectedCommits = _selectCommits.ToList();
+
             Dispatcher.UIThread.Invoke(() => _histories.IsLoading = true);
 
             var builder = new StringBuilder();
@@ -1344,6 +1352,8 @@ namespace SourceGit.ViewModels
                     _histories.Graph = graph;
 
                     BisectState = _histories.UpdateBisectInfo();
+
+                    _histories.MarkCommitsAsSelected(oldSelectedCommits);
 
                     if (!string.IsNullOrEmpty(_navigateToCommitDelayed))
                         NavigateToCommit(_navigateToCommitDelayed);
@@ -2031,6 +2041,7 @@ namespace SourceGit.ViewModels
         private bool _onlySearchCommitsInCurrentBranch = false;
         private string _searchCommitFilter = string.Empty;
         private List<Models.Commit> _searchedCommits = new List<Models.Commit>();
+        private List<Models.Commit> _selectCommits = new List<Models.Commit>();
         private Models.Commit _selectedSearchedCommit = null;
         private bool _requestingWorktreeFiles = false;
         private List<string> _worktreeFiles = null;

--- a/src/Views/CommitGraph.cs
+++ b/src/Views/CommitGraph.cs
@@ -230,6 +230,12 @@ namespace SourceGit.Views
                         context.DrawLine(dotFillPen, new Point(center.X, center.Y - 3), new Point(center.X, center.Y + 3));
                         context.DrawLine(dotFillPen, new Point(center.X - 3, center.Y), new Point(center.X + 3, center.Y));
                         break;
+                    case Models.CommitGraph.DotType.Filter:
+                        context.DrawEllipse(pen.Brush, null, center, 7, 7);
+                        context.DrawLine(dotFillPen, new Point(center.X, center.Y - 5), new Point(center.X, center.Y + 5));
+                        context.DrawLine(dotFillPen, new Point(center.X - 4, center.Y - 3), new Point(center.X + 4, center.Y + 3));
+                        context.DrawLine(dotFillPen, new Point(center.X + 4, center.Y - 3), new Point(center.X - 4, center.Y + 3));
+                        break;
                     default:
                         context.DrawEllipse(dotFill, pen, center, 3, 3);
                         break;

--- a/src/Views/Histories.axaml.cs
+++ b/src/Views/Histories.axaml.cs
@@ -122,6 +122,15 @@ namespace SourceGit.Views
             set => SetValue(NavigationIdProperty, value);
         }
 
+        public static readonly StyledProperty<List<Models.Commit>> LastSelectedCommitsProperty =
+            AvaloniaProperty.Register<Histories, List<Models.Commit>>(nameof(LastSelectedCommits));
+
+        public List<Models.Commit> LastSelectedCommits
+        {
+            get => GetValue(LastSelectedCommitsProperty);
+            set => SetValue(LastSelectedCommitsProperty, value);
+        }
+
         public static readonly StyledProperty<bool> IsScrollToTopVisibleProperty =
             AvaloniaProperty.Register<Histories, bool>(nameof(IsScrollToTopVisible));
 
@@ -145,6 +154,18 @@ namespace SourceGit.Views
                 if (CommitListContainer is { SelectedItems.Count: 1, IsLoaded: true } dataGrid)
                     dataGrid.ScrollIntoView(dataGrid.SelectedItem, null);
             }
+            if (change.Property == LastSelectedCommitsProperty)
+            {
+                if (LastSelectedCommits?.Count > 1 &&
+                    (CommitListContainer is DataGrid { IsLoaded: true } dataGrid))
+                {
+                    foreach (var c in LastSelectedCommits)
+                    {
+                        dataGrid.SelectedItems.Add(c);
+                    }
+                }
+            }
+
         }
 
         private void OnCommitListLoaded(object sender, RoutedEventArgs e)

--- a/src/Views/Histories.axaml.cs
+++ b/src/Views/Histories.axaml.cs
@@ -412,6 +412,17 @@ namespace SourceGit.Views
             menu.Items.Add(saveToPatch);
             menu.Items.Add(new MenuItem() { Header = "-" });
 
+            var soloCommits = new MenuItem();
+            soloCommits.Header = App.Text("CommitCM.SoloCommits");
+            soloCommits.Icon = App.CreateMenuIcon("Icons.LightOn");
+            soloCommits.Click += (_, e) =>
+            {
+                repo.SetSoloCommitFilterMode(selected, Models.FilterMode.Included);
+                e.Handled = true;
+            };
+            menu.Items.Add(soloCommits);
+            menu.Items.Add(new MenuItem() { Header = "-" });
+
             var copyShas = new MenuItem();
             copyShas.Header = App.Text("CommitCM.CopySHA");
             copyShas.Icon = App.CreateMenuIcon("Icons.Hash");

--- a/src/Views/Histories.axaml.cs
+++ b/src/Views/Histories.axaml.cs
@@ -824,6 +824,17 @@ namespace SourceGit.Views
                 menu.Items.Add(new MenuItem() { Header = "-" });
             }
 
+            var SoloCommits = new MenuItem();
+            SoloCommits.Header = App.Text("CommitCM.SoloCommits");
+            SoloCommits.Icon = App.CreateMenuIcon("Icons.LightOn");
+            SoloCommits.Click += (_, e) =>
+            {
+                repo.SetSoloCommitFilterMode(commit, Models.FilterMode.Included);
+                e.Handled = true;
+            };
+
+            menu.Items.Add(SoloCommits);
+
             var copySHA = new MenuItem();
             copySHA.Header = App.Text("CommitCM.CopySHA");
             copySHA.Icon = App.CreateMenuIcon("Icons.Hash");

--- a/src/Views/Repository.axaml
+++ b/src/Views/Repository.axaml
@@ -838,6 +838,7 @@
                          Bisect="{Binding Bisect}"
                          IssueTrackers="{Binding $parent[v:Repository].((vm:Repository)DataContext).IssueTrackers}"
                          OnlyHighlightCurrentBranch="{Binding $parent[v:Repository].((vm:Repository)DataContext).OnlyHighlightCurrentBranchInHistories}"
+                         LastSelectedCommits="{Binding LastSelectedCommits}"
                          NavigationId="{Binding NavigationId}"/>
           </DataTemplate>
 

--- a/src/Views/Repository.axaml
+++ b/src/Views/Repository.axaml
@@ -800,7 +800,7 @@
 
             <ItemsControl.ItemTemplate>
               <DataTemplate DataType="m:Filter">
-                <Border Height="20"
+                <Border Height="24"
                         Margin="0,0,6,0"
                         CornerRadius="12"
                         BorderThickness="1"
@@ -808,8 +808,14 @@
                   <StackPanel Orientation="Horizontal" Margin="8,0">
                     <Path Width="10" Height="10" Data="{StaticResource Icons.Branch}" IsVisible="{Binding IsBranch}"/>
                     <Path Width="10" Height="10" Data="{StaticResource Icons.Tag}" IsVisible="{Binding !IsBranch}"/>
-                    <TextBlock Classes="primary" Text="{Binding Pattern, Converter={x:Static c:StringConverters.TrimRefsPrefix}}" Margin="4,0,8,0"/>
-
+                    <Button Margin="4,0,8,0"
+                            Padding="0"
+                            Background="Transparent"
+                            BorderThickness="0"
+                            Classes="icon_button"
+                            Click="OnNavigateToFilter"
+                            Content="{Binding Pattern, Converter={x:Static c:StringConverters.TrimRefsPrefix}}"
+                            />
                     <Button Classes="icon_button" VerticalAlignment="Center" Margin="0" Padding="0" Click="OnRemoveSelectedHistoriesFilter">
                       <Path Width="8" Height="8" Data="{StaticResource Icons.Close}"/>
                     </Button>

--- a/src/Views/Repository.axaml.cs
+++ b/src/Views/Repository.axaml.cs
@@ -659,6 +659,35 @@ namespace SourceGit.Views
             e.Handled = true;
         }
 
+        private void OnNavigateToFilter(object sender, RoutedEventArgs e)
+        {
+            if (DataContext is ViewModels.Repository repo && sender is Button { DataContext: Models.Filter filter })
+            {
+                if (filter.Mode == Models.FilterMode.Excluded)
+                    return;
+
+                switch (filter.Type)
+                {
+                    default:
+                    case Models.FilterType.LocalBranchFolder:
+                    case Models.FilterType.RemoteBranchFolder:
+                        break;
+                    case Models.FilterType.LocalBranch:
+                    case Models.FilterType.RemoteBranch:
+                        repo.NavigateToBranch(filter.Pattern);
+                        break;
+                    case Models.FilterType.Tag:
+                        repo.NavigateToTag(filter.Pattern);
+                        break;
+                    case Models.FilterType.SoloCommits:
+                        repo.NavigateToCommit(filter.Pattern);
+                        break;
+                }
+                e.Handled = true;
+            }
+        }
+
+
         private void OnRemoveSelectedHistoriesFilter(object sender, RoutedEventArgs e)
         {
             if (DataContext is ViewModels.Repository repo && sender is Button { DataContext: Models.Filter filter })

--- a/src/Views/RepositoryToolbar.axaml
+++ b/src/Views/RepositoryToolbar.axaml
@@ -132,6 +132,9 @@
       <Button Classes="icon_button" Width="32" Click="NavigateToHead" ToolTip.Tip="{DynamicResource Text.Repository.NavigateToCurrentHead}">
         <Path Width="13" Height="13" Margin="0,2,0,0" Data="{StaticResource Icons.Target}" Fill="{DynamicResource Brush.FG1}"/>
       </Button>
+      <Button Classes="icon_button" Width="32" Click="SoloModeOnCurrentHead" ToolTip.Tip="{DynamicResource Text.Repository.SoloModeOnCurrentHead}">
+        <Path Width="13" Height="13" Margin="0,2,0,0" Data="{StaticResource Icons.LightOn}" Fill="{DynamicResource Brush.FG1}"/>
+      </Button>
     </StackPanel>
   </Grid>
 </UserControl>

--- a/src/Views/RepositoryToolbar.axaml.cs
+++ b/src/Views/RepositoryToolbar.axaml.cs
@@ -462,5 +462,14 @@ namespace SourceGit.Views
                 e.Handled = true;
             }
         }
+
+        private void SoloModeOnCurrentHead(object sender, RoutedEventArgs e)
+        {
+            if (DataContext is ViewModels.Repository { CurrentBranch: not null } repo)
+            {
+                repo.SetSoloCommitFilterMode(["HEAD", repo.CurrentBranch.Head[..10]], Models.FilterMode.Included);
+                e.Handled = true;
+            }
+        }
     }
 }


### PR DESCRIPTION
# Introducing the whole new solo mode Now:

Based the commit(s), the Solo mode will show the commit and its contians decorators(branchs/tags/etc.), make you focus on your work , Eliminate other interferences

# solo `Head` just one click
   a. This will add `HEAD` and current_HEAD_sha to filter, current_HEAD_sha IT will be usefull if `HEAD` is changed in future

# solo commit
   You can select commit and add this commit to solo-commit filter
# solo Commits
   You can select multi commits and add those commits to solo-commit filter. That is great to focus/compare branch/tag/etc

# navigate
   Fantastically, you can navigate the branch/tag/commit filter  in graph view now.

https://github.com/user-attachments/assets/aa5a8b2a-20a4-48cc-a634-b281646fa478

