### PR TITLE
Force squash across merges: UI dialog, safety toggle, and env support

### DIFF
--- a/src/Commands/Command.cs
+++ b/src/Commands/Command.cs
@@ -36,6 +36,7 @@ namespace SourceGit.Commands
         public CancellationToken CancellationToken { get; set; } = CancellationToken.None;
         public bool RaiseError { get; set; } = true;
         public Models.ICommandLog Log { get; set; } = null;
+        public Dictionary<string, string> Envs { get; } = new();
 
         public async Task<bool> ExecAsync()
         {
@@ -191,6 +192,9 @@ namespace SourceGit.Commands
                 start.Environment.Add("LANG", "C");
                 start.Environment.Add("LC_ALL", "C");
             }
+
+            foreach (var kv in Envs)
+                start.Environment[kv.Key] = kv.Value;
 
             var builder = new StringBuilder();
             builder

--- a/src/Commands/DiffAll.cs
+++ b/src/Commands/DiffAll.cs
@@ -1,0 +1,20 @@
+using System.Threading.Tasks;
+
+namespace SourceGit.Commands
+{
+    public class DiffAll : Command
+    {
+        public DiffAll(string repo, string range)
+        {
+            WorkingDirectory = repo;
+            Context = repo;
+            Args = $"diff {range}";
+        }
+
+        public async Task<string> GetResultAsync()
+        {
+            var rs = await ReadToEndAsync();
+            return rs.IsSuccess ? rs.StdOut : string.Empty;
+        }
+    }
+}

--- a/src/Commands/DiffStat.cs
+++ b/src/Commands/DiffStat.cs
@@ -1,0 +1,22 @@
+using System.Threading.Tasks;
+
+namespace SourceGit.Commands
+{
+    public class DiffStat : Command
+    {
+        public DiffStat(string repo, string range)
+        {
+            WorkingDirectory = repo;
+            Context = repo;
+            Args = $"diff --stat {range}";
+        }
+
+        public async Task<string> GetResultAsync()
+        {
+            var rs = await ReadToEndAsync().ConfigureAwait(false);
+            if (rs.IsSuccess && !string.IsNullOrEmpty(rs.StdOut))
+                return rs.StdOut.Trim();
+            return string.Empty;
+        }
+    }
+}

--- a/src/Commands/IsAncestor.cs
+++ b/src/Commands/IsAncestor.cs
@@ -1,0 +1,20 @@
+using System.Threading.Tasks;
+
+namespace SourceGit.Commands
+{
+    public class IsAncestor : Command
+    {
+        public IsAncestor(string repo, string ancestor, string descendant)
+        {
+            WorkingDirectory = repo;
+            Context = repo;
+            Args = $"merge-base --is-ancestor {ancestor} {descendant}";
+            RaiseError = false;
+        }
+
+        public bool Test()
+        {
+            return ReadToEnd().IsSuccess;
+        }
+    }
+}

--- a/src/Resources/Locales/de_DE.axaml
+++ b/src/Resources/Locales/de_DE.axaml
@@ -148,6 +148,7 @@
   <x:String x:Key="Text.CommitCM.Reword" xml:space="preserve">Umformulieren</x:String>
   <x:String x:Key="Text.CommitCM.SaveAsPatch" xml:space="preserve">Als Patch speichern...</x:String>
   <x:String x:Key="Text.CommitCM.Squash" xml:space="preserve">Squash in den Vorgänger</x:String>
+  <x:String x:Key="Text.CommitCM.ForceSquash" xml:space="preserve">Squash hierher erzwingen...</x:String>
   <x:String x:Key="Text.CommitDetail.Changes" xml:space="preserve">ÄNDERUNGEN</x:String>
   <x:String x:Key="Text.CommitDetail.Changes.Count" xml:space="preserve">geänderte Datei(en)</x:String>
   <x:String x:Key="Text.CommitDetail.Changes.Search" xml:space="preserve">Änderungen durchsuchen...</x:String>
@@ -751,6 +752,19 @@
   <x:String x:Key="Text.SHALinkCM.NavigateTo" xml:space="preserve">Zum Commit wechseln</x:String>
   <x:String x:Key="Text.Squash" xml:space="preserve">Squash Commits</x:String>
   <x:String x:Key="Text.Squash.Into" xml:space="preserve">In:</x:String>
+  <x:String x:Key="Text.ForceSquash.Title" xml:space="preserve">Squash über Merges (Historie glätten)</x:String>
+  <x:String x:Key="Text.ForceSquash.Warn1" xml:space="preserve">Operation überschreibt die Historie vom gewählten Commit bis HEAD zu einem Commit</x:String>
+  <x:String x:Key="Text.ForceSquash.Warn2" xml:space="preserve">Alle Merge-Commits im Bereich werden entfernt</x:String>
+  <x:String x:Key="Text.ForceSquash.Warn3" xml:space="preserve">Signierte Commits oder Merges verlieren Signaturen</x:String>
+  <x:String x:Key="Text.ForceSquash.Warn4" xml:space="preserve">Anschließend ist ein Force-Push erforderlich</x:String>
+  <x:String x:Key="Text.ForceSquash.Warn5" xml:space="preserve">Schließe oder aktualisiere alle zugehörigen MR/PR</x:String>
+  <x:String x:Key="Text.ForceSquash.CreateBackup" xml:space="preserve">Vor dem Überschreiben Sicherungszweig erstellen</x:String>
+  <x:String x:Key="Text.ForceSquash.AutoStash" xml:space="preserve">Lokale Änderungen automatisch stashen</x:String>
+  <x:String x:Key="Text.ForceSquash.KeepAuthorDate" xml:space="preserve">Originalautor und -datum des Ziel-Commits beibehalten</x:String>
+  <x:String x:Key="Text.ForceSquash.AppendMessages" xml:space="preserve">Nachrichten der gesquashten Commits an den Body anhängen</x:String>
+  <x:String x:Key="Text.ForceSquash.StashPopFailed" xml:space="preserve">Automatischen Stash anwenden fehlgeschlagen.</x:String>
+  <x:String x:Key="Text.ForceSquash.Success" xml:space="preserve">Historie abgeflacht. Sicherungszweig: {0}</x:String>
+  <x:String x:Key="Text.ForceSquash.SuccessNoBackup" xml:space="preserve">Historie abgeflacht.</x:String>
   <x:String x:Key="Text.SSHKey" xml:space="preserve">SSH privater Schlüssel:</x:String>
   <x:String x:Key="Text.SSHKey.Placeholder" xml:space="preserve">Pfad zum privaten SSH Schlüssel</x:String>
   <x:String x:Key="Text.Start" xml:space="preserve">START</x:String>

--- a/src/Resources/Locales/en_US.axaml
+++ b/src/Resources/Locales/en_US.axaml
@@ -144,6 +144,7 @@
   <x:String x:Key="Text.CommitCM.Reword" xml:space="preserve">Reword</x:String>
   <x:String x:Key="Text.CommitCM.SaveAsPatch" xml:space="preserve">Save as Patch...</x:String>
   <x:String x:Key="Text.CommitCM.Squash" xml:space="preserve">Squash into Parent</x:String>
+  <x:String x:Key="Text.CommitCM.ForceSquash" xml:space="preserve">Force squash to here...</x:String>
   <x:String x:Key="Text.CommitDetail.Changes" xml:space="preserve">CHANGES</x:String>
   <x:String x:Key="Text.CommitDetail.Changes.Count" xml:space="preserve">changed file(s)</x:String>
   <x:String x:Key="Text.CommitDetail.Changes.Search" xml:space="preserve">Search Changes...</x:String>
