### PR TITLE
Use env variable for update detection

### DIFF
--- a/src/App.Commands.cs
+++ b/src/App.Commands.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Windows.Input;
 using Avalonia.Controls;
+using SourceGit.Native;
 
 namespace SourceGit
 {
@@ -29,11 +30,7 @@ namespace SourceGit
         {
             get
             {
-#if DISABLE_UPDATE_DETECTION
-                return false;
-#else
-                return true;
-#endif
+                return OS.ShouldCheckForUpdates();
             }
         }
 

--- a/src/App.axaml.cs
+++ b/src/App.axaml.cs
@@ -568,10 +568,8 @@ namespace SourceGit
             desktop.MainWindow = new Views.Launcher() { DataContext = _launcher };
             desktop.ShutdownMode = ShutdownMode.OnMainWindowClose;
 
-#if !DISABLE_UPDATE_DETECTION
-            if (pref.ShouldCheck4UpdateOnStartup())
+            if (Native.OS.ShouldCheckForUpdates() && pref.ShouldCheck4UpdateOnStartup())
                 Check4Update();
-#endif
         }
 
         private void TryOpenRepository(string repo)

--- a/src/Native/OS.cs
+++ b/src/Native/OS.cs
@@ -119,6 +119,11 @@ namespace SourceGit.Native
             _backend.SetupApp(builder);
         }
 
+        public static bool ShouldCheckForUpdates()
+        {
+            return Environment.GetEnvironmentVariable("SOURCEGIT_DISABLE_UPDATE_DETECTION") == null;
+        }
+
         public static void SetupDataDir()
         {
             if (OperatingSystem.IsWindows())

--- a/src/SourceGit.csproj
+++ b/src/SourceGit.csproj
@@ -24,10 +24,6 @@
     <TrimMode>link</TrimMode>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(DisableUpdateDetection)' == 'true'">
-    <DefineConstants>$(DefineConstants);DISABLE_UPDATE_DETECTION</DefineConstants>
-  </PropertyGroup>
-
   <ItemGroup>
     <AvaloniaResource Include="App.ico" />
     <AvaloniaResource Include="Resources/Fonts/*" />


### PR DESCRIPTION
This allows update detection to be disabled using a env var instead of a compilation define.