### PR TITLE
enhance: implement fast path for repository local change status update when `core.fsmonitor` and `core.untrackedcache` are enabled

### DIFF
--- a/src/Commands/Config.cs
+++ b/src/Commands/Config.cs
@@ -74,6 +74,27 @@ namespace SourceGit.Commands
             return rs.StdOut.Trim();
         }
 
+        // Get config value with type canonicalization
+        // Weird values will be converted by git, like "000" -> "false", "010" -> "true"
+        // git will report bad values like "fatal: bad boolean config value 'kkk' for 'core.untrackedcache'"
+        public async Task<bool?> GetBoolAsync(string key)
+        {
+            Args = $"config get --bool {key}";
+
+            var rs = await ReadToEndAsync().ConfigureAwait(false);
+            var stdout = rs.StdOut.Trim();
+            switch (rs.StdOut.Trim())
+            {
+                case "true":
+                    return true;
+                case "false":
+                    return false;
+                default:
+                    // Illegal values behave as if they are not set
+                    return null;
+            }
+        }
+
         public async Task<bool> SetAsync(string key, string value, bool allowEmpty = false)
         {
             var scope = _isLocal ? "--local" : "--global";

--- a/src/ViewModels/DropHead.cs
+++ b/src/ViewModels/DropHead.cs
@@ -29,7 +29,7 @@ namespace SourceGit.ViewModels
             var log = _repo.CreateLog($"Drop '{Target.SHA}'");
             Use(log);
 
-            var changes = await new Commands.QueryLocalChanges(_repo.FullPath, true).GetResultAsync();
+            var changes = await new Commands.QueryLocalChanges(_repo.FullPath, true, _repo.UseFastPathForUntrackedFiles).GetResultAsync();
             var needAutoStash = changes.Count > 0;
             var succ = false;
 

--- a/src/ViewModels/Reword.cs
+++ b/src/ViewModels/Reword.cs
@@ -37,7 +37,7 @@ namespace SourceGit.ViewModels
             var log = _repo.CreateLog("Reword HEAD");
             Use(log);
 
-            var changes = await new Commands.QueryLocalChanges(_repo.FullPath, false).GetResultAsync();
+            var changes = await new Commands.QueryLocalChanges(_repo.FullPath, false, _repo.UseFastPathForUntrackedFiles).GetResultAsync();
             var signOff = _repo.Settings.EnableSignOffForCommit;
             var noVerify = _repo.Settings.NoVerifyOnCommit;
             var needAutoStash = false;

--- a/src/ViewModels/SquashOrFixupHead.cs
+++ b/src/ViewModels/SquashOrFixupHead.cs
@@ -39,7 +39,7 @@ namespace SourceGit.ViewModels
             var log = _repo.CreateLog(IsFixupMode ? "Fixup" : "Squash");
             Use(log);
 
-            var changes = await new Commands.QueryLocalChanges(_repo.FullPath, false).GetResultAsync();
+            var changes = await new Commands.QueryLocalChanges(_repo.FullPath, false, _repo.UseFastPathForUntrackedFiles).GetResultAsync();
             var signOff = _repo.Settings.EnableSignOffForCommit;
             var noVerify = _repo.Settings.NoVerifyOnCommit;
             var needAutoStash = false;

--- a/src/ViewModels/StashChanges.cs
+++ b/src/ViewModels/StashChanges.cs
@@ -73,7 +73,7 @@ namespace SourceGit.ViewModels
                     }
                     else
                     {
-                        var all = await new Commands.QueryLocalChanges(_repo.FullPath, false)
+                        var all = await new Commands.QueryLocalChanges(_repo.FullPath, false, _repo.UseFastPathForUntrackedFiles)
                             .Use(log)
                             .GetResultAsync();
 


### PR DESCRIPTION
Finally this experiment has come to a stage where it's reviewable. It is still very early. Opinions are welcome. Binaries for testing (win-x64 only) can be downloaded here: https://github.com/AlanIWBFT/sourcegit/releases

### Problem it aims to solve: https://github.com/sourcegit-scm/sourcegit/issues/1998
To accurately report and let the user pick each individual untracked file, SourceGit uses `--untracked-files=all` (`-uall`) when doing `QueryLocalChanges`, which is unfortunately very slow on large repositories. `core.fsmonitor` and `core.untrackedcache` cannot help this case if `-uall` is specified as it makes the untracked cache bypassed, yielding no performance improvement.
This pull request detects if `core.fsmonitor` and `core.untrackedcache` are enabled and uses a two pass algorithm: it runs a normal `git status` first to retrive a list of untracked directories (which is fast as untracked cache is functioning here), then run `git status -uall` only on these dirs. The time it takes to traverse these dirs are much faster than running `-uall` on the entire repository.

To use this experimental feature, the user must deliberately enable `core.fsmonitor` and `core.untrackedcache`, or not setting `core.untrackedcache` but setting `feature.manyfiles` to `true`.

### Components
First, to robustly detect if the fast path is possible, `Commands.Config.GetBoolAsync` is added which leverages git itself to canonicalize possible weird values in config files, like "000" will be intepreted as "false", "010" -> "true".
Every time you open a repository the above detection is performed. If they are enabled, a normal, index-locking 'git status' will be run to populate/update the untracked cache. The first time will be slow as the cache needs to be populated entirely from empty. Subsequent runs will be much faster, in fact, negligible. (~0.4s on UE5-main). Thus the slow-down on UI start-up isn't very noticable expect for the first time. Since SourceGit always runs `git status` with `--no-optional-locks` which means the index will not be modified, the untracked cache thus cannot be updated either, once SourceGit is up. So we need a place to insert the update, and it is scheduled when you open the repository, as said above.

### Performance results
On large repos like UE5, a consistent ~5x - ~6x speedup is observed whenever a status update is needed and the responsiveness is greatly improved.

### Other fixes
As we've discussed in https://github.com/sourcegit-scm/sourcegit/issues/1998#issuecomment-3692145166, `Stash.PushAsync` `bool includeUntracked`'s default value has been changed to `false`. The intention is to let git handle the untracked instead of manually stash them (which was performed with `--included-untracked`, very slow (2x slower than the slow status update)).