### PR TITLE
add background fetch to log + background fetch respects git defaults

### DIFF
--- a/src/Commands/Fetch.cs
+++ b/src/Commands/Fetch.cs
@@ -5,7 +5,7 @@ namespace SourceGit.Commands
 {
     public class Fetch : Command
     {
-        public Fetch(string repo, string remote, bool noTags, bool force)
+        public Fetch(string repo, string remote, bool? noTags, bool force)
         {
             _remote = remote;
 
@@ -14,7 +14,8 @@ namespace SourceGit.Commands
 
             var builder = new StringBuilder(512);
             builder.Append("fetch --progress --verbose ");
-            builder.Append(noTags ? "--no-tags " : "--tags ");
+            if (noTags.HasValue)
+                builder.Append(noTags.Value ? "--no-tags " : "--tags ");
             if (force)
                 builder.Append("--force ");
             builder.Append(remote);

--- a/src/ViewModels/Repository.cs
+++ b/src/ViewModels/Repository.cs
@@ -1850,11 +1850,14 @@ namespace SourceGit.ViewModels
                     remotes.Add(r.Name);
 
                 IsAutoFetching = true;
+                var log = CreateLog("background Fetch");
 
                 if (_settings.FetchAllRemotes)
                 {
                     foreach (var remote in remotes)
-                        await new Commands.Fetch(FullPath, remote, false, false) { RaiseError = false }.RunAsync();
+                        await new Commands.Fetch(FullPath, remote, null, false) { RaiseError = false }
+                            .Use(log)
+                            .RunAsync();
                 }
                 else if (remotes.Count > 0)
                 {
@@ -1862,8 +1865,12 @@ namespace SourceGit.ViewModels
                         remotes.Find(x => x.Equals(_settings.DefaultRemote, StringComparison.Ordinal)) :
                         remotes[0];
 
-                    await new Commands.Fetch(FullPath, remote, false, false) { RaiseError = false }.RunAsync();
+                    await new Commands.Fetch(FullPath, remote, null, false) { RaiseError = false }
+                        .Use(log)
+                        .RunAsync();
                 }
+
+                log.Complete();
 
                 _lastFetchTime = DateTime.Now;
                 IsAutoFetching = false;


### PR DESCRIPTION
* adds a log entry for background fetches as they are git commands being run by user configuration of the application.
* in background fetches there is no possibility to choose between with or without tags. This needs to either be a user configuration, or use the 'tagOpt' git configuration (which it does by default when not specifying an option). To achieve this we need a third value for noTags, namely default. i introduced this through a nullable value with null being the 3th value.

possible changes to this PR:
* split the commit into 2 commits/PR's (but since it's so small i thought it wouldn't be an issue)
* introduce an enum instead of using null as a value
* make a repo or global configuration for the noTags in the background fetch.

if you want any of the mentioned changes (or any other), please let me know.