### PR TITLE
feat: Add custom branch name option for push operations

### DIFF
--- a/src/Resources/Locales/de_DE.axaml
+++ b/src/Resources/Locales/de_DE.axaml
@@ -631,6 +631,8 @@
   <x:String x:Key="Text.Push.Revision.Title" xml:space="preserve">Revision zu Remote-Branch pushen</x:String>
   <x:String x:Key="Text.Push.Title" xml:space="preserve">Push</x:String>
   <x:String x:Key="Text.Push.To" xml:space="preserve">Remote-Branch:</x:String>
+  <x:String x:Key="Text.Push.To.CustomBranch" xml:space="preserve">Benutzerdefinierten Branch-Namen verwenden</x:String>
+  <x:String x:Key="Text.Push.To.CustomBranch.Placeholder" xml:space="preserve">Benutzerdefinierten Branch-Namen eingeben...</x:String>
   <x:String x:Key="Text.Push.Tracking" xml:space="preserve">Remote-Branch verfolgen</x:String>
   <x:String x:Key="Text.Push.WithAllTags" xml:space="preserve">Alle Tags pushen</x:String>
   <x:String x:Key="Text.PushTag" xml:space="preserve">Tag zum Remote pushen</x:String>

--- a/src/Resources/Locales/en_US.axaml
+++ b/src/Resources/Locales/en_US.axaml
@@ -631,6 +631,8 @@
   <x:String x:Key="Text.Push.Revision.Title" xml:space="preserve">Push Revision To Remote</x:String>
   <x:String x:Key="Text.Push.Title" xml:space="preserve">Push Changes To Remote</x:String>
   <x:String x:Key="Text.Push.To" xml:space="preserve">Remote Branch:</x:String>
+  <x:String x:Key="Text.Push.To.CustomBranch" xml:space="preserve">Use custom branch name</x:String>
+  <x:String x:Key="Text.Push.To.CustomBranch.Placeholder" xml:space="preserve">Enter custom branch name...</x:String>
   <x:String x:Key="Text.Push.Tracking" xml:space="preserve">Set as tracking branch</x:String>
   <x:String x:Key="Text.Push.WithAllTags" xml:space="preserve">Push all tags</x:String>
   <x:String x:Key="Text.PushTag" xml:space="preserve">Push Tag To Remote</x:String>

--- a/src/Resources/Locales/es_ES.axaml
+++ b/src/Resources/Locales/es_ES.axaml
@@ -635,6 +635,8 @@
   <x:String x:Key="Text.Push.Revision.Title" xml:space="preserve">Push Revisión al Remoto</x:String>
   <x:String x:Key="Text.Push.Title" xml:space="preserve">Push Cambios al Remoto</x:String>
   <x:String x:Key="Text.Push.To" xml:space="preserve">Rama Remota:</x:String>
+  <x:String x:Key="Text.Push.To.CustomBranch" xml:space="preserve">Usar nombre de rama personalizado</x:String>
+  <x:String x:Key="Text.Push.To.CustomBranch.Placeholder" xml:space="preserve">Ingrese nombre de rama personalizado...</x:String>
   <x:String x:Key="Text.Push.Tracking" xml:space="preserve">Establecer como rama de seguimiento</x:String>
   <x:String x:Key="Text.Push.WithAllTags" xml:space="preserve">Push todas las etiquetas</x:String>
   <x:String x:Key="Text.PushTag" xml:space="preserve">Push Etiqueta al Remoto</x:String>

--- a/src/Resources/Locales/fr_FR.axaml
+++ b/src/Resources/Locales/fr_FR.axaml
@@ -498,6 +498,8 @@
   <x:String x:Key="Text.Push.Remote" xml:space="preserve">Dépôt distant :</x:String>
   <x:String x:Key="Text.Push.Title" xml:space="preserve">Pousser les changements vers le dépôt distant</x:String>
   <x:String x:Key="Text.Push.To" xml:space="preserve">Branche distante :</x:String>
