### PR TITLE
doc: simplify Homebrew installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,9 +104,8 @@ For **Windows** users:
 
 For **macOS** users:
 
-* Thanks [@ybeapps](https://github.com/ybeapps) for making `SourceGit` available on `Homebrew`. You can simply install it with following command:
+* Thanks [@ybeapps](https://github.com/ybeapps) for making `SourceGit` available on `Homebrew`:
   ```shell
-  brew tap ybeapps/homebrew-sourcegit
   brew install --cask sourcegit
   ```
 * If you want to install `SourceGit.app` from GitHub Release manually, you need run following command to make sure it works:


### PR DESCRIPTION
Removed brew tap requirement as SourceGit is now available in the official Homebrew Cask repository. 🎉🎉🎉🎉🎉🎉🎉🎉🎉

@love-linger I think we can think to setup a web hook on your repo so whenever a release is maid - it will trigger the update to hombres immediately instead of 4 times a day
I can provide the simple workflow - but I need to pass you the secret token (that will allow you to trigger github action in my repo) somehow.

how can we do this?

this can do the job:
```yaml
name: Notify Homebrew Tap

on:
  release:
    types: [published]

jobs:
  notify-homebrew:
    runs-on: ubuntu-latest
    steps:
      - name: Notify Homebrew tap
        env:
          TAG: ${{ github.event.release.tag_name }}
          HOMEBREW_TAP_REPO_TOKEN: ${{ secrets.HOMEBREW_TAP_REPO_TOKEN }}
        run: |
          echo "📢 Notifying Homebrew tap of new release $TAG..."
          curl -X POST \
            -H "Authorization: token $HOMEBREW_TAP_REPO_TOKEN" \
            -H "Accept: application/vnd.github.v3+json" \
            https://api.github.com/repos/ybeapps/homebrew-sourcegit/dispatches \
            -d "{\"event_type\":\"new-sourcegit-release\",\"client_payload\":{\"version\":\"$TAG\"}}"
          echo "✅ Homebrew tap notified successfully"
```