### PR TITLE
feature: webhook to release to homebrew

### DIFF
--- a/.github/workflows/homebrew-notify.yml
+++ b/.github/workflows/homebrew-notify.yml
@@ -1,0 +1,22 @@
+name: Notify Homebrew Tap
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  notify-homebrew:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify Homebrew tap
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+          HOMEBREW_TAP_REPO_TOKEN: ${{ secrets.HOMEBREW_TAP_REPO_TOKEN }}
+        run: |
+          echo "📢 Notifying Homebrew tap of new release $TAG..."
+          curl -X POST \
+            -H "Authorization: token $HOMEBREW_TAP_REPO_TOKEN" \
+            -H "Accept: application/vnd.github.v3+json" \
+            https://api.github.com/repos/ybeapps/homebrew-sourcegit/dispatches \
+            -d "{\"event_type\":\"new-sourcegit-release\",\"client_payload\":{\"version\":\"$TAG\"}}"
+          echo "✅ Homebrew tap notified successfully"


### PR DESCRIPTION
this triggers a full workflow that eventually create a PR in hombrew-cask repo when this PR gets merged - all brew users can consume the new version