+  <x:String x:Key="Text.Push.To.CustomBranch" xml:space="preserve">Utiliser un nom de branche personnalisé</x:String>
+  <x:String x:Key="Text.Push.To.CustomBranch.Placeholder" xml:space="preserve">Saisir un nom de branche personnalisé...</x:String>
   <x:String x:Key="Text.Push.Tracking" xml:space="preserve">Définir comme branche de suivi</x:String>
   <x:String x:Key="Text.Push.WithAllTags" xml:space="preserve">Pousser tous les tags</x:String>
   <x:String x:Key="Text.PushTag" xml:space="preserve">Pousser les tags vers le dépôt distant</x:String>

--- a/src/Resources/Locales/it_IT.axaml
+++ b/src/Resources/Locales/it_IT.axaml
@@ -610,6 +610,8 @@
   <x:String x:Key="Text.Push.Revision.Title" xml:space="preserve">Invia Revisione Al Remoto</x:String>
   <x:String x:Key="Text.Push.Title" xml:space="preserve">Invia modifiche al remoto</x:String>
   <x:String x:Key="Text.Push.To" xml:space="preserve">Branch Remoto:</x:String>
+  <x:String x:Key="Text.Push.To.CustomBranch" xml:space="preserve">Usa nome branch personalizzato</x:String>
+  <x:String x:Key="Text.Push.To.CustomBranch.Placeholder" xml:space="preserve">Inserisci nome branch personalizzato...</x:String>
   <x:String x:Key="Text.Push.Tracking" xml:space="preserve">Imposta come branch di tracciamento</x:String>
   <x:String x:Key="Text.Push.WithAllTags" xml:space="preserve">Invia tutti i tag</x:String>
   <x:String x:Key="Text.PushTag" xml:space="preserve">Invia Tag al Remoto</x:String>

--- a/src/Resources/Locales/ja_JP.axaml
+++ b/src/Resources/Locales/ja_JP.axaml
@@ -497,6 +497,8 @@
   <x:String x:Key="Text.Push.Remote" xml:space="preserve">リモート:</x:String>
   <x:String x:Key="Text.Push.Title" xml:space="preserve">変更をリモートにプッシュ</x:String>
   <x:String x:Key="Text.Push.To" xml:space="preserve">リモート ブランチ:</x:String>
+  <x:String x:Key="Text.Push.To.CustomBranch" xml:space="preserve">カスタムブランチ名を使用</x:String>
+  <x:String x:Key="Text.Push.To.CustomBranch.Placeholder" xml:space="preserve">カスタムブランチ名を入力...</x:String>
   <x:String x:Key="Text.Push.Tracking" xml:space="preserve">追跡ブランチとして設定</x:String>
   <x:String x:Key="Text.Push.WithAllTags" xml:space="preserve">すべてのタグをプッシュ</x:String>
   <x:String x:Key="Text.PushTag" xml:space="preserve">リモートにタグをプッシュ</x:String>

--- a/src/Resources/Locales/pt_BR.axaml
+++ b/src/Resources/Locales/pt_BR.axaml
@@ -457,6 +457,8 @@
   <x:String x:Key="Text.Push.Remote" xml:space="preserve">Remoto:</x:String>
   <x:String x:Key="Text.Push.Title" xml:space="preserve">Empurrar Alterações para o Remoto</x:String>
   <x:String x:Key="Text.Push.To" xml:space="preserve">Branch Remoto:</x:String>
+  <x:String x:Key="Text.Push.To.CustomBranch" xml:space="preserve">Usar nome de branch personalizado</x:String>
+  <x:String x:Key="Text.Push.To.CustomBranch.Placeholder" xml:space="preserve">Digite o nome do branch personalizado...</x:String>
   <x:String x:Key="Text.Push.Tracking" xml:space="preserve">Definir como branch de rastreamento</x:String>
   <x:String x:Key="Text.Push.WithAllTags" xml:space="preserve">Empurrar todas as tags</x:String>
   <x:String x:Key="Text.PushTag" xml:space="preserve">Empurrar Tag para o Remoto</x:String>

--- a/src/Resources/Locales/ru_RU.axaml
+++ b/src/Resources/Locales/ru_RU.axaml
@@ -635,6 +635,8 @@
   <x:String x:Key="Text.Push.Revision.Title" xml:space="preserve">Выложить ревизию на удалёную</x:String>
   <x:String x:Key="Text.Push.Title" xml:space="preserve">Выложить изменения на внешний репозиторий</x:String>
   <x:String x:Key="Text.Push.To" xml:space="preserve">Ветка внешнего репозитория:</x:String>
