### PR TITLE
fix: migrate issue trackers of 2025.26

### DIFF
--- a/src/App.JsonCodeGen.cs
+++ b/src/App.JsonCodeGen.cs
@@ -65,6 +65,7 @@ namespace SourceGit
     [JsonSerializable(typeof(Models.ThemeOverrides))]
     [JsonSerializable(typeof(Models.Version))]
     [JsonSerializable(typeof(Models.RepositorySettings))]
+    [JsonSerializable(typeof(Models.IssueTrackerMigrator.IssueTrackerRepositorySettingsVersion202526))]
     [JsonSerializable(typeof(List<Models.VisualStudioInstance>))]
     [JsonSerializable(typeof(ViewModels.Preferences))]
     internal partial class JsonCodeGen : JsonSerializerContext { }

--- a/src/Models/IssueTrackerMigrator.cs
+++ b/src/Models/IssueTrackerMigrator.cs
@@ -1,0 +1,58 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using Avalonia.Collections;
+
+namespace SourceGit.Models
+{
+    public static class IssueTrackerMigrator
+    {
+        public static IEnumerable<IssueTracker> Migrate(string gitDir)
+        {
+            var settingsFileVersion202526 = Path.Combine(gitDir, "sourcegit.settings");
+            var rules = ReadIssueTrackerSettings202526(settingsFileVersion202526);
+
+            var additionalIssueTrackers = rules.Select(rule => new IssueTracker
+            {
+                IsShared = false,
+                Name = rule.Name,
+                RegexString = rule.RegexString,
+                URLTemplate = rule.URLTemplate,
+            });
+
+            return additionalIssueTrackers;
+        }
+
+        private static IEnumerable<IssueTrackerRuleVersion202526> ReadIssueTrackerSettings202526(
+            string settingsFileVersion202526
+        )
+        {
+            if (!File.Exists(settingsFileVersion202526))
+                return [];
+
+            try
+            {
+                using var stream = File.OpenRead(settingsFileVersion202526);
+                var jsonTypeInfo = JsonCodeGen.Default.IssueTrackerRepositorySettingsVersion202526;
+                var settings = JsonSerializer.Deserialize(stream, jsonTypeInfo);
+                var rules = settings.IssueTrackerRules;
+                return rules ?? [];
+            }
+            catch
+            {
+                return [];
+            }
+        }
+
+        public record IssueTrackerRepositorySettingsVersion202526(
+            AvaloniaList<IssueTrackerRuleVersion202526> IssueTrackerRules
+        );
+
+        public record IssueTrackerRuleVersion202526(
+            string Name,
+            string RegexString,
+            string URLTemplate
+        );
+    }
+}

--- a/src/ViewModels/Repository.cs
+++ b/src/ViewModels/Repository.cs
@@ -784,6 +784,7 @@ namespace SourceGit.ViewModels
                 var issuetrackers = new List<Models.IssueTracker>();
                 await CreateIssueTrackerCommand(true).ReadAllAsync(issuetrackers, true).ConfigureAwait(false);
                 await CreateIssueTrackerCommand(false).ReadAllAsync(issuetrackers, false).ConfigureAwait(false);
+                issuetrackers.AddRange(Models.IssueTrackerMigrator.Migrate(_gitDir));
                 Dispatcher.UIThread.Post(() =>
                 {
                     IssueTrackers.Clear();


### PR DESCRIPTION
Starting with version 2025.26 (implemented in commits b345bb4 and 9802ac9 for issue #1599) the issue trackers configured in repository settings are stored in a new format, deleting the issue trackers configured before.

Since this breaks compatibility, now these issue trackers in the old format used in versions up to 2025.26 are automatically migrated, so they don't get lost.

Fixes #1725.