### PR TITLE
fix: set macOS (Intel) runner to `macos-15-intel`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
             os: windows-2022
             runtime: win-arm64
           - name: macOS (Intel)
-            os: macos-13
+            os: macos-15-intel
             runtime: osx-x64
           - name: macOS (Apple Silicon)
             os: macos-latest


### PR DESCRIPTION
This is the last version supported by GitHub Actions for macOS x86_64.  The runner image `macos-13` is now deprecated.  See https://github.com/actions/runner-images/issues/13046.

For Apple Silicon the runner image is already set to `macos-latest`.