@@ -552,6 +553,7 @@
   <x:String x:Key="Text.Preferences.DiffMerge.Type" xml:space="preserve">Tool</x:String>
   <x:String x:Key="Text.Preferences.General" xml:space="preserve">GENERAL</x:String>
   <x:String x:Key="Text.Preferences.General.Check4UpdatesOnStartup" xml:space="preserve">Check for updates on startup</x:String>
+  <x:String x:Key="Text.Preferences.General.EnableDangerousHistoryRewrites" xml:space="preserve">Enable dangerous history rewrites</x:String>
   <x:String x:Key="Text.Preferences.General.DateFormat" xml:space="preserve">Date Format</x:String>
   <x:String x:Key="Text.Preferences.General.Locale" xml:space="preserve">Language</x:String>
   <x:String x:Key="Text.Preferences.General.MaxHistoryCommits" xml:space="preserve">History Commits</x:String>
@@ -746,6 +748,19 @@
   <x:String x:Key="Text.SHALinkCM.NavigateTo" xml:space="preserve">Go to</x:String>
   <x:String x:Key="Text.Squash" xml:space="preserve">Squash Commits</x:String>
   <x:String x:Key="Text.Squash.Into" xml:space="preserve">Into:</x:String>
+  <x:String x:Key="Text.ForceSquash.Title" xml:space="preserve">Squash across merges (flatten history)</x:String>
+  <x:String x:Key="Text.ForceSquash.Warn1" xml:space="preserve">Operation rewrites history from selected commit to HEAD into one commit</x:String>
+  <x:String x:Key="Text.ForceSquash.Warn2" xml:space="preserve">All merge commits in range will be removed</x:String>
+  <x:String x:Key="Text.ForceSquash.Warn3" xml:space="preserve">Signed commits or merges lose signatures</x:String>
+  <x:String x:Key="Text.ForceSquash.Warn4" xml:space="preserve">Force push is required afterwards</x:String>
+  <x:String x:Key="Text.ForceSquash.Warn5" xml:space="preserve">Close or update any related MR/PR</x:String>
+  <x:String x:Key="Text.ForceSquash.CreateBackup" xml:space="preserve">Create safety backup branch before rewrite</x:String>
+  <x:String x:Key="Text.ForceSquash.AutoStash" xml:space="preserve">Auto-stash local changes</x:String>
+  <x:String x:Key="Text.ForceSquash.KeepAuthorDate" xml:space="preserve">Keep original author/date of target commit</x:String>
+  <x:String x:Key="Text.ForceSquash.AppendMessages" xml:space="preserve">Append messages of squashed commits to body</x:String>
+  <x:String x:Key="Text.ForceSquash.StashPopFailed" xml:space="preserve">Failed to apply auto stash.</x:String>
+  <x:String x:Key="Text.ForceSquash.Success" xml:space="preserve">History flattened. Backup branch: {0}</x:String>
+  <x:String x:Key="Text.ForceSquash.SuccessNoBackup" xml:space="preserve">History flattened.</x:String>
   <x:String x:Key="Text.SSHKey" xml:space="preserve">SSH Private Key:</x:String>
   <x:String x:Key="Text.SSHKey.Placeholder" xml:space="preserve">Private SSH key store path</x:String>
   <x:String x:Key="Text.Start" xml:space="preserve">START</x:String>

--- a/src/Resources/Locales/es_ES.axaml
+++ b/src/Resources/Locales/es_ES.axaml
@@ -148,6 +148,7 @@
   <x:String x:Key="Text.CommitCM.Reword" xml:space="preserve">Reescribir</x:String>
   <x:String x:Key="Text.CommitCM.SaveAsPatch" xml:space="preserve">Guardar como Parche...</x:String>
   <x:String x:Key="Text.CommitCM.Squash" xml:space="preserve">Squash en Parent</x:String>
+  <x:String x:Key="Text.CommitCM.ForceSquash" xml:space="preserve">Forzar squash aquí...</x:String>
   <x:String x:Key="Text.CommitDetail.Changes" xml:space="preserve">CAMBIOS</x:String>
   <x:String x:Key="Text.CommitDetail.Changes.Count" xml:space="preserve">archivo(s) modificado(s)</x:String>
   <x:String x:Key="Text.CommitDetail.Changes.Search" xml:space="preserve">Buscar Cambios...</x:String>
@@ -750,6 +751,19 @@
   <x:String x:Key="Text.SHALinkCM.NavigateTo" xml:space="preserve">Ir a</x:String>
   <x:String x:Key="Text.Squash" xml:space="preserve">Squash Commits</x:String>
   <x:String x:Key="Text.Squash.Into" xml:space="preserve">En:</x:String>
+  <x:String x:Key="Text.ForceSquash.Title" xml:space="preserve">Squash a través de merges (aplanar historial)</x:String>
+  <x:String x:Key="Text.ForceSquash.Warn1" xml:space="preserve">La operación reescribe el historial desde el commit seleccionado hasta HEAD en un solo commit</x:String>
+  <x:String x:Key="Text.ForceSquash.Warn2" xml:space="preserve">Todos los commits de merge en el rango serán eliminados</x:String>
+  <x:String x:Key="Text.ForceSquash.Warn3" xml:space="preserve">Los commits o merges firmados pierden sus firmas</x:String>
+  <x:String x:Key="Text.ForceSquash.Warn4" xml:space="preserve">Se requiere un force push después</x:String>
+  <x:String x:Key="Text.ForceSquash.Warn5" xml:space="preserve">Cierra o actualiza cualquier MR/PR relacionado</x:String>
+  <x:String x:Key="Text.ForceSquash.CreateBackup" xml:space="preserve">Crear rama de respaldo antes de sobrescribir</x:String>
+  <x:String x:Key="Text.ForceSquash.AutoStash" xml:space="preserve">Guardar automáticamente los cambios locales</x:String>
+  <x:String x:Key="Text.ForceSquash.KeepAuthorDate" xml:space="preserve">Conservar autor/fecha originales del commit destino</x:String>
+  <x:String x:Key="Text.ForceSquash.AppendMessages" xml:space="preserve">Añadir mensajes de los commits aplastados al cuerpo</x:String>
+  <x:String x:Key="Text.ForceSquash.StashPopFailed" xml:space="preserve">No se pudo aplicar el auto-stash.</x:String>
+  <x:String x:Key="Text.ForceSquash.Success" xml:space="preserve">Historial aplanado. Rama de respaldo: {0}</x:String>
+  <x:String x:Key="Text.ForceSquash.SuccessNoBackup" xml:space="preserve">Historial aplanado.</x:String>
   <x:String x:Key="Text.SSHKey" xml:space="preserve">Clave Privada SSH:</x:String>
   <x:String x:Key="Text.SSHKey.Placeholder" xml:space="preserve">Ruta de almacenamiento de la clave privada SSH</x:String>
   <x:String x:Key="Text.Start" xml:space="preserve">INICIAR</x:String>

--- a/src/Resources/Locales/fr_FR.axaml
+++ b/src/Resources/Locales/fr_FR.axaml
@@ -108,6 +108,7 @@
   <x:String x:Key="Text.CommitCM.Reword" xml:space="preserve">Reformuler</x:String>
   <x:String x:Key="Text.CommitCM.SaveAsPatch" xml:space="preserve">Enregistrer en tant que patch...</x:String>
   <x:String x:Key="Text.CommitCM.Squash" xml:space="preserve">Squash dans le parent</x:String>
+  <x:String x:Key="Text.CommitCM.ForceSquash" xml:space="preserve">Forcer le squash ici...</x:String>
   <x:String x:Key="Text.CommitDetail.Changes" xml:space="preserve">CHANGEMENTS</x:String>
   <x:String x:Key="Text.CommitDetail.Changes.Search" xml:space="preserve">Rechercher les changements...</x:String>
   <x:String x:Key="Text.CommitDetail.Files" xml:space="preserve">FICHIERS</x:String>
