### PR TITLE
feature: add support for additional flags in push command

### DIFF
--- a/src/Commands/Push.cs
+++ b/src/Commands/Push.cs
@@ -4,7 +4,7 @@ namespace SourceGit.Commands
 {
     public class Push : Command
     {
-        public Push(string repo, string local, string remote, string remoteBranch, bool withTags, bool checkSubmodules, bool track, bool force)
+        public Push(string repo, string local, string remote, string remoteBranch, bool withTags, bool checkSubmodules, bool track, bool force, string additionalFlags = "")
         {
             _remote = remote;
 
@@ -20,6 +20,8 @@ namespace SourceGit.Commands
                 Args += "-u ";
             if (force)
                 Args += "--force-with-lease ";
+            if (!string.IsNullOrWhiteSpace(additionalFlags))
+                Args += $"{additionalFlags.Trim()} ";
 
             Args += $"{remote} {local}:{remoteBranch}";
         }

--- a/src/Resources/Locales/en_US.axaml
+++ b/src/Resources/Locales/en_US.axaml
@@ -654,6 +654,7 @@
   <x:String x:Key="Text.Push.To" xml:space="preserve">Remote Branch:</x:String>
   <x:String x:Key="Text.Push.Tracking" xml:space="preserve">Set as tracking branch</x:String>
   <x:String x:Key="Text.Push.WithAllTags" xml:space="preserve">Push all tags</x:String>
+  <x:String x:Key="Text.Push.AdditionalFlags" xml:space="preserve">Additional flags:</x:String>
   <x:String x:Key="Text.PushTag" xml:space="preserve">Push Tag To Remote</x:String>
   <x:String x:Key="Text.PushTag.PushAllRemotes" xml:space="preserve">Push to all remotes</x:String>
   <x:String x:Key="Text.PushTag.Remote" xml:space="preserve">Remote:</x:String>

--- a/src/ViewModels/Push.cs
+++ b/src/ViewModels/Push.cs
@@ -97,6 +97,12 @@ namespace SourceGit.ViewModels
             set;
         }
 
+        public string AdditionalFlags
+        {
+            get => _additionalFlags;
+            set => SetProperty(ref _additionalFlags, value);
+        }
+
         public Push(Repository repo, Models.Branch localBranch)
         {
             _repo = repo;
@@ -204,7 +210,8 @@ namespace SourceGit.ViewModels
                 PushAllTags,
                 _repo.Submodules.Count > 0 && CheckSubmodules,
                 _isSetTrackOptionVisible && _tracking,
-                ForcePush).Use(log).RunAsync();
+                ForcePush,
+                AdditionalFlags).Use(log).RunAsync();
 
             log.Complete();
             return succ;
@@ -263,5 +270,6 @@ namespace SourceGit.ViewModels
         private Models.Branch _selectedRemoteBranch = null;
         private bool _isSetTrackOptionVisible = false;
         private bool _tracking = true;
+        private string _additionalFlags = string.Empty;
     }
 }

--- a/src/Views/Push.axaml
+++ b/src/Views/Push.axaml
@@ -18,7 +18,7 @@
                  Text="{DynamicResource Text.Push.Title}"/>
     </StackPanel>
 
-    <Grid Margin="0,16,0,0" RowDefinitions="32,32,32,Auto,Auto,32,32" ColumnDefinitions="130,*">
+    <Grid Margin="0,16,0,0" RowDefinitions="32,32,32,Auto,Auto,32,32,32" ColumnDefinitions="130,*">
       <TextBlock Grid.Row="0" Grid.Column="0"
                  HorizontalAlignment="Right" VerticalAlignment="Center"
                  Margin="0,0,8,0"
@@ -122,6 +122,16 @@
                 Content="{DynamicResource Text.Push.Force}"
                 IsChecked="{Binding ForcePush, Mode=TwoWay}"
                 ToolTip.Tip="--force-with-lease"/>
+
+      <TextBlock Grid.Row="7" Grid.Column="0"
+                 HorizontalAlignment="Right" VerticalAlignment="Center"
+                 Margin="0,0,8,0"
+                 Text="{DynamicResource Text.Push.AdditionalFlags}"/>
+      <TextBox Grid.Row="7" Grid.Column="1"
+               Height="28" Padding="8,0"
+               VerticalAlignment="Center" HorizontalAlignment="Stretch"
+               Text="{Binding AdditionalFlags, Mode=TwoWay}"
+               Watermark="--no-verify, --dry-run, etc."/>
     </Grid>
   </StackPanel>
 </UserControl>


### PR DESCRIPTION
A little bug bear of mine. Sometimes for good reason, I need to skip the verify command. Previously I always had to revert to the CLI, I would prefer to be able to do this within sourcegit.

This allows users to pass custom git flags (e.g., --no-verify, --dry-run) to the push command through a new optional text field in the push dialog.

<img width="623" height="325" alt="image" src="https://github.com/user-attachments/assets/5da58b3e-ecbc-4a54-a35f-2bc749700029" />

<img width="623" height="325" alt="image" src="https://github.com/user-attachments/assets/41b4247e-d4b3-41af-b075-bf17549ad5ab" />
