### PR TITLE
Feature: In the commit details menu, add a “Copy File Name” action.

### DIFF
--- a/TRANSLATION.md
+++ b/TRANSLATION.md
@@ -562,6 +562,7 @@ This document shows the translation status of each locale file in the repository
 - Text.ConfirmEmptyCommit.WithLocalChanges
 - Text.ConfirmRestart.Title
 - Text.ConfirmRestart.Message
+- Text.CopyFileName
 - Text.CopyFullPath
 - Text.CreateBranch.OverwriteExisting
 - Text.DeinitSubmodule

--- a/src/Resources/Locales/de_DE.axaml
+++ b/src/Resources/Locales/de_DE.axaml
@@ -265,6 +265,7 @@
   <x:String x:Key="Text.ConventionalCommit.Type" xml:space="preserve">Typ der Änderung:</x:String>
   <x:String x:Key="Text.Copy" xml:space="preserve">Kopieren</x:String>
   <x:String x:Key="Text.CopyAllText" xml:space="preserve">Gesamten Text kopieren</x:String>
+  <x:String x:Key="Text.CopyFileName" xml:space="preserve">Dateinamen kopieren</x:String>
   <x:String x:Key="Text.CopyFullPath" xml:space="preserve">Ganzen Pfad kopieren</x:String>
   <x:String x:Key="Text.CopyPath" xml:space="preserve">Pfad kopieren</x:String>
   <x:String x:Key="Text.CreateBranch" xml:space="preserve">Branch erstellen...</x:String>

--- a/src/Resources/Locales/en_US.axaml
+++ b/src/Resources/Locales/en_US.axaml
@@ -263,6 +263,7 @@
   <x:String x:Key="Text.ConventionalCommit.Type" xml:space="preserve">Type of Change:</x:String>
   <x:String x:Key="Text.Copy" xml:space="preserve">Copy</x:String>
   <x:String x:Key="Text.CopyAllText" xml:space="preserve">Copy All Text</x:String>
+  <x:String x:Key="Text.CopyFileName" xml:space="preserve">Copy File Name</x:String>
   <x:String x:Key="Text.CopyFullPath" xml:space="preserve">Copy Full Path</x:String>
   <x:String x:Key="Text.CopyPath" xml:space="preserve">Copy Path</x:String>
   <x:String x:Key="Text.CreateBranch" xml:space="preserve">Create Branch...</x:String>

--- a/src/Resources/Locales/es_ES.axaml
+++ b/src/Resources/Locales/es_ES.axaml
@@ -264,6 +264,7 @@
   <x:String x:Key="Text.ConventionalCommit.Type" xml:space="preserve">Tipo de Cambio:</x:String>
   <x:String x:Key="Text.Copy" xml:space="preserve">Copiar</x:String>
   <x:String x:Key="Text.CopyAllText" xml:space="preserve">Copiar Todo el Texto</x:String>
+  <x:String x:Key="Text.CopyFileName" xml:space="preserve">Copiar nombre de archivo</x:String>
   <x:String x:Key="Text.CopyFullPath" xml:space="preserve">Copiar Ruta Completa</x:String>
   <x:String x:Key="Text.CopyPath" xml:space="preserve">Copiar Ruta</x:String>
   <x:String x:Key="Text.CreateBranch" xml:space="preserve">Crear Rama...</x:String>

--- a/src/Resources/Locales/fr_FR.axaml
+++ b/src/Resources/Locales/fr_FR.axaml
@@ -180,6 +180,7 @@
   <x:String x:Key="Text.ConventionalCommit.Type" xml:space="preserve">Type de Changement :</x:String>
   <x:String x:Key="Text.Copy" xml:space="preserve">Copier</x:String>
   <x:String x:Key="Text.CopyAllText" xml:space="preserve">Copier tout le texte</x:String>
+  <x:String x:Key="Text.CopyFileName" xml:space="preserve">Copier le nom du fichier</x:String>
   <x:String x:Key="Text.CopyFullPath" xml:space="preserve">Copier le chemin complet</x:String>
   <x:String x:Key="Text.CopyPath" xml:space="preserve">Copier le chemin</x:String>
   <x:String x:Key="Text.CreateBranch" xml:space="preserve">Créer une branche...</x:String>

--- a/src/Resources/Locales/it_IT.axaml
+++ b/src/Resources/Locales/it_IT.axaml
@@ -257,6 +257,7 @@
   <x:String x:Key="Text.ConventionalCommit.Type" xml:space="preserve">Tipo di Modifica:</x:String>
   <x:String x:Key="Text.Copy" xml:space="preserve">Copia</x:String>
   <x:String x:Key="Text.CopyAllText" xml:space="preserve">Copia Tutto il Testo</x:String>
