### PR TITLE
fix: the menu of copy tag name in history view

### DIFF
--- a/src/Resources/Locales/en_US.axaml
+++ b/src/Resources/Locales/en_US.axaml
@@ -785,6 +785,7 @@
   <x:String x:Key="Text.TagCM.Copy.Message" xml:space="preserve">Message</x:String>
   <x:String x:Key="Text.TagCM.Copy.Name" xml:space="preserve">Name</x:String>
   <x:String x:Key="Text.TagCM.Copy.Tagger" xml:space="preserve">Tagger</x:String>
+  <x:String x:Key="Text.TagCM.CopyName" xml:space="preserve">Copy Tag Name</x:String>
   <x:String x:Key="Text.TagCM.CustomAction" xml:space="preserve">Custom Action</x:String>
   <x:String x:Key="Text.TagCM.Delete" xml:space="preserve">Delete ${0}$...</x:String>
   <x:String x:Key="Text.TagCM.Merge" xml:space="preserve">Merge ${0}$ into ${1}$...</x:String>

--- a/src/Resources/Locales/zh_CN.axaml
+++ b/src/Resources/Locales/zh_CN.axaml
@@ -789,6 +789,7 @@
   <x:String x:Key="Text.TagCM.Copy.Message" xml:space="preserve">标签信息</x:String>
   <x:String x:Key="Text.TagCM.Copy.Name" xml:space="preserve">标签名</x:String>
   <x:String x:Key="Text.TagCM.Copy.Tagger" xml:space="preserve">创建者</x:String>
+  <x:String x:Key="Text.TagCM.CopyName" xml:space="preserve">复制标签名</x:String>
   <x:String x:Key="Text.TagCM.CustomAction" xml:space="preserve">自定义操作</x:String>
   <x:String x:Key="Text.TagCM.Delete" xml:space="preserve">删除 ${0}$...</x:String>
   <x:String x:Key="Text.TagCM.Merge" xml:space="preserve">合并 ${0}$ 到 ${1}$...</x:String>

--- a/src/Resources/Locales/zh_TW.axaml
+++ b/src/Resources/Locales/zh_TW.axaml
@@ -789,6 +789,7 @@
   <x:String x:Key="Text.TagCM.Copy.Message" xml:space="preserve">標籤訊息</x:String>
   <x:String x:Key="Text.TagCM.Copy.Name" xml:space="preserve">標籤名稱</x:String>
   <x:String x:Key="Text.TagCM.Copy.Tagger" xml:space="preserve">創建者</x:String>
+  <x:String x:Key="Text.TagCM.CopyName" xml:space="preserve">複製標籤名稱</x:String>
   <x:String x:Key="Text.TagCM.CustomAction" xml:space="preserve">自訂動作</x:String>
   <x:String x:Key="Text.TagCM.Delete" xml:space="preserve">刪除 ${0}$...</x:String>
   <x:String x:Key="Text.TagCM.Merge" xml:space="preserve">合併 ${0}$ 到 ${1}$...</x:String>

--- a/src/Views/Histories.axaml.cs
+++ b/src/Views/Histories.axaml.cs
@@ -1200,7 +1200,7 @@ namespace SourceGit.Views
             submenu.Items.Add(new MenuItem() { Header = "-" });
 
             var copy = new MenuItem();
-            copy.Header = App.Text("TagCM.Copy");
+            copy.Header = App.Text("TagCM.CopyName");
             copy.Icon = App.CreateMenuIcon("Icons.Copy");
             copy.Click += async (_, e) =>
             {


### PR DESCRIPTION
old:
<img width="575" height="190" alt="PixPin_2025-08-08_16-52-02" src="https://github.com/user-attachments/assets/e40c09cd-c348-4476-896b-fa278022410a" />

fix:
<img width="580" height="204" alt="PixPin_2025-08-08_16-49-31" src="https://github.com/user-attachments/assets/e5e679c4-e0d5-4628-bafb-58a020f66395" />
