### PR TITLE
[BUG] Fix: AutoScrollToFirstChange() was not working reliably for Side-By-Side Diff

### DIFF
--- a/src/ViewModels/DiffContext.cs
+++ b/src/ViewModels/DiffContext.cs
@@ -136,8 +136,7 @@ namespace SourceGit.ViewModels
 
                 if (ctx.IsSideBySide() != UseSideBySide)
                 {
-                    ctx = ctx.SwitchMode();
-                    Content = ctx;
+                    Content = ctx.SwitchMode();
                 }
             }
         }

--- a/src/Views/TextDiffView.axaml.cs
+++ b/src/Views/TextDiffView.axaml.cs
@@ -487,44 +487,38 @@ namespace SourceGit.Views
         {
         }
 
-        public virtual void GotoFirstChange()
+        protected virtual void SyncScrollOffset()
         {
-            var first = BlockNavigation.GotoFirst();
-            if (first != null)
+        }
+
+        private void GotoChange(ViewModels.BlockNavigation.Block block)
+        {
+            if (block != null)
             {
-                TextArea.Caret.Line = first.Start;
-                ScrollToLine(first.Start);
+                TextArea.Caret.Line = block.Start;
+                ScrollToLine(block.Start);
+                SyncScrollOffset();
             }
         }
 
-        public virtual void GotoPrevChange()
+        public void GotoFirstChange()
         {
-            var prev = BlockNavigation.GotoPrev();
-            if (prev != null)
-            {
-                TextArea.Caret.Line = prev.Start;
-                ScrollToLine(prev.Start);
-            }
+            GotoChange(BlockNavigation.GotoFirst());
         }
 
-        public virtual void GotoNextChange()
+        public void GotoPrevChange()
         {
-            var next = BlockNavigation.GotoNext();
-            if (next != null)
-            {
-                TextArea.Caret.Line = next.Start;
-                ScrollToLine(next.Start);
-            }
+            GotoChange(BlockNavigation.GotoPrev());
         }
 
-        public virtual void GotoLastChange()
+        public void GotoNextChange()
         {
-            var next = BlockNavigation.GotoLast();
-            if (next != null)
-            {
-                TextArea.Caret.Line = next.Start;
-                ScrollToLine(next.Start);
-            }
+            GotoChange(BlockNavigation.GotoNext());
+        }
+
+        public void GotoLastChange()
+        {
+            GotoChange(BlockNavigation.GotoLast());
         }
 
         public override void Render(DrawingContext context)
@@ -1095,30 +1089,6 @@ namespace SourceGit.Views
             return [];
         }
 
-        public override void GotoFirstChange()
-        {
-            base.GotoFirstChange();
-            SyncScrollOffset();
-        }
-
-        public override void GotoPrevChange()
-        {
-            base.GotoPrevChange();
-            SyncScrollOffset();
-        }
-
-        public override void GotoNextChange()
-        {
-            base.GotoNextChange();
-            SyncScrollOffset();
-        }
-
-        public override void GotoLastChange()
-        {
-            base.GotoLastChange();
-            SyncScrollOffset();
-        }
-
         public override void UpdateSelectedChunk(double y)
         {
             if (DataContext is not ViewModels.TwoSideTextDiff diff)
@@ -1315,7 +1285,7 @@ namespace SourceGit.Views
                 TextArea?.TextView?.Redraw();
         }
 
-        private void SyncScrollOffset()
+        protected override void SyncScrollOffset()
         {
             if (_scrollViewer is not null && DataContext is ViewModels.TwoSideTextDiff diff)
                 diff.ScrollOffset = _scrollViewer.Offset;


### PR DESCRIPTION
Both of the `SingleSideTextDiffPresenter` instances need to be scrolled/synced in `AutoScrollToFirstChange()`, for the auto-scrolling to work reliably. (To see where it failed, open a `Side-By-Side Diff` where the first change-block would be out-of-view, then toggle `Show All Lines` - when enabling the latter, the first change-block would NOT be correctly scrolled-to.)

As a bonus, a bit of cleanup and simplification was also done in related code:
* Added private helper method GotoChange(), to remove redundant code.
* Made `SyncScrollOffset()` virtual, so the `Goto<...>Change()` methods could be removed.
* In `DiffContext.CheckSettings()`, setting the `Context` is now made on a single (less redundant) line, just like in the `DiffContext.UseSideBySide` setter.