@@ -611,6 +612,19 @@
   <x:String x:Key="Text.SHALinkCM.NavigateTo" xml:space="preserve">Aller à</x:String>
   <x:String x:Key="Text.Squash" xml:space="preserve">Squash les commits</x:String>
   <x:String x:Key="Text.Squash.Into" xml:space="preserve">Dans :</x:String>
+  <x:String x:Key="Text.ForceSquash.Title" xml:space="preserve">Squasher à travers les fusions (aplatir l'historique)</x:String>
+  <x:String x:Key="Text.ForceSquash.Warn1" xml:space="preserve">L'opération réécrit l'historique du commit sélectionné jusqu'à HEAD en un seul commit</x:String>
+  <x:String x:Key="Text.ForceSquash.Warn2" xml:space="preserve">Tous les commits de fusion dans l'intervalle seront supprimés</x:String>
+  <x:String x:Key="Text.ForceSquash.Warn3" xml:space="preserve">Les commits ou fusions signés perdent leurs signatures</x:String>
+  <x:String x:Key="Text.ForceSquash.Warn4" xml:space="preserve">Un push forcé est nécessaire ensuite</x:String>
+  <x:String x:Key="Text.ForceSquash.Warn5" xml:space="preserve">Fermez ou mettez à jour toute MR/PR liée</x:String>
+  <x:String x:Key="Text.ForceSquash.CreateBackup" xml:space="preserve">Créer une branche de sauvegarde avant la réécriture</x:String>
+  <x:String x:Key="Text.ForceSquash.AutoStash" xml:space="preserve">Stasher automatiquement les modifications locales</x:String>
+  <x:String x:Key="Text.ForceSquash.KeepAuthorDate" xml:space="preserve">Conserver l'auteur/la date originaux du commit cible</x:String>
+  <x:String x:Key="Text.ForceSquash.AppendMessages" xml:space="preserve">Ajouter les messages des commits squashés au corps</x:String>
+  <x:String x:Key="Text.ForceSquash.StashPopFailed" xml:space="preserve">Échec de l'application de l'auto-stash.</x:String>
+  <x:String x:Key="Text.ForceSquash.Success" xml:space="preserve">Historique aplati. Branche de sauvegarde : {0}</x:String>
+  <x:String x:Key="Text.ForceSquash.SuccessNoBackup" xml:space="preserve">Historique aplati.</x:String>
   <x:String x:Key="Text.SSHKey" xml:space="preserve">Clé privée SSH :</x:String>
   <x:String x:Key="Text.SSHKey.Placeholder" xml:space="preserve">Chemin du magasin de clés privées SSH</x:String>
   <x:String x:Key="Text.Start" xml:space="preserve">START</x:String>

--- a/src/Resources/Locales/it_IT.axaml
+++ b/src/Resources/Locales/it_IT.axaml
@@ -119,6 +119,7 @@
   <x:String x:Key="Text.CommitCM.Reword" xml:space="preserve">Modifica</x:String>
   <x:String x:Key="Text.CommitCM.SaveAsPatch" xml:space="preserve">Salva come Patch...</x:String>
   <x:String x:Key="Text.CommitCM.Squash" xml:space="preserve">Compatta nel Genitore</x:String>
+  <x:String x:Key="Text.CommitCM.ForceSquash" xml:space="preserve">Forza squash qui...</x:String>
   <x:String x:Key="Text.CommitDetail.Changes" xml:space="preserve">MODIFICHE</x:String>
   <x:String x:Key="Text.CommitDetail.Changes.Search" xml:space="preserve">Cerca Modifiche...</x:String>
   <x:String x:Key="Text.CommitDetail.Files" xml:space="preserve">FILE</x:String>
@@ -639,6 +640,19 @@
   <x:String x:Key="Text.SHALinkCM.NavigateTo" xml:space="preserve">Vai a</x:String>
   <x:String x:Key="Text.Squash" xml:space="preserve">Compatta Commit</x:String>
   <x:String x:Key="Text.Squash.Into" xml:space="preserve">In:</x:String>
+  <x:String x:Key="Text.ForceSquash.Title" xml:space="preserve">Squash attraverso i merge (appiattisci la cronologia)</x:String>
+  <x:String x:Key="Text.ForceSquash.Warn1" xml:space="preserve">L'operazione riscrive la cronologia dal commit selezionato a HEAD in un solo commit</x:String>
+  <x:String x:Key="Text.ForceSquash.Warn2" xml:space="preserve">Tutti i commit di merge nell'intervallo saranno rimossi</x:String>
+  <x:String x:Key="Text.ForceSquash.Warn3" xml:space="preserve">I commit o i merge firmati perdono le firme</x:String>
+  <x:String x:Key="Text.ForceSquash.Warn4" xml:space="preserve">È richiesto un force push dopo</x:String>
+  <x:String x:Key="Text.ForceSquash.Warn5" xml:space="preserve">Chiudi o aggiorna qualsiasi MR/PR correlato</x:String>
+  <x:String x:Key="Text.ForceSquash.CreateBackup" xml:space="preserve">Crea un ramo di backup prima della riscrittura</x:String>
+  <x:String x:Key="Text.ForceSquash.AutoStash" xml:space="preserve">Esegui auto-stash delle modifiche locali</x:String>
+  <x:String x:Key="Text.ForceSquash.KeepAuthorDate" xml:space="preserve">Mantieni autore/data originali del commit di destinazione</x:String>
+  <x:String x:Key="Text.ForceSquash.AppendMessages" xml:space="preserve">Aggiungi i messaggi dei commit squasciati al corpo</x:String>
+  <x:String x:Key="Text.ForceSquash.StashPopFailed" xml:space="preserve">Applicazione dell'auto-stash non riuscita.</x:String>
+  <x:String x:Key="Text.ForceSquash.Success" xml:space="preserve">Cronologia appiattita. Ramo di backup: {0}</x:String>
+  <x:String x:Key="Text.ForceSquash.SuccessNoBackup" xml:space="preserve">Cronologia appiattita.</x:String>
   <x:String x:Key="Text.SSHKey" xml:space="preserve">Chiave Privata SSH:</x:String>
   <x:String x:Key="Text.SSHKey.Placeholder" xml:space="preserve">Percorso per la chiave SSH privata</x:String>
   <x:String x:Key="Text.Start" xml:space="preserve">AVVIA</x:String>

--- a/src/Resources/Locales/ja_JP.axaml
+++ b/src/Resources/Locales/ja_JP.axaml
@@ -107,6 +107,7 @@
   <x:String x:Key="Text.CommitCM.Reword" xml:space="preserve">書き直す</x:String>
   <x:String x:Key="Text.CommitCM.SaveAsPatch" xml:space="preserve">パッチとして保存...</x:String>
   <x:String x:Key="Text.CommitCM.Squash" xml:space="preserve">親にスカッシュ</x:String>
+  <x:String x:Key="Text.CommitCM.ForceSquash" xml:space="preserve">ここに強制スクワッシュ...</x:String>
   <x:String x:Key="Text.CommitDetail.Changes" xml:space="preserve">変更</x:String>
   <x:String x:Key="Text.CommitDetail.Changes.Search" xml:space="preserve">変更を検索...</x:String>
   <x:String x:Key="Text.CommitDetail.Files" xml:space="preserve">ファイル</x:String>
@@ -609,6 +610,19 @@
   <x:String x:Key="Text.SHALinkCM.NavigateTo" xml:space="preserve">Go to</x:String>
   <x:String x:Key="Text.Squash" xml:space="preserve">スカッシュコミット</x:String>
   <x:String x:Key="Text.Squash.Into" xml:space="preserve">宛先:</x:String>
+  <x:String x:Key="Text.ForceSquash.Title" xml:space="preserve">マージをまたいでスクワッシュ（履歴を平坦化）</x:String>
+  <x:String x:Key="Text.ForceSquash.Warn1" xml:space="preserve">選択したコミットからHEADまでの履歴を1つのコミットに書き換えます</x:String>
+  <x:String x:Key="Text.ForceSquash.Warn2" xml:space="preserve">範囲内のすべてのマージコミットは削除されます</x:String>
+  <x:String x:Key="Text.ForceSquash.Warn3" xml:space="preserve">署名付きのコミットやマージは署名を失います</x:String>
+  <x:String x:Key="Text.ForceSquash.Warn4" xml:space="preserve">その後は強制プッシュが必要です</x:String>
+  <x:String x:Key="Text.ForceSquash.Warn5" xml:space="preserve">関連するMR/PRを閉じるか更新してください</x:String>
+  <x:String x:Key="Text.ForceSquash.CreateBackup" xml:space="preserve">書き換え前に安全なバックアップブランチを作成</x:String>
+  <x:String x:Key="Text.ForceSquash.AutoStash" xml:space="preserve">ローカル変更を自動でスタッシュ</x:String>
+  <x:String x:Key="Text.ForceSquash.KeepAuthorDate" xml:space="preserve">対象コミットの元の作者/日付を保持</x:String>
+  <x:String x:Key="Text.ForceSquash.AppendMessages" xml:space="preserve">スクワッシュされたコミットのメッセージを本文に追加</x:String>
+  <x:String x:Key="Text.ForceSquash.StashPopFailed" xml:space="preserve">自動スタッシュの適用に失敗しました。</x:String>
+  <x:String x:Key="Text.ForceSquash.Success" xml:space="preserve">履歴を平坦化しました。バックアップブランチ: {0}</x:String>
+  <x:String x:Key="Text.ForceSquash.SuccessNoBackup" xml:space="preserve">履歴を平坦化しました。</x:String>
   <x:String x:Key="Text.SSHKey" xml:space="preserve">SSH プライベートキー:</x:String>
   <x:String x:Key="Text.SSHKey.Placeholder" xml:space="preserve">プライベートSSHキーストアのパス</x:String>
   <x:String x:Key="Text.Start" xml:space="preserve">スタート</x:String>

--- a/src/Resources/Locales/pt_BR.axaml
+++ b/src/Resources/Locales/pt_BR.axaml
@@ -97,6 +97,7 @@
   <x:String x:Key="Text.CommitCM.Reword" xml:space="preserve">Modificar Mensagem</x:String>
   <x:String x:Key="Text.CommitCM.SaveAsPatch" xml:space="preserve">Salvar como Patch...</x:String>
   <x:String x:Key="Text.CommitCM.Squash" xml:space="preserve">Mesclar ao Commit Pai</x:String>
+  <x:String x:Key="Text.CommitCM.ForceSquash" xml:space="preserve">Forçar squash aqui...</x:String>
   <x:String x:Key="Text.CommitDetail.Changes" xml:space="preserve">ALTERAÇÕES</x:String>
   <x:String x:Key="Text.CommitDetail.Changes.Search" xml:space="preserve">Buscar Alterações...</x:String>
   <x:String x:Key="Text.CommitDetail.Files" xml:space="preserve">ARQUIVOS</x:String>
@@ -553,6 +554,19 @@
   <x:String x:Key="Text.SHALinkCM.CopySHA" xml:space="preserve">Copiar SHA</x:String>
   <x:String x:Key="Text.Squash" xml:space="preserve">Squash Commits</x:String>
   <x:String x:Key="Text.Squash.Into" xml:space="preserve">Squash commits em:</x:String>
+  <x:String x:Key="Text.ForceSquash.Title" xml:space="preserve">Squash através dos merges (achatar histórico)</x:String>
+  <x:String x:Key="Text.ForceSquash.Warn1" xml:space="preserve">A operação reescreve o histórico do commit selecionado até o HEAD em um único commit</x:String>
+  <x:String x:Key="Text.ForceSquash.Warn2" xml:space="preserve">Todos os commits de merge no intervalo serão removidos</x:String>
+  <x:String x:Key="Text.ForceSquash.Warn3" xml:space="preserve">Commits ou merges assinados perdem as assinaturas</x:String>
+  <x:String x:Key="Text.ForceSquash.Warn4" xml:space="preserve">Um force push é necessário depois</x:String>
+  <x:String x:Key="Text.ForceSquash.Warn5" xml:space="preserve">Feche ou atualize qualquer MR/PR relacionado</x:String>
+  <x:String x:Key="Text.ForceSquash.CreateBackup" xml:space="preserve">Criar branch de backup antes de reescrever</x:String>
+  <x:String x:Key="Text.ForceSquash.AutoStash" xml:space="preserve">Auto-stash das alterações locais</x:String>
+  <x:String x:Key="Text.ForceSquash.KeepAuthorDate" xml:space="preserve">Manter autor/data originais do commit de destino</x:String>
+  <x:String x:Key="Text.ForceSquash.AppendMessages" xml:space="preserve">Anexar mensagens dos commits squashados ao corpo</x:String>
+  <x:String x:Key="Text.ForceSquash.StashPopFailed" xml:space="preserve">Falha ao aplicar auto-stash.</x:String>
+  <x:String x:Key="Text.ForceSquash.Success" xml:space="preserve">Histórico achatado. Branch de backup: {0}</x:String>
+  <x:String x:Key="Text.ForceSquash.SuccessNoBackup" xml:space="preserve">Histórico achatado.</x:String>
   <x:String x:Key="Text.SSHKey" xml:space="preserve">Chave SSH Privada:</x:String>
   <x:String x:Key="Text.SSHKey.Placeholder" xml:space="preserve">Caminho para a chave SSH privada</x:String>
   <x:String x:Key="Text.Start" xml:space="preserve">INICIAR</x:String>

--- a/src/Resources/Locales/ru_RU.axaml
+++ b/src/Resources/Locales/ru_RU.axaml
@@ -146,9 +146,10 @@
   <x:String x:Key="Text.CommitCM.Reword" xml:space="preserve">Изменить комментарий</x:String>
   <x:String x:Key="Text.CommitCM.SaveAsPatch" xml:space="preserve">Сохранить как заплатки...</x:String>
   <x:String x:Key="Text.CommitCM.Squash" xml:space="preserve">Объединить с предыдущей ревизией</x:String>
+  <x:String x:Key="Text.CommitCM.ForceSquash" xml:space="preserve">Принудительно объединить сюда...</x:String>
   <x:String x:Key="Text.CommitDetail.Changes" xml:space="preserve">ИЗМЕНЕНИЯ</x:String>
   <x:String x:Key="Text.CommitDetail.Changes.Count" xml:space="preserve">изменённый(х) файл(ов)</x:String>
-  <x:String x:Key="Text.CommitDetail.Changes.Search" xml:space="preserve">Найти изменения....</x:String>
+  <x:String x:Key="Text.CommitDetail.Changes.Search" xml:space="preserve">Найти изменения...</x:String>
   <x:String x:Key="Text.CommitDetail.Files" xml:space="preserve">ФАЙЛЫ</x:String>
   <x:String x:Key="Text.CommitDetail.Files.LFS" xml:space="preserve">Файл LFS</x:String>
   <x:String x:Key="Text.CommitDetail.Files.Search" xml:space="preserve">Поиск файлов...</x:String>
@@ -545,6 +546,7 @@
   <x:String x:Key="Text.Preferences.DiffMerge.Type" xml:space="preserve">Инструмент</x:String>
   <x:String x:Key="Text.Preferences.General" xml:space="preserve">ОСНОВНЫЕ</x:String>
   <x:String x:Key="Text.Preferences.General.Check4UpdatesOnStartup" xml:space="preserve">Проверить обновления при старте</x:String>
+  <x:String x:Key="Text.Preferences.General.EnableDangerousHistoryRewrites" xml:space="preserve">Включить опасные переписывания истории</x:String>
   <x:String x:Key="Text.Preferences.General.DateFormat" xml:space="preserve">Формат даты</x:String>
   <x:String x:Key="Text.Preferences.General.Locale" xml:space="preserve">Язык</x:String>
   <x:String x:Key="Text.Preferences.General.MaxHistoryCommits" xml:space="preserve">Максимальная длина истории</x:String>
@@ -739,6 +741,19 @@
   <x:String x:Key="Text.SHALinkCM.NavigateTo" xml:space="preserve">Перейти</x:String>
   <x:String x:Key="Text.Squash" xml:space="preserve">Втиснуть ревизии</x:String>
   <x:String x:Key="Text.Squash.Into" xml:space="preserve">В:</x:String>
+  <x:String x:Key="Text.ForceSquash.Title" xml:space="preserve">Втиснуть через слияния (выпрямить историю)</x:String>
+  <x:String x:Key="Text.ForceSquash.Warn1" xml:space="preserve">Операция перепишет историю от выбранного коммита до HEAD в один коммит</x:String>
+  <x:String x:Key="Text.ForceSquash.Warn2" xml:space="preserve">Все merge-коммиты в диапазоне будут удалены</x:String>
+  <x:String x:Key="Text.ForceSquash.Warn3" xml:space="preserve">Подписи коммитов и merge будут потеряны</x:String>
+  <x:String x:Key="Text.ForceSquash.Warn4" xml:space="preserve">Далее потребуется принудительная отправка</x:String>
+  <x:String x:Key="Text.ForceSquash.Warn5" xml:space="preserve">Закройте или обновите связанные MR/PR</x:String>
+  <x:String x:Key="Text.ForceSquash.CreateBackup" xml:space="preserve">Создать резервную ветку перед переписыванием</x:String>
+  <x:String x:Key="Text.ForceSquash.AutoStash" xml:space="preserve">Авто-сохранение локальных изменений</x:String>
+  <x:String x:Key="Text.ForceSquash.KeepAuthorDate" xml:space="preserve">Сохранить автора и дату целевого коммита</x:String>
+  <x:String x:Key="Text.ForceSquash.AppendMessages" xml:space="preserve">Добавить сообщения объединяемых коммитов в тело</x:String>
+  <x:String x:Key="Text.ForceSquash.StashPopFailed" xml:space="preserve">Не удалось применить авто-стэш.</x:String>
+  <x:String x:Key="Text.ForceSquash.Success" xml:space="preserve">История сплюснута. Резервная ветка: {0}</x:String>
+  <x:String x:Key="Text.ForceSquash.SuccessNoBackup" xml:space="preserve">История сплюснута.</x:String>
   <x:String x:Key="Text.SSHKey" xml:space="preserve">Приватный ключ SSH:</x:String>
   <x:String x:Key="Text.SSHKey.Placeholder" xml:space="preserve">Путь хранения приватного ключа SSH</x:String>
   <x:String x:Key="Text.Start" xml:space="preserve">ЗАПУСК</x:String>

--- a/src/Resources/Locales/ta_IN.axaml
+++ b/src/Resources/Locales/ta_IN.axaml
@@ -107,6 +107,7 @@
   <x:String x:Key="Text.CommitCM.Reword" xml:space="preserve">வேறுமொழி</x:String>
   <x:String x:Key="Text.CommitCM.SaveAsPatch" xml:space="preserve">ஒட்டாக சேமி...</x:String>
   <x:String x:Key="Text.CommitCM.Squash" xml:space="preserve">பெற்றோர்களில் நொறுக்கு</x:String>
+  <x:String x:Key="Text.CommitCM.ForceSquash" xml:space="preserve">இங்கே நொறுக்கு கட்டாயப்படுத்து...</x:String>
   <x:String x:Key="Text.CommitDetail.Changes" xml:space="preserve">மாற்றங்கள்</x:String>
   <x:String x:Key="Text.CommitDetail.Changes.Search" xml:space="preserve">மாற்றங்களைத் தேடு...</x:String>
   <x:String x:Key="Text.CommitDetail.Files" xml:space="preserve">கோப்புகள்</x:String>
@@ -610,6 +611,19 @@
   <x:String x:Key="Text.SHALinkCM.NavigateTo" xml:space="preserve">இதற்கு செல்</x:String>
   <x:String x:Key="Text.Squash" xml:space="preserve">நொறுக்கு உறுதிமொழிகள்</x:String>
   <x:String x:Key="Text.Squash.Into" xml:space="preserve">இதில்:</x:String>
+  <x:String x:Key="Text.ForceSquash.Title" xml:space="preserve">இணைப்புகளை தாண்டி நொறுக்கு (வரலாற்றை சமப்படுத்து)</x:String>
+  <x:String x:Key="Text.ForceSquash.Warn1" xml:space="preserve">தேர்ந்தெடுக்கப்பட்ட commit-இலிருந்து HEAD வரை வரலாறு ஒரே commit-ஆக மாற்றப்படும்</x:String>
+  <x:String x:Key="Text.ForceSquash.Warn2" xml:space="preserve">வரம்பில் உள்ள merge commit-கள் அனைத்தும் அகற்றப்படும்</x:String>
+  <x:String x:Key="Text.ForceSquash.Warn3" xml:space="preserve">கையொப்பமிட்ட commit-கள் அல்லது merge-கள் கையொப்பங்களை இழக்கும்</x:String>
+  <x:String x:Key="Text.ForceSquash.Warn4" xml:space="preserve">பிறகு force push தேவை</x:String>
+  <x:String x:Key="Text.ForceSquash.Warn5" xml:space="preserve">தொடர்புடைய MR/PR-ஐ மூட அல்லது புதுப்பிக்கவும்</x:String>
+  <x:String x:Key="Text.ForceSquash.CreateBackup" xml:space="preserve">மீண்டும் எழுதுவதற்கு முன் பாதுகாப்பு காப்பு branch உருவாக்கவும்</x:String>
+  <x:String x:Key="Text.ForceSquash.AutoStash" xml:space="preserve">உள்ளூர் மாற்றங்களை தானாக stash செய்</x:String>
+  <x:String x:Key="Text.ForceSquash.KeepAuthorDate" xml:space="preserve">இலக்கு commit-ன் அசல் author/தேதியை வைத்திரு</x:String>
+  <x:String x:Key="Text.ForceSquash.AppendMessages" xml:space="preserve">நொறுக்கப்பட்ட commit-களின் செய்திகளை body-க்கு சேர்க்கவும்</x:String>
+  <x:String x:Key="Text.ForceSquash.StashPopFailed" xml:space="preserve">Auto stash-ஐ பயன்படுத்த முடியவில்லை.</x:String>
+  <x:String x:Key="Text.ForceSquash.Success" xml:space="preserve">வரலாறு சமப்படுத்தப்பட்டது. காப்பு branch: {0}</x:String>
+  <x:String x:Key="Text.ForceSquash.SuccessNoBackup" xml:space="preserve">வரலாறு சமப்படுத்தப்பட்டது.</x:String>
   <x:String x:Key="Text.SSHKey" xml:space="preserve">பாஓடு தனியார் திறவுகோல்:</x:String>
   <x:String x:Key="Text.SSHKey.Placeholder" xml:space="preserve">தனியார் பாஓடு திறவுகோல் கடை பாதை</x:String>
   <x:String x:Key="Text.Start" xml:space="preserve">தொடங்கு</x:String>

--- a/src/Resources/Locales/uk_UA.axaml
+++ b/src/Resources/Locales/uk_UA.axaml
@@ -108,6 +108,7 @@
   <x:String x:Key="Text.CommitCM.Reword" xml:space="preserve">Змінити повідомлення</x:String>
   <x:String x:Key="Text.CommitCM.SaveAsPatch" xml:space="preserve">Зберегти як патч...</x:String>
   <x:String x:Key="Text.CommitCM.Squash" xml:space="preserve">Склеїти з батьківським комітом</x:String>
+  <x:String x:Key="Text.CommitCM.ForceSquash" xml:space="preserve">Примусово сплюснути сюди...</x:String>
   <x:String x:Key="Text.CommitDetail.Changes" xml:space="preserve">ЗМІНИ</x:String>
   <x:String x:Key="Text.CommitDetail.Changes.Search" xml:space="preserve">Пошук змін...</x:String>
   <x:String x:Key="Text.CommitDetail.Files" xml:space="preserve">ФАЙЛИ</x:String>
@@ -615,6 +616,19 @@
   <x:String x:Key="Text.SHALinkCM.NavigateTo" xml:space="preserve">Перейти до</x:String>
   <x:String x:Key="Text.Squash" xml:space="preserve">Squash (Склеїти коміти)</x:String>
   <x:String x:Key="Text.Squash.Into" xml:space="preserve">В:</x:String>
+  <x:String x:Key="Text.ForceSquash.Title" xml:space="preserve">Сплющити через мерджі (вирівняти історію)</x:String>
+  <x:String x:Key="Text.ForceSquash.Warn1" xml:space="preserve">Операція перепише історію від вибраного коміту до HEAD в один коміт</x:String>
+  <x:String x:Key="Text.ForceSquash.Warn2" xml:space="preserve">Усі коміти злиття в діапазоні буде вилучено</x:String>
+  <x:String x:Key="Text.ForceSquash.Warn3" xml:space="preserve">Підписані коміти або злиття втратять підписи</x:String>
+  <x:String x:Key="Text.ForceSquash.Warn4" xml:space="preserve">Після цього потрібен примусовий push</x:String>
+  <x:String x:Key="Text.ForceSquash.Warn5" xml:space="preserve">Закрийте або оновіть пов’язані MR/PR</x:String>
+  <x:String x:Key="Text.ForceSquash.CreateBackup" xml:space="preserve">Створити резервну гілку перед переписуванням</x:String>
+  <x:String x:Key="Text.ForceSquash.AutoStash" xml:space="preserve">Автоматично застешити локальні зміни</x:String>
+  <x:String x:Key="Text.ForceSquash.KeepAuthorDate" xml:space="preserve">Зберегти автора/дату цільового коміту</x:String>
+  <x:String x:Key="Text.ForceSquash.AppendMessages" xml:space="preserve">Додати повідомлення сплюснутих комітів у тіло</x:String>
+  <x:String x:Key="Text.ForceSquash.StashPopFailed" xml:space="preserve">Не вдалося застосувати автостеш.</x:String>
+  <x:String x:Key="Text.ForceSquash.Success" xml:space="preserve">Історію сплюснуто. Резервна гілка: {0}</x:String>
+  <x:String x:Key="Text.ForceSquash.SuccessNoBackup" xml:space="preserve">Історію сплюснуто.</x:String>
   <x:String x:Key="Text.SSHKey" xml:space="preserve">Приватний ключ SSH:</x:String>
   <x:String x:Key="Text.SSHKey.Placeholder" xml:space="preserve">Шлях до сховища приватного ключа SSH</x:String>
   <x:String x:Key="Text.Start" xml:space="preserve">ПОЧАТИ</x:String>

--- a/src/Resources/Locales/zh_CN.axaml
+++ b/src/Resources/Locales/zh_CN.axaml
@@ -148,6 +148,7 @@
   <x:String x:Key="Text.CommitCM.Reword" xml:space="preserve">编辑提交信息</x:String>
   <x:String x:Key="Text.CommitCM.SaveAsPatch" xml:space="preserve">另存为补丁 ...</x:String>
   <x:String x:Key="Text.CommitCM.Squash" xml:space="preserve">合并此提交到上一个提交</x:String>
+  <x:String x:Key="Text.CommitCM.ForceSquash" xml:space="preserve">强制压缩到此...</x:String>
   <x:String x:Key="Text.CommitDetail.Changes" xml:space="preserve">变更对比</x:String>
   <x:String x:Key="Text.CommitDetail.Changes.Count" xml:space="preserve">个文件发生变更</x:String>
   <x:String x:Key="Text.CommitDetail.Changes.Search" xml:space="preserve">查找变更...</x:String>
@@ -750,6 +751,19 @@
   <x:String x:Key="Text.SHALinkCM.NavigateTo" xml:space="preserve">跳转到提交</x:String>
   <x:String x:Key="Text.Squash" xml:space="preserve">压缩为单个提交</x:String>
   <x:String x:Key="Text.Squash.Into" xml:space="preserve">合并入：</x:String>
+  <x:String x:Key="Text.ForceSquash.Title" xml:space="preserve">跨合并压缩（扁平化历史）</x:String>
+  <x:String x:Key="Text.ForceSquash.Warn1" xml:space="preserve">操作会把从选定提交到 HEAD 的历史重写为一个提交</x:String>
+  <x:String x:Key="Text.ForceSquash.Warn2" xml:space="preserve">范围内的所有合并提交都会被移除</x:String>
+  <x:String x:Key="Text.ForceSquash.Warn3" xml:space="preserve">签名的提交或合并将丢失签名</x:String>
+  <x:String x:Key="Text.ForceSquash.Warn4" xml:space="preserve">之后需要强制推送</x:String>
+  <x:String x:Key="Text.ForceSquash.Warn5" xml:space="preserve">请关闭或更新相关的 MR/PR</x:String>
+  <x:String x:Key="Text.ForceSquash.CreateBackup" xml:space="preserve">重写前创建安全备份分支</x:String>
+  <x:String x:Key="Text.ForceSquash.AutoStash" xml:space="preserve">自动保存本地更改</x:String>
+  <x:String x:Key="Text.ForceSquash.KeepAuthorDate" xml:space="preserve">保留目标提交的原作者/日期</x:String>
+  <x:String x:Key="Text.ForceSquash.AppendMessages" xml:space="preserve">将被压缩提交的消息追加到正文</x:String>
+  <x:String x:Key="Text.ForceSquash.StashPopFailed" xml:space="preserve">应用自动保存失败。</x:String>
+  <x:String x:Key="Text.ForceSquash.Success" xml:space="preserve">历史已扁平化。备份分支：{0}</x:String>
+  <x:String x:Key="Text.ForceSquash.SuccessNoBackup" xml:space="preserve">历史已扁平化。</x:String>
   <x:String x:Key="Text.SSHKey" xml:space="preserve">SSH密钥 ：</x:String>
   <x:String x:Key="Text.SSHKey.Placeholder" xml:space="preserve">SSH密钥文件</x:String>
   <x:String x:Key="Text.Start" xml:space="preserve">开    始</x:String>

--- a/src/Resources/Locales/zh_TW.axaml
+++ b/src/Resources/Locales/zh_TW.axaml
@@ -148,6 +148,7 @@
   <x:String x:Key="Text.CommitCM.Reword" xml:space="preserve">編輯提交訊息</x:String>
   <x:String x:Key="Text.CommitCM.SaveAsPatch" xml:space="preserve">另存為修補檔 (patch)...</x:String>
   <x:String x:Key="Text.CommitCM.Squash" xml:space="preserve">合併此提交到上一個提交</x:String>
+  <x:String x:Key="Text.CommitCM.ForceSquash" xml:space="preserve">強制壓縮到此...</x:String>
   <x:String x:Key="Text.CommitDetail.Changes" xml:space="preserve">變更對比</x:String>
   <x:String x:Key="Text.CommitDetail.Changes.Count" xml:space="preserve">個檔案已變更</x:String>
   <x:String x:Key="Text.CommitDetail.Changes.Search" xml:space="preserve">搜尋變更...</x:String>
@@ -750,6 +751,19 @@
   <x:String x:Key="Text.SHALinkCM.NavigateTo" xml:space="preserve">前往此提交</x:String>
   <x:String x:Key="Text.Squash" xml:space="preserve">壓縮為單個提交</x:String>
   <x:String x:Key="Text.Squash.Into" xml:space="preserve">合併入:</x:String>
+  <x:String x:Key="Text.ForceSquash.Title" xml:space="preserve">跨合併壓縮（扁平化歷史）</x:String>
+  <x:String x:Key="Text.ForceSquash.Warn1" xml:space="preserve">操作會將從選定提交到 HEAD 的歷史重寫為單一提交</x:String>
+  <x:String x:Key="Text.ForceSquash.Warn2" xml:space="preserve">範圍內的所有合併提交都會被移除</x:String>
+  <x:String x:Key="Text.ForceSquash.Warn3" xml:space="preserve">簽名的提交或合併會失去簽章</x:String>
+  <x:String x:Key="Text.ForceSquash.Warn4" xml:space="preserve">之後需要強制推送</x:String>
+  <x:String x:Key="Text.ForceSquash.Warn5" xml:space="preserve">請關閉或更新相關的 MR/PR</x:String>
+  <x:String x:Key="Text.ForceSquash.CreateBackup" xml:space="preserve">重寫前建立安全備份分支</x:String>
+  <x:String x:Key="Text.ForceSquash.AutoStash" xml:space="preserve">自動暫存本地變更</x:String>
+  <x:String x:Key="Text.ForceSquash.KeepAuthorDate" xml:space="preserve">保留目標提交的原作者/日期</x:String>
+  <x:String x:Key="Text.ForceSquash.AppendMessages" xml:space="preserve">將被壓縮的提交訊息附加到正文</x:String>
+  <x:String x:Key="Text.ForceSquash.StashPopFailed" xml:space="preserve">套用自動暫存失敗。</x:String>
+  <x:String x:Key="Text.ForceSquash.Success" xml:space="preserve">歷史已扁平化。備份分支：{0}</x:String>
+  <x:String x:Key="Text.ForceSquash.SuccessNoBackup" xml:space="preserve">歷史已扁平化。</x:String>
   <x:String x:Key="Text.SSHKey" xml:space="preserve">SSH 金鑰:</x:String>
   <x:String x:Key="Text.SSHKey.Placeholder" xml:space="preserve">SSH 金鑰檔案</x:String>
   <x:String x:Key="Text.Start" xml:space="preserve">開  始</x:String>

--- a/src/ViewModels/ForceSquashAcrossMerges.cs
+++ b/src/ViewModels/ForceSquashAcrossMerges.cs
@@ -1,0 +1,144 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace SourceGit.ViewModels
+{
+    public class ForceSquashAcrossMerges : Popup
+    {
+        public Models.Commit Target { get; }
+        public bool CreateBackup { get; set; } = true;
+        public bool AutoStash { get; set; } = true;
+        public bool KeepAuthorDate { get; set; }
+        public bool AppendMessages { get; set; }
+        public string Message { get => _message; set => SetProperty(ref _message, value, true); }
+
+        public ForceSquashAcrossMerges(Repository repo, Models.Commit target)
+        {
+            _repo = repo;
+            Target = target;
+            _message = target.Subject;
+        }
+
+        public override async Task<bool> Sure()
+        {
+            _repo.SetWatcherEnabled(false);
+            ProgressDescription = "Squashing ...";
+            var log = _repo.CreateLog("ForceSquash");
+            Use(log);
+
+            var baseSHA = Target.Parents[0];
+            var signOff = _repo.Settings.EnableSignOffForCommit;
+            var stashName = string.Empty;
+            var succ = true;
+            var head = await new Commands.QueryRevisionByRefName(_repo.FullPath, "HEAD").GetResultAsync();
+            var headShort = head[..7];
+
+            if (AutoStash)
+            {
+                var changes = await new Commands.QueryLocalChanges(_repo.FullPath, false).GetResultAsync();
+                foreach (var c in changes)
+                {
+                    if (c.Index != Models.ChangeState.None || c.WorkTree != Models.ChangeState.None)
+                    {
+                        stashName = $"sourcegit/force-squash/{headShort}-{Guid.NewGuid().ToString("N")[..6]}";
+                        succ = await new Commands.Stash(_repo.FullPath).Use(log).PushAsync(stashName);
+                        break;
+                    }
+                }
+                if (!succ)
+                {
+                    log.Complete();
+                    _repo.SetWatcherEnabled(true);
+                    return false;
+                }
+            }
+
+            var backupName = string.Empty;
+            if (CreateBackup && _repo.CurrentBranch != null)
+            {
+                backupName = $"sourcegit/backup/flatten-{Models.Branch.FixName(_repo.CurrentBranch.Name)}-{_repo.CurrentBranch.Head[..7]}";
+                succ = await new Commands.Branch(_repo.FullPath, backupName).Use(log).CreateAsync("HEAD", false);
+                if (!succ)
+                {
+                    log.Complete();
+                    _repo.SetWatcherEnabled(true);
+                    return false;
+                }
+            }
+
+            List<Models.Commit> append = null;
+            if (AppendMessages)
+            {
+                append = await new Commands.QueryCommits(_repo.FullPath, $"{Target.SHA}..{head}", false).GetResultAsync();
+                append.Sort((l, r) => l.CommitterTime.CompareTo(r.CommitterTime));
+            }
+
+            succ = await new Commands.Reset(_repo.FullPath, baseSHA, "--soft").Use(log).ExecAsync();
+            if (!succ)
+            {
+                log.Complete();
+                _repo.SetWatcherEnabled(true);
+                return false;
+            }
+
+            var commitMsg = Message;
+            if (AppendMessages && append.Count > 0)
+            {
+                var lines = new List<string>();
+                foreach (var c in append)
+                {
+                    var msg = c.Subject.Trim();
+                    if (msg.Length == 0)
+                        continue;
+                    if (!lines.Contains(msg))
+                        lines.Add(msg);
+                }
+                if (lines.Count > 0)
+                    commitMsg += "\n\n" + string.Join("\n", lines);
+            }
+
+            var commit = new Commands.Commit(_repo.FullPath, commitMsg, signOff, false, false);
+            if (KeepAuthorDate)
+            {
+                var author = Target.Author;
+                var date = DateTimeOffset.FromUnixTimeSeconds((long)Target.AuthorTime).ToString("o");
+                commit.Args += $" --author={("" + author.Name + " <" + author.Email + ">").Quoted()} --date={date.Quoted()}";
+                commit.Envs["GIT_COMMITTER_DATE"] = date;
+            }
+            succ = await commit.Use(log).RunAsync();
+            if (!succ)
+            {
+                log.Complete();
+                _repo.SetWatcherEnabled(true);
+                return false;
+            }
+
+            if (!string.IsNullOrEmpty(stashName))
+            {
+                succ = await new Commands.Stash(_repo.FullPath).Use(log).PopAsync(stashName);
+                if (!succ)
+                {
+                    App.SendNotification(_repo.FullPath, App.Text("ForceSquash.StashPopFailed"));
+                    log.Complete();
+                    _repo.SetWatcherEnabled(true);
+                    return false;
+                }
+            }
+
+            log.Complete();
+            _repo.SetWatcherEnabled(true);
+            _repo.RefreshCommits();
+            if (!string.IsNullOrEmpty(backupName))
+                App.SendNotification(_repo.FullPath, App.Text("ForceSquash.Success", backupName));
+            else
+                App.SendNotification(_repo.FullPath, App.Text("ForceSquash.SuccessNoBackup"));
+            _repo.ShowPopup(new Push(_repo, _repo.CurrentBranch) { ForcePush = true });
+            return true;
+        }
+
+        private readonly Repository _repo;
+        private string _message;
+
+    }
+}

--- a/src/ViewModels/Histories.cs
+++ b/src/ViewModels/Histories.cs
@@ -331,6 +331,13 @@ namespace SourceGit.ViewModels
             }
         }
 