+  <x:String x:Key="Text.Push.To.CustomBranch" xml:space="preserve">Использовать пользовательское имя ветки</x:String>
+  <x:String x:Key="Text.Push.To.CustomBranch.Placeholder" xml:space="preserve">Введите пользовательское имя ветки...</x:String>
   <x:String x:Key="Text.Push.Tracking" xml:space="preserve">Отслеживать ветку</x:String>
   <x:String x:Key="Text.Push.WithAllTags" xml:space="preserve">Выложить все метки</x:String>
   <x:String x:Key="Text.PushTag" xml:space="preserve">Выложить метку на внешний репозиторий</x:String>

--- a/src/Resources/Locales/ta_IN.axaml
+++ b/src/Resources/Locales/ta_IN.axaml
@@ -497,6 +497,8 @@
   <x:String x:Key="Text.Push.Remote" xml:space="preserve">தொலை:</x:String>
   <x:String x:Key="Text.Push.Title" xml:space="preserve">மாற்றங்களை தொலைக்கு தள்ளு</x:String>
   <x:String x:Key="Text.Push.To" xml:space="preserve">தொலை கிளை:</x:String>
+  <x:String x:Key="Text.Push.To.CustomBranch" xml:space="preserve">தனிப்பயன் கிளைப் பெயரைப் பயன்படுத்து</x:String>
+  <x:String x:Key="Text.Push.To.CustomBranch.Placeholder" xml:space="preserve">தனிப்பயன் கிளைப் பெயரை உள்ளிடவும்...</x:String>
   <x:String x:Key="Text.Push.Tracking" xml:space="preserve">கண்காணிப்பு கிளையாக அமை</x:String>
   <x:String x:Key="Text.Push.WithAllTags" xml:space="preserve">அனைத்து குறிச்சொற்களையும் தள்ளு</x:String>
   <x:String x:Key="Text.PushTag" xml:space="preserve">தொலைக்கு குறிச்சொல்லை தள்ளு</x:String>

--- a/src/Resources/Locales/uk_UA.axaml
+++ b/src/Resources/Locales/uk_UA.axaml
@@ -502,6 +502,8 @@
   <x:String x:Key="Text.Push.Remote" xml:space="preserve">Віддалене сховище:</x:String>
   <x:String x:Key="Text.Push.Title" xml:space="preserve">Надіслати зміни на віддалене сховище</x:String>
   <x:String x:Key="Text.Push.To" xml:space="preserve">Віддалена гілка:</x:String>
+  <x:String x:Key="Text.Push.To.CustomBranch" xml:space="preserve">Використовувати користувацьку назву гілки</x:String>
+  <x:String x:Key="Text.Push.To.CustomBranch.Placeholder" xml:space="preserve">Введіть користувацьку назву гілки...</x:String>
   <x:String x:Key="Text.Push.Tracking" xml:space="preserve">Встановити як відстежувану гілку</x:String>
   <x:String x:Key="Text.Push.WithAllTags" xml:space="preserve">Надіслати всі теги</x:String>
   <x:String x:Key="Text.PushTag" xml:space="preserve">Надіслати тег на віддалене сховище</x:String>

--- a/src/Resources/Locales/zh_CN.axaml
+++ b/src/Resources/Locales/zh_CN.axaml
@@ -635,6 +635,8 @@
   <x:String x:Key="Text.Push.Revision.Title" xml:space="preserve">推送指定修订到远程仓库</x:String>
   <x:String x:Key="Text.Push.Title" xml:space="preserve">推送到远程仓库</x:String>
   <x:String x:Key="Text.Push.To" xml:space="preserve">远程分支 ：</x:String>
+  <x:String x:Key="Text.Push.To.CustomBranch" xml:space="preserve">使用自定义分支名称</x:String>
+  <x:String x:Key="Text.Push.To.CustomBranch.Placeholder" xml:space="preserve">输入自定义分支名称...</x:String>
   <x:String x:Key="Text.Push.Tracking" xml:space="preserve">跟踪远程分支</x:String>
   <x:String x:Key="Text.Push.WithAllTags" xml:space="preserve">同时推送标签</x:String>
   <x:String x:Key="Text.PushTag" xml:space="preserve">推送标签到远程仓库</x:String>

