### PR TITLE
"Show only my locks" checkbox did not work anymore in the LFS Locks window

### DIFF
--- a/src/ViewModels/LFSLocks.cs
+++ b/src/ViewModels/LFSLocks.cs
@@ -10,9 +10,9 @@ namespace SourceGit.ViewModels
     {
         public bool HasValidUserName
         {
-            get;
-            private set;
-        } = false;
+            get => _hasValidUsername;
+            private set => SetProperty(ref _hasValidUsername, value);
+        }
 
         public bool IsLoading
         {
@@ -99,5 +99,6 @@ namespace SourceGit.ViewModels
         private List<Models.LFSLock> _visibleLocks = [];
         private bool _showOnlyMyLocks = false;
         private string _userName;
+        private bool _hasValidUsername;
     }
 }


### PR DESCRIPTION
The "Show only my locks" checkbox stopped working, even if the username was valid. It was caused by a non-functional bound property. 
So I refactored the `HasValidUserName` property in `LFSLocks.cs` to use a backing field with SetProperty support. The bind now works correctly, and the checkbox can be used again.