+        public Task ForceSquashAsync(Models.Commit commit)
+        {
+            if (_repo.CanCreatePopup())
+                _repo.ShowPopup(new ForceSquashAcrossMerges(_repo, commit));
+            return Task.CompletedTask;
+        }
+
         public async Task InteractiveRebaseAsync(Models.Commit commit, Models.InteractiveRebaseAction act)
         {
             var prefill = new InteractiveRebasePrefill(commit.SHA, act);

--- a/src/ViewModels/Preferences.cs
+++ b/src/ViewModels/Preferences.cs
@@ -158,6 +158,12 @@ namespace SourceGit.ViewModels
             set => SetProperty(ref _check4UpdatesOnStartup, value);
         }
 
+        public bool EnableDangerousHistoryRewrites
+        {
+            get => _enableDangerousHistoryRewrites;
+            set => SetProperty(ref _enableDangerousHistoryRewrites, value);
+        }
+
         public bool ShowAuthorTimeInGraph
         {
             get => _showAuthorTimeInGraph;
@@ -710,6 +716,7 @@ namespace SourceGit.ViewModels
         private bool _showChildren = false;
 
         private bool _check4UpdatesOnStartup = true;
+        private bool _enableDangerousHistoryRewrites = false;
         private double _lastCheckUpdateTime = 0;
         private string _ignoreUpdateTag = string.Empty;
 

--- a/src/Views/ForceSquashAcrossMerges.axaml
+++ b/src/Views/ForceSquashAcrossMerges.axaml
@@ -1,0 +1,31 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="using:SourceGit.ViewModels"
+             xmlns:v="using:SourceGit.Views"
+             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+             x:Class="SourceGit.Views.ForceSquashAcrossMerges"
+             x:DataType="vm:ForceSquashAcrossMerges">
+  <DockPanel Margin="8,0" Height="400">
+    <v:CommitMessageTextBox DockPanel.Dock="Bottom" Height="120" Margin="0,18,0,0" Text="{Binding Message, Mode=TwoWay}"/>
+    <StackPanel Orientation="Vertical">
+      <TextBlock FontSize="18"
+                 Classes="bold"
+                 Text="{DynamicResource Text.ForceSquash.Title}"/>
+      <StackPanel Margin="0,18,0,0">
+        <TextBlock Text="{DynamicResource Text.ForceSquash.Warn1}" Foreground="Red"/>
+        <TextBlock Margin="0,4,0,0" Text="{DynamicResource Text.ForceSquash.Warn2}"/>
+        <TextBlock Margin="0,4,0,0" Text="{DynamicResource Text.ForceSquash.Warn3}"/>
+        <TextBlock Margin="0,4,0,0" Text="{DynamicResource Text.ForceSquash.Warn4}"/>
+        <TextBlock Margin="0,4,0,0" Text="{DynamicResource Text.ForceSquash.Warn5}"/>
+      </StackPanel>
+      <StackPanel Margin="0,18,0,0">
+        <CheckBox Content="{DynamicResource Text.ForceSquash.CreateBackup}" IsChecked="{Binding CreateBackup, Mode=TwoWay}"/>
+        <CheckBox Content="{DynamicResource Text.ForceSquash.AutoStash}" IsChecked="{Binding AutoStash, Mode=TwoWay}"/>
+        <CheckBox Content="{DynamicResource Text.ForceSquash.KeepAuthorDate}" IsChecked="{Binding KeepAuthorDate, Mode=TwoWay}"/>
+        <CheckBox Content="{DynamicResource Text.ForceSquash.AppendMessages}" IsChecked="{Binding AppendMessages, Mode=TwoWay}"/>
+      </StackPanel>
+    </StackPanel>
+  </DockPanel>
+</UserControl>

--- a/src/Views/ForceSquashAcrossMerges.axaml.cs
+++ b/src/Views/ForceSquashAcrossMerges.axaml.cs
@@ -1,0 +1,13 @@
+using Avalonia.Controls;
+
+namespace SourceGit.Views
+{
+    public partial class ForceSquashAcrossMerges : UserControl
+    {
+        public ForceSquashAcrossMerges()
+        {
+            InitializeComponent();
+        }
+
+    }
+}

--- a/src/Views/Histories.axaml.cs
+++ b/src/Views/Histories.axaml.cs
@@ -10,6 +10,7 @@ using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Platform.Storage;
 using Avalonia.VisualTree;
+using SourceGit.ViewModels;
 
 namespace SourceGit.Views
 {
@@ -705,6 +706,22 @@ namespace SourceGit.Views
 
                         menu.Items.Add(new MenuItem() { Header = "-" });
                         menu.Items.Add(interactiveRebase);
+                    }
+                }
+
+                if (ViewModels.Preferences.Instance.EnableDangerousHistoryRewrites && commit.Parents.Count > 0)
+                {
+                    if (new Commands.IsAncestor(repo.FullPath, commit.SHA, "HEAD").Test())
+                    {
+                        var forceSquash = new MenuItem();
+                        forceSquash.Header = App.Text("CommitCM.ForceSquash");
+                        forceSquash.Icon = App.CreateMenuIcon("Icons.SquashIntoParent");
+                        forceSquash.Click += async (_, e) =>
+                        {
+                            await vm.ForceSquashAsync(commit);
+                            e.Handled = true;
+                        };
+                        menu.Items.Add(forceSquash);
                     }
                 }
 

