### PR TITLE
Enhance CommitMessageToolBox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 .vs/
 .vscode/
 .idea/
+# DevExpress CodeRush related files
+.cr/
 
 *.sln.docstates
 *.user

--- a/src/Views/CommitMessageToolBox.axaml
+++ b/src/Views/CommitMessageToolBox.axaml
@@ -38,7 +38,7 @@
           <Button Grid.Column="0"
                   Classes="icon_button"
                   Width="24"
-                  Margin="0,0,4,0" Padding="0"
+                  Margin="0,0,4,0" Padding="4"
                   Click="OnOpenCommitMessagePicker"
                   IsVisible="{Binding #ThisControl.ShowAdvancedOptions}"
                   ToolTip.Tip="{DynamicResource Text.WorkingCopy.CommitMessageHelper}">
@@ -48,7 +48,7 @@
           <Button Grid.Column="1"
                   Classes="icon_button"
                   Width="24"
-                  Margin="0,0,4,0" Padding="0"
+                  Margin="0,0,4,0" Padding="4"
                   Click="OnOpenOpenAIHelper"
                   IsVisible="{Binding #ThisControl.ShowAdvancedOptions}"
                   ToolTip.Tip="{DynamicResource Text.AIAssistant.Tip}">
@@ -58,7 +58,7 @@
           <Button Grid.Column="2"
                   Classes="icon_button"
                   Width="24"
-                  Margin="0,0,4,0" Padding="0"
+                  Margin="0,0,4,0" Padding="4"
                   Click="OnOpenConventionalCommitHelper"
                   ToolTip.Tip="{DynamicResource Text.ConventionalCommit}">
             <Path Width="13" Height="13" Margin="0,1,0,0" Data="{StaticResource Icons.CommitMessageGenerator}"/>

--- a/src/Views/CommitMessageToolBox.axaml.cs
+++ b/src/Views/CommitMessageToolBox.axaml.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
-
+using System.Threading.Tasks;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
@@ -365,8 +365,16 @@ namespace SourceGit.Views
             InitializeComponent();
         }
 
+        private ContextMenu _commitMessagePickerMenu = null;
+
         private async void OnOpenCommitMessagePicker(object sender, RoutedEventArgs e)
         {
+            if (_commitMessagePickerMenu != null)
+            {
+                e.Handled = true;
+                return;
+            }
+
             if (sender is Button button && DataContext is ViewModels.WorkingCopy vm && ShowAdvancedOptions)
             {
                 var repo = vm.Repository;
@@ -478,14 +486,28 @@ namespace SourceGit.Views
                 }
 
                 menu.Placement = PlacementMode.TopEdgeAlignedLeft;
+                menu.Closed += async (_, _) =>
+                {
+                    await Task.Delay(100); // Let the click event be processed
+                    _commitMessagePickerMenu = null;
+                };
+                _commitMessagePickerMenu = menu;
                 menu.Open(button);
             }
 
             e.Handled = true;
         }
 
+        private ContextMenu _openAIHelperMenu = null;
+
         private async void OnOpenOpenAIHelper(object sender, RoutedEventArgs e)
         {
+            if (_openAIHelperMenu != null)
+            {
+                e.Handled = true;
+                return;
+            }
+
             if (DataContext is ViewModels.WorkingCopy vm && sender is Control control && ShowAdvancedOptions)
             {
                 var repo = vm.Repository;
@@ -523,6 +545,12 @@ namespace SourceGit.Views
 
                     menu.Items.Add(item);
                 }
+                menu.Closed += async (_, _) =>
+                {
+                    await Task.Delay(100); // Let the click event be processed
+                    _openAIHelperMenu = null;
+                };
+                _openAIHelperMenu = menu;
                 menu.Open(control);
             }
 


### PR DESCRIPTION
Increase the padding of the three buttons to make them easier to press and prevent two context menus from reopening.
