### PR TITLE
feat: add clear history button to commit message template/history dropdown

### DIFF
--- a/src/Resources/Locales/en_US.axaml
+++ b/src/Resources/Locales/en_US.axaml
@@ -856,6 +856,8 @@
   <x:String x:Key="Text.WorkingCopy.IncludeUntracked" xml:space="preserve">INCLUDE UNTRACKED FILES</x:String>
   <x:String x:Key="Text.WorkingCopy.NoCommitHistories" xml:space="preserve">NO RECENT INPUT MESSAGES</x:String>
   <x:String x:Key="Text.WorkingCopy.NoCommitTemplates" xml:space="preserve">NO COMMIT TEMPLATES</x:String>
+  <x:String x:Key="Text.WorkingCopy.ClearCommitHistories" xml:space="preserve">Clear History</x:String>
+  <x:String x:Key="Text.WorkingCopy.ConfirmClearHistories" xml:space="preserve">Are you sure you want to clear all commit message history? This action cannot be undone.</x:String>
   <x:String x:Key="Text.WorkingCopy.ResetAuthor" xml:space="preserve">Reset Author</x:String>
   <x:String x:Key="Text.WorkingCopy.SignOff" xml:space="preserve">SignOff</x:String>
   <x:String x:Key="Text.WorkingCopy.Staged" xml:space="preserve">STAGED</x:String>

--- a/src/ViewModels/WorkingCopy.cs
+++ b/src/ViewModels/WorkingCopy.cs
@@ -606,6 +606,15 @@ namespace SourceGit.ViewModels
             CommitMessage = tmpl.Apply(_repo.CurrentBranch, _staged);
         }
 
+        public async Task ClearCommitMessageHistory()
+        {
+            if (await App.AskConfirmAsync(App.Text("WorkingCopy.ConfirmClearHistories")))
+                Dispatcher.UIThread.Invoke(() =>
+                {
+                    _repo.Settings.CommitMessages.Clear();
+                });
+        }
+
         public async Task CommitAsync(bool autoStage, bool autoPush, Models.CommitCheckPassed checkPassed = Models.CommitCheckPassed.None)
         {
             if (string.IsNullOrWhiteSpace(_commitMessage))

--- a/src/Views/CommitMessageTextBox.axaml.cs
+++ b/src/Views/CommitMessageTextBox.axaml.cs
@@ -269,7 +269,7 @@ namespace SourceGit.Views
 
                         menu.Items.Add(item);
                     }
-                    
+
                     menu.Items.Add(new MenuItem() { Header = "-" });
 
                     var clearHistoryItem = new MenuItem()

--- a/src/Views/CommitMessageTextBox.axaml.cs
+++ b/src/Views/CommitMessageTextBox.axaml.cs
@@ -269,6 +269,21 @@ namespace SourceGit.Views
 
                         menu.Items.Add(item);
                     }
+                    
+                    menu.Items.Add(new MenuItem() { Header = "-" });
+
+                    var clearHistoryItem = new MenuItem()
+                    {
+                        Header = App.Text("WorkingCopy.ClearCommitHistories"),
+                        Icon = App.CreateMenuIcon("Icons.Clear")
+                    };
+                    clearHistoryItem.Click += async (_, e) =>
+                    {
+                        await vm.ClearCommitMessageHistory();
+                        e.Handled = true;
+                    };
+
+                    menu.Items.Add(clearHistoryItem);
                 }
 
                 menu.Placement = PlacementMode.TopEdgeAlignedLeft;


### PR DESCRIPTION
- Added ClearCommitMessageHistory method to WorkingCopy ViewModel with user confirmation
- Added "Clear History" menu item to commit message picker dropdown
- Implemented thread-safe collection clearing using Dispatcher.UIThread.Invoke
- Added localization support for clear history button and confirmation dialog
- Follows existing codebase patterns for destructive operations with async/await

<img width="359" height="222" alt="Screenshot 2025-08-22 082918" src="https://github.com/user-attachments/assets/c9fa24ef-f6f0-4cdf-a5e8-54dd26e8a9ad" />
<img width="552" height="138" alt="Screenshot 2025-08-22 082926" src="https://github.com/user-attachments/assets/ccff4bca-f3b6-424a-bdb4-961eb641fc8f" />