### PR TITLE
fix: do not fail if the pre-push hook is a broken symlink

### DIFF
--- a/src/ViewModels/Repository.cs
+++ b/src/ViewModels/Repository.cs
@@ -644,8 +644,15 @@ namespace SourceGit.ViewModels
             if (!File.Exists(path))
                 return false;
 
-            var content = File.ReadAllText(path);
-            return content.Contains("git lfs pre-push");
+            try
+            {
+                var content = File.ReadAllText(path);
+                return content.Contains("git lfs pre-push");
+            }
+            catch
+            {
+                return false;
+            }
         }
 
         public async Task InstallLFSAsync()


### PR DESCRIPTION
If the pre-push hook is a broken symlink, IsLFSEnabled was currently throwing a FileNotFoundException during ReadAllText.
It seems like File.Exists is not suffisant, as it only checks if the symlink exist, but not if the target of the symlink exists.