--- a/src/Views/Preferences.axaml
+++ b/src/Views/Preferences.axaml
@@ -46,7 +46,7 @@
           <TabItem.Header>
             <TextBlock Classes="tab_header" Text="{DynamicResource Text.Preferences.General}"/>
           </TabItem.Header>
-          <Grid Margin="8" RowDefinitions="32,32,32,32,32,32,32,32,Auto" ColumnDefinitions="Auto,*">
+          <Grid Margin="8" RowDefinitions="32,32,32,32,32,32,32,32,32,Auto" ColumnDefinitions="Auto,*">
             <TextBlock Grid.Row="0" Grid.Column="0"
                        Text="{DynamicResource Text.Preferences.General.Locale}"
                        HorizontalAlignment="Right"
@@ -152,6 +152,11 @@
                       Content="{DynamicResource Text.Preferences.General.Check4UpdatesOnStartup}"
                       IsVisible="{x:Static s:App.IsCheckForUpdateCommandVisible}"
                       IsChecked="{Binding Check4UpdatesOnStartup, Mode=TwoWay}"/>
+
+            <CheckBox Grid.Row="9" Grid.Column="1"
+                      Height="32"
+                      Content="{DynamicResource Text.Preferences.General.EnableDangerousHistoryRewrites}"
+                      IsChecked="{Binding EnableDangerousHistoryRewrites, Mode=TwoWay}"/>
           </Grid>
         </TabItem>
 


### PR DESCRIPTION
- Adds “Force squash to here…” in the commit context menu, gated by Preferences → “Enable dangerous history rewrites.”
- New dialog with options: create backup branch, auto-stash local changes, keep target commit’s author/date, append messages from squashed commits.
- Implementation: soft-reset to the target’s first parent, create a single commit, restore stash, then open Push dialog with Force Push preselected.
- Adds new commands: IsAncestor, DiffAll, DiffStat; extends Command with `Envs` to pass env vars (e.g., `GIT_COMMITTER_DATE`).
- Updates localizations for all supported languages.

<img width="789" height="466" alt="Screenshot 2025-08-19 at 05 08 23" src="https://github.com/user-attachments/assets/971b8845-bf46-404c-9f9e-beda169f2852" />