--- a/src/Resources/Locales/zh_TW.axaml
+++ b/src/Resources/Locales/zh_TW.axaml
@@ -635,6 +635,8 @@
   <x:String x:Key="Text.Push.Revision.Title" xml:space="preserve">推送修訂到遠端存放庫</x:String>
   <x:String x:Key="Text.Push.Title" xml:space="preserve">推送到遠端存放庫</x:String>
   <x:String x:Key="Text.Push.To" xml:space="preserve">遠端分支:</x:String>
+  <x:String x:Key="Text.Push.To.CustomBranch" xml:space="preserve">使用自訂分支名稱</x:String>
+  <x:String x:Key="Text.Push.To.CustomBranch.Placeholder" xml:space="preserve">輸入自訂分支名稱...</x:String>
   <x:String x:Key="Text.Push.Tracking" xml:space="preserve">追蹤遠端分支</x:String>
   <x:String x:Key="Text.Push.WithAllTags" xml:space="preserve">同時推送標籤</x:String>
   <x:String x:Key="Text.PushTag" xml:space="preserve">推送標籤到遠端存放庫</x:String>

--- a/src/Views/Push.axaml
+++ b/src/Views/Push.axaml
@@ -12,7 +12,7 @@
                Classes="bold"
                Text="{DynamicResource Text.Push.Title}"/>
 
-    <Grid Margin="0,16,0,0" RowDefinitions="32,32,32,Auto,Auto,32,32" ColumnDefinitions="130,*">
+    <Grid Margin="0,16,0,0" RowDefinitions="32,32,32,32,Auto,Auto,32,32" ColumnDefinitions="130,*">
       <TextBlock Grid.Row="0" Grid.Column="0"
                  HorizontalAlignment="Right" VerticalAlignment="Center"
                  Margin="0,0,8,0"
@@ -58,51 +58,64 @@
                  HorizontalAlignment="Right" VerticalAlignment="Center"
                  Margin="0,0,8,0"
                  Text="{DynamicResource Text.Push.To}"/>
-      <ComboBox Grid.Row="2" Grid.Column="1"
-                x:Name="RemoteBranchesComboBox"
-                Height="28" Padding="8,0"
-                VerticalAlignment="Center" HorizontalAlignment="Stretch"
-                ItemsSource="{Binding RemoteBranches}"
-                IsTextSearchEnabled="True"
-                SelectedItem="{Binding SelectedRemoteBranch, Mode=TwoWay}">
-        <ComboBox.ItemTemplate>
-          <DataTemplate x:DataType="{x:Type m:Branch}">
-            <StackPanel Orientation="Horizontal" Height="20" VerticalAlignment="Center">
-              <Path Margin="0,0,8,0" Width="14" Height="14" Fill="{DynamicResource Brush.FG1}" Data="{StaticResource Icons.Branch}"/>
-              <TextBlock Text="{Binding Name}" VerticalAlignment="Center"/>
-              <Border Height="14"
-                      CornerRadius="7"
-                      Margin="4,0,0,0" Padding="6,0"
-                      VerticalAlignment="Center"
-                      Background="Green"
-                      IsVisible="{Binding Head, Converter={x:Static StringConverters.IsNullOrEmpty}}">
-                <TextBlock Text="{DynamicResource Text.Push.New}" FontSize="9" FontFamily="{DynamicResource Fonts.Monospace}" Foreground="White" VerticalAlignment="Center"/>
-              </Border>
-            </StackPanel>
-          </DataTemplate>
-        </ComboBox.ItemTemplate>
-      </ComboBox>
+      <Grid Grid.Row="2" Grid.Column="1">
+        <ComboBox x:Name="RemoteBranchesComboBox"
+                  Height="28" Padding="8,0"
+                  VerticalAlignment="Center" HorizontalAlignment="Stretch"
+                  ItemsSource="{Binding RemoteBranches}"
+                  IsTextSearchEnabled="True"
+                  SelectedItem="{Binding SelectedRemoteBranch, Mode=TwoWay}"
+                  IsVisible="{Binding !UseCustomBranchName}">
+          <ComboBox.ItemTemplate>
+            <DataTemplate x:DataType="{x:Type m:Branch}">
+              <StackPanel Orientation="Horizontal" Height="20" VerticalAlignment="Center">
+                <Path Margin="0,0,8,0" Width="14" Height="14" Fill="{DynamicResource Brush.FG1}" Data="{StaticResource Icons.Branch}"/>
+                <TextBlock Text="{Binding Name}" VerticalAlignment="Center"/>
+                <Border Height="14"
+                        CornerRadius="7"
+                        Margin="4,0,0,0" Padding="6,0"
+                        VerticalAlignment="Center"
+                        Background="Green"
+                        IsVisible="{Binding Head, Converter={x:Static StringConverters.IsNullOrEmpty}}">
+                  <TextBlock Text="{DynamicResource Text.Push.New}" FontSize="9" FontFamily="{DynamicResource Fonts.Monospace}" Foreground="White" VerticalAlignment="Center"/>
+                </Border>
+              </StackPanel>
+            </DataTemplate>
+          </ComboBox.ItemTemplate>
+        </ComboBox>
+
+        <TextBox Height="28" Padding="8,0"
+                 VerticalAlignment="Center" HorizontalAlignment="Stretch"
+                 Text="{Binding CustomRemoteBranchName, Mode=TwoWay}"
+                 Watermark="{DynamicResource Text.Push.To.CustomBranch.Placeholder}"
+                 IsVisible="{Binding UseCustomBranchName}"/>
+      </Grid>
 
       <CheckBox Grid.Row="3" Grid.Column="1"
