### PR TITLE
Default tracking branch for worktrees

### DIFF
--- a/src/Views/AddWorktree.axaml
+++ b/src/Views/AddWorktree.axaml
@@ -88,7 +88,7 @@
                 VerticalAlignment="Center" HorizontalAlignment="Stretch"
                 ItemsSource="{Binding RemoteBranches}"
                 IsTextSearchEnabled="True"
-                SelectedItem="{Binding SelectedTrackingBranch, Mode=TwoWay}"
+                SelectedItem="{Binding SetSelectedTrackingBranch, Mode=TwoWay}"
                 IsVisible="{Binding SetTrackingBranch, Mode=OneWay}">
         <ComboBox.ItemTemplate>
           <DataTemplate>


### PR DESCRIPTION
When the user toggles the checkbox for "Set tracking branch" in the worktree dialog, then the default tracking branch is set as the same as the selected branch.