### PR TITLE
feat: prune on demand - with respect to git config as default

### DIFF
--- a/src/Commands/Fetch.cs
+++ b/src/Commands/Fetch.cs
@@ -5,7 +5,7 @@ namespace SourceGit.Commands
 {
     public class Fetch : Command
     {
-        public Fetch(string repo, string remote, bool noTags, bool force)
+        public Fetch(string repo, string remote, bool noTags, bool force, bool prune)
         {
             _remote = remote;
 
@@ -17,6 +17,8 @@ namespace SourceGit.Commands
             builder.Append(noTags ? "--no-tags " : "--tags ");
             if (force)
                 builder.Append("--force ");
+            if (prune)
+                builder.Append("--prune ");
             builder.Append(remote);
 
             Args = builder.ToString();

--- a/src/Resources/Locales/en_US.axaml
+++ b/src/Resources/Locales/en_US.axaml
@@ -386,6 +386,7 @@
   <x:String x:Key="Text.Fetch.AllRemotes" xml:space="preserve">Fetch all remotes</x:String>
   <x:String x:Key="Text.Fetch.Force" xml:space="preserve">Force override local refs</x:String>
   <x:String x:Key="Text.Fetch.NoTags" xml:space="preserve">Fetch without tags</x:String>
+  <x:String x:Key="Text.Fetch.Prune" xml:space="preserve">Prune deleted branches</x:String>
   <x:String x:Key="Text.Fetch.Remote" xml:space="preserve">Remote:</x:String>
   <x:String x:Key="Text.Fetch.Title" xml:space="preserve">Fetch Remote Changes</x:String>
   <x:String x:Key="Text.FileCM.AssumeUnchanged" xml:space="preserve">Assume unchanged</x:String>

--- a/src/ViewModels/AddRemote.cs
+++ b/src/ViewModels/AddRemote.cs
@@ -105,7 +105,7 @@ namespace SourceGit.ViewModels
                     .Use(log)
                     .SetAsync($"remote.{_name}.sshkey", _useSSH ? SSHKey : null);
 
-                await new Commands.Fetch(_repo.FullPath, _name, false, false)
+                await new Commands.Fetch(_repo.FullPath, _name, false, false, false)
                     .Use(log)
                     .RunAsync();
             }

--- a/src/Views/Fetch.axaml
+++ b/src/Views/Fetch.axaml
@@ -18,7 +18,7 @@
                  Text="{DynamicResource Text.Fetch.Title}"/>
     </StackPanel>
     
-    <Grid Margin="0,16,0,0" RowDefinitions="32,32,Auto,32" ColumnDefinitions="120,*">
+    <Grid Margin="0,16,0,0" RowDefinitions="32,32,Auto,32,32" ColumnDefinitions="120,*">
       <TextBlock Grid.Row="0" Grid.Column="0"
                  HorizontalAlignment="Right" VerticalAlignment="Center"
                  Margin="0,0,8,0"
@@ -60,6 +60,11 @@
                 Content="{DynamicResource Text.Fetch.NoTags}"
                 IsChecked="{Binding NoTags, Mode=TwoWay}"
                 ToolTip.Tip="--no-tags"/>
+
+      <CheckBox Grid.Row="4" Grid.Column="1"
+                Content="{DynamicResource Text.Fetch.Prune}"
+                IsChecked="{Binding Prune, Mode=TwoWay}"
+                ToolTip.Tip="--prune"/>
     </Grid>
   </StackPanel>
 </UserControl>


### PR DESCRIPTION
SourceGit already have global setting for --prune that is fully synced with git config.

but sometimes there is a need to prune on demand.
I'm using it a lot - and still prefer default to be off.
I also saw there was another PR suggesting a fix for that - so it's not only my need. but my PR respects the repo config and git config - **so it should not break current design**.

if there will be no accepted solution - there is no way to prune-on-demand via SourceGit and I find myself everytime switch to terminal :(