+  <x:String x:Key="Text.CopyFileName" xml:space="preserve">Copia nome file</x:String>
   <x:String x:Key="Text.CopyFullPath" xml:space="preserve">Copia Intero Percorso</x:String>
   <x:String x:Key="Text.CopyPath" xml:space="preserve">Copia Percorso</x:String>
   <x:String x:Key="Text.CreateBranch" xml:space="preserve">Crea Branch...</x:String>

--- a/src/Resources/Locales/ja_JP.axaml
+++ b/src/Resources/Locales/ja_JP.axaml
@@ -179,6 +179,7 @@
   <x:String x:Key="Text.ConventionalCommit.Type" xml:space="preserve">変更の種類:</x:String>
   <x:String x:Key="Text.Copy" xml:space="preserve">コピー</x:String>
   <x:String x:Key="Text.CopyAllText" xml:space="preserve">すべてのテキストをコピー</x:String>
+  <x:String x:Key="Text.CopyFileName" xml:space="preserve">ファイル名をコピーする</x:String>
   <x:String x:Key="Text.CopyFullPath" xml:space="preserve">絶対パスをコピー</x:String>
   <x:String x:Key="Text.CopyPath" xml:space="preserve">パスをコピー</x:String>
   <x:String x:Key="Text.CreateBranch" xml:space="preserve">ブランチを作成...</x:String>

--- a/src/Resources/Locales/pt_BR.axaml
+++ b/src/Resources/Locales/pt_BR.axaml
@@ -163,6 +163,7 @@
   <x:String x:Key="Text.ConventionalCommit.Type" xml:space="preserve">Tipo de mudança:</x:String>
   <x:String x:Key="Text.Copy" xml:space="preserve">Copiar</x:String>
   <x:String x:Key="Text.CopyAllText" xml:space="preserve">Copiar todo o texto</x:String>
+  <x:String x:Key="Text.CopyFileName" xml:space="preserve">Copiar nome do arquivo</x:String>
   <x:String x:Key="Text.CopyPath" xml:space="preserve">Copiar Caminho</x:String>
   <x:String x:Key="Text.CreateBranch" xml:space="preserve">Criar Branch...</x:String>
   <x:String x:Key="Text.CreateBranch.BasedOn" xml:space="preserve">Baseado Em:</x:String>

--- a/src/Resources/Locales/ru_RU.axaml
+++ b/src/Resources/Locales/ru_RU.axaml
@@ -264,6 +264,7 @@
   <x:String x:Key="Text.ConventionalCommit.Type" xml:space="preserve">Тип изменения:</x:String>
   <x:String x:Key="Text.Copy" xml:space="preserve">Копировать</x:String>
   <x:String x:Key="Text.CopyAllText" xml:space="preserve">Копировать весь текст</x:String>
+  <x:String x:Key="Text.CopyFileName" xml:space="preserve">Копировать имя файла</x:String>
   <x:String x:Key="Text.CopyFullPath" xml:space="preserve">Копировать полный путь</x:String>
   <x:String x:Key="Text.CopyPath" xml:space="preserve">Копировать путь</x:String>
   <x:String x:Key="Text.CreateBranch" xml:space="preserve">Создать ветку...</x:String>

--- a/src/Views/CommitDetail.axaml.cs
+++ b/src/Views/CommitDetail.axaml.cs
@@ -298,8 +298,19 @@ namespace SourceGit.Views
                 e.Handled = true;
             };
 
+             var copyFileName = new MenuItem();
+            copyFileName.Header = App.Text("CopyFileName");
+            copyFileName.Icon = App.CreateMenuIcon("Icons.Copy");
+            copyFileName.Tag = OperatingSystem.IsMacOS() ? "⌘+⌥+C" : "Ctrl+Alt+C";
+            copyFileName.Click += async (_, e) =>
+            {
+                await App.CopyTextAsync(Path.GetFileName(fullPath));
+                e.Handled = true;
+            };
+
             menu.Items.Add(copyPath);
             menu.Items.Add(copyFullPath);
+            menu.Items.Add(copyFileName);
             return menu;
         }
 


### PR DESCRIPTION
Workflow - When reviewing a commit, a user can quickly copy the file’s name from the menu and paste it into their editor’s file search or navigation dialog, making it easier to locate and open the file.