### PR TITLE
build: use `_topdir` macro instead of hardcoded relative path

### DIFF
--- a/build/resources/rpm/SPECS/build.spec
+++ b/build/resources/rpm/SPECS/build.spec
@@ -20,10 +20,10 @@ mkdir -p %{buildroot}/opt/sourcegit
 mkdir -p %{buildroot}/%{_bindir}
 mkdir -p %{buildroot}/usr/share/applications
 mkdir -p %{buildroot}/usr/share/icons
-cp -f ../../../SourceGit/* %{buildroot}/opt/sourcegit/
+cp -f %{_topdir}/../../SourceGit/* %{buildroot}/opt/sourcegit/
 ln -rsf %{buildroot}/opt/sourcegit/sourcegit %{buildroot}/%{_bindir}
-cp -r ../../_common/applications %{buildroot}/%{_datadir}
-cp -r ../../_common/icons %{buildroot}/%{_datadir}
+cp -r %{_topdir}/../_common/applications %{buildroot}/%{_datadir}
+cp -r %{_topdir}/../_common/icons %{buildroot}/%{_datadir}
 chmod 755 -R %{buildroot}/opt/sourcegit
 chmod 755 %{buildroot}/%{_datadir}/applications/sourcegit.desktop
 


### PR DESCRIPTION
I just noticed that Codeberg package CI started to fail when packaging rpm, probably, something related to working directory changed in rpmbuild. This change eliminates dependency on working directory, ensuring that path is relative to the spec file.