+                Height="32"
+                Content="{DynamicResource Text.Push.To.CustomBranch}"
+                IsChecked="{Binding UseCustomBranchName, Mode=TwoWay}"/>
+
+      <CheckBox Grid.Row="4" Grid.Column="1"
                 Height="32"
                 Content="{DynamicResource Text.Push.Tracking}"
                 IsChecked="{Binding Tracking, Mode=TwoWay}"
                 IsVisible="{Binding IsSetTrackOptionVisible}"
                 ToolTip.Tip="-u"/>
 
-      <CheckBox Grid.Row="4" Grid.Column="1"
+      <CheckBox Grid.Row="5" Grid.Column="1"
                 Height="32"
                 Content="{DynamicResource Text.Push.CheckSubmodules}"
                 IsChecked="{Binding CheckSubmodules, Mode=TwoWay}"
                 IsVisible="{Binding IsCheckSubmodulesVisible}"
                 ToolTip.Tip="--recurse-submodules=check"/>
 
-      <CheckBox Grid.Row="5" Grid.Column="1"
+      <CheckBox Grid.Row="6" Grid.Column="1"
                 Content="{DynamicResource Text.Push.WithAllTags}"
                 IsChecked="{Binding PushAllTags, Mode=TwoWay}"
                 ToolTip.Tip="--tags"/>
 
-      <CheckBox Grid.Row="6" Grid.Column="1"
+      <CheckBox Grid.Row="7" Grid.Column="1"
                 Content="{DynamicResource Text.Push.Force}"
                 IsChecked="{Binding ForcePush, Mode=TwoWay}"
                 ToolTip.Tip="--force-with-lease"/>


### PR DESCRIPTION
### Summary
This PR adds the ability to push to a custom remote branch name while maintaining the current recommended workflow by default. Unlike PR #981, this implementation uses an opt-in toggle that guides users toward best practices while still providing flexibility when explicitly needed.

### Motivation
- Quick bug fixes: Working on develop and pushing a small fix to hotfix/issue-123 without creating the branch locally first
- Testing workflows: Creating a feature/new-experiment branch to test changes before pushing to feature/main
- New remote branches: Pushing to branches that don't exist yet or that you don't have local visibility to
- Cross-branch workflows: Experimenting on one branch and pushing to another for review

### Benefits
- For Beginners: Default ComboBox guides them to match local/remote branch names (addressing maintainer concerns)
- For Advanced Users: Checkbox provides explicit flexibility when needed (addressing user request)
- Clear Intent: Users consciously choose to use custom names rather than accidentally typing the wrong branch
- Discoverability: Feature is visible but not intrusive

<img width="535" height="360" alt="image" src="https://github.com/user-attachments/assets/3df1b101-59c3-4bda-ad88-c7c1d9c2f7a9" />
