### PR TITLE
Trim leading/trailing spaces for LFSLock data

### DIFF
--- a/src/Models/LFSLock.cs
+++ b/src/Models/LFSLock.cs
@@ -2,8 +2,21 @@
 {
     public class LFSLock
     {
-        public string File { get; set; } = string.Empty;
-        public string User { get; set; } = string.Empty;
+        public string File
+        {
+            get => _file;
+            set => _file = value.Trim();
+        }
+
+        public string User
+        {
+            get => _user;
+            set => _user = value.Trim();
+        }
+
         public long ID { get; set; } = 0;
+        
+        private string _file = string.Empty;
+        private string _user = string.Empty;
     }
 }


### PR DESCRIPTION
I have trimmed the leading/trailing spaces for the `File` and `User` properties in `LFSLock`. These spaces prevented the unlock procedure.