### PR TITLE
fix: handling of last line without newline in hunks

### DIFF
--- a/src/Models/DiffResult.cs
+++ b/src/Models/DiffResult.cs
@@ -176,7 +176,7 @@ namespace SourceGit.Models
                     var line = Lines[i];
                     if (line.Type != TextDiffLineType.Added)
                         continue;
-                    writer.WriteLine($"+{line.Content}");
+                    WriteLine(writer, '+', line);
                 }
             }
 
@@ -257,16 +257,16 @@ namespace SourceGit.Models
                     else if (line.Type == TextDiffLineType.Added)
                     {
                         if (revert)
-                            writer.WriteLine($" {line.Content}");
+                            WriteLine(writer, ' ', line);
                     }
                     else if (line.Type == TextDiffLineType.Deleted)
                     {
                         if (!revert)
-                            writer.WriteLine($" {line.Content}");
+                            WriteLine(writer, ' ', line);
                     }
                     else if (line.Type == TextDiffLineType.Normal)
                     {
-                        writer.WriteLine($" {line.Content}");
+                        WriteLine(writer, ' ', line);
                     }
                 }
             }
@@ -282,15 +282,15 @@ namespace SourceGit.Models
                 }
                 else if (line.Type == TextDiffLineType.Normal)
                 {
-                    writer.WriteLine($" {line.Content}");
+                    WriteLine(writer, ' ', line);
                 }
                 else if (line.Type == TextDiffLineType.Added)
                 {
-                    writer.WriteLine($"+{line.Content}");
+                    WriteLine(writer, '+', line);
                 }
                 else if (line.Type == TextDiffLineType.Deleted)
                 {
-                    writer.WriteLine($"-{line.Content}");
+                    WriteLine(writer, '-', line);
                 }
             }
 
@@ -380,16 +380,16 @@ namespace SourceGit.Models
                     else if (line.Type == TextDiffLineType.Added)
                     {
                         if (revert)
-                            writer.WriteLine($" {line.Content}");
+                            WriteLine(writer, ' ', line);
                     }
                     else if (line.Type == TextDiffLineType.Deleted)
                     {
                         if (!revert)
-                            writer.WriteLine($" {line.Content}");
+                            WriteLine(writer, ' ', line);
                     }
                     else if (line.Type == TextDiffLineType.Normal)
                     {
-                        writer.WriteLine($" {line.Content}");
+                        WriteLine(writer, ' ', line);
                     }
                 }
             }
@@ -405,7 +405,7 @@ namespace SourceGit.Models
                 }
                 else if (line.Type == TextDiffLineType.Normal)
                 {
-                    writer.WriteLine($" {line.Content}");
+                    WriteLine(writer, ' ', line);
                 }
                 else if (line.Type == TextDiffLineType.Added)
                 {
@@ -413,7 +413,7 @@ namespace SourceGit.Models
                     {
                         if (revert)
                         {
-                            writer.WriteLine($" {line.Content}");
+                            WriteLine(writer, ' ', line);
                         }
                         else
                         {
@@ -422,20 +422,20 @@ namespace SourceGit.Models
                     }
                     else
                     {
-                        writer.WriteLine($"+{line.Content}");
+                        WriteLine(writer, '+', line);
                     }
                 }
                 else if (line.Type == TextDiffLineType.Deleted)
                 {
                     if (isOldSide)
                     {
-                        writer.WriteLine($"-{line.Content}");
+                        WriteLine(writer, '-', line);
                     }
                     else
                     {
                         if (!revert)
                         {
-                            writer.WriteLine($" {line.Content}");
+                            WriteLine(writer, ' ', line);
                         }
                         else
                         {
@@ -596,6 +596,14 @@ namespace SourceGit.Models
 
             writer.WriteLine($"@@ -{oldStart},{oldCount} +{newStart},{newCount} @@");
             return true;
+        }
+
+        private static void WriteLine(StreamWriter writer, char prefix, TextDiffLine line)
+        {
+            writer.WriteLine($"{prefix}{line.Content}");
+
+            if (line.NoNewLineEndOfFile)
+                writer.WriteLine("\\ No newline at end of file");
         }
 
         [GeneratedRegex(@"^@@ \-(\d+),?\d* \+(\d+),?\d* @@")]


### PR DESCRIPTION
Motivation: Some editors (depending on editor configuration) change the last line of a file by adding a missing newline.  But in order to keep diffs at a minimum, it's sometimes advisable to not include this change into the commit.  This should be possible by discarding the hunk with this change.

Now it is possible to discard (or stage/unstage) such a change. Previously discarding such a change was ignored, when there were other changes in the same file.