### PR TITLE
feature: click filters to navigate to branches and tags

### DIFF
--- a/src/ViewModels/Repository.cs
+++ b/src/ViewModels/Repository.cs
@@ -897,8 +897,24 @@ namespace SourceGit.ViewModels
             else
             {
                 SelectedViewIndex = 0;
+                if (sha == "HEAD")
+                    sha = _currentBranch.Head;
                 _histories?.NavigateTo(sha);
             }
+        }
+
+        public void NavigateToBranch(string branch, bool isDelayMode = false)
+        {
+            var b = _branches.Find(b => b.FullName.Equals(branch, StringComparison.Ordinal));
+            if (b != null)
+                NavigateToCommit(b.Head);
+        }
+
+        public void NavigateToTag(string tag, bool isDelayMode = false)
+        {
+            var t = _tags.Find(t => t.Name.Equals(tag, StringComparison.Ordinal));
+            if (t != null)
+                NavigateToCommit(t.SHA);
         }
 
         public void SetCommitMessage(string message)

--- a/src/Views/Repository.axaml
+++ b/src/Views/Repository.axaml
@@ -821,8 +821,14 @@
                   <StackPanel Orientation="Horizontal" Margin="8,0">
                     <Path Width="10" Height="10" Data="{StaticResource Icons.Branch}" IsVisible="{Binding IsBranch}"/>
                     <Path Width="10" Height="10" Data="{StaticResource Icons.Tag}" IsVisible="{Binding !IsBranch}"/>
-                    <TextBlock Text="{Binding Pattern, Converter={x:Static c:StringConverters.TrimRefsPrefix}}" Margin="4,0,8,0"/>
-
+                    <Button Margin="4,0,8,0"
+                            Padding="0"
+                            Background="Transparent"
+                            BorderThickness="0"
+                            Classes="icon_button"
+                            Click="OnNavigateToFilter"
+                            Content="{Binding Pattern, Converter={x:Static c:StringConverters.TrimRefsPrefix}}"
+                            />
                     <Button Classes="icon_button" VerticalAlignment="Center" Margin="0" Padding="0" Click="OnRemoveSelectedHistoryFilter">
                       <Path Width="8" Height="8" Data="{StaticResource Icons.Close}"/>
                     </Button>

--- a/src/Views/Repository.axaml.cs
+++ b/src/Views/Repository.axaml.cs
@@ -593,6 +593,31 @@ namespace SourceGit.Views
             e.Handled = true;
         }
 
+        private void OnNavigateToFilter(object sender, RoutedEventArgs e)
+        {
+            if (DataContext is ViewModels.Repository repo && sender is Button { DataContext: Models.HistoryFilter filter })
+            {
+                if (filter.Mode == Models.FilterMode.Excluded)
+                    return;
+
+                switch (filter.Type)
+                {
+                    default:
+                    case Models.FilterType.LocalBranchFolder:
+                    case Models.FilterType.RemoteBranchFolder:
+                        break;
+                    case Models.FilterType.LocalBranch:
+                    case Models.FilterType.RemoteBranch:
+                        repo.NavigateToBranch(filter.Pattern);
+                        break;
+                    case Models.FilterType.Tag:
+                        repo.NavigateToTag(filter.Pattern);
+                        break;
+                }
+                e.Handled = true;
+            }
+        }
+
         private void OnRemoveSelectedHistoryFilter(object sender, RoutedEventArgs e)
         {
             if (DataContext is ViewModels.Repository repo && sender is Button { DataContext: Models.HistoryFilter filter })


### PR DESCRIPTION
- Add a function that allows you to navigate to the corresponding node by clicking the filter icon

https://github.com/user-attachments/assets/cde2a953-dc6f-490c-833f-274e9c6ae5e2

