### PR TITLE
fix: correct Windows version parameter in window frame fix

### DIFF
--- a/src/Native/Windows.cs
+++ b/src/Native/Windows.cs
@@ -56,7 +56,7 @@ namespace SourceGit.Native
         public void SetupApp(AppBuilder builder)
         {
             // Fix drop shadow issue on Windows 10
-            if (!OperatingSystem.IsWindowsVersionAtLeast(10, 22000))
+            if (!OperatingSystem.IsWindowsVersionAtLeast(10, 0, 22000))
             {
                 Window.WindowStateProperty.Changed.AddClassHandler<Window>((w, _) => FixWindowFrameOnWin10(w));
                 Control.LoadedEvent.AddClassHandler<Window>((w, _) => FixWindowFrameOnWin10(w));


### PR DESCRIPTION
The current code uses incorrect parameters when checking for Windows versions below Windows 10. The correct threshold should be (10, 0, 22000). 