### PR TITLE
fix: extra empty lines in diff (Windows)

### DIFF
--- a/src/Views/TextDiffView.axaml.cs
+++ b/src/Views/TextDiffView.axaml.cs
@@ -931,7 +931,7 @@ namespace SourceGit.Views
                     if (line.NoNewLineEndOfFile)
                         builder.Append("\u26D4");
 
-                    builder.AppendLine();
+                    builder.Append('\n');
                 }
 
                 Text = builder.ToString();
@@ -1121,7 +1121,7 @@ namespace SourceGit.Views
                     if (line.NoNewLineEndOfFile)
                         builder.Append("\u26D4");
 
-                    builder.AppendLine();
+                    builder.Append('\n');
                 }
 
                 Text = builder.ToString();


### PR DESCRIPTION
When using CR/LF as newline on Windows, there were extra empty lines shown in diffs.

Commit b84b79 fixed a regression (#1996) by keeping CRs as content of diff lines instead of removing them.  Additionally since commit 796f88 (#1543) the output for diffs uses the default newline depending on platform, that's CR/LF on Windows.

As consequence on Windows with files containing CR/LF as newlines the content (ending in CR) and the default newline CR/LF resulted in CR CR LF, which is interpreted as two line breaks instead of one.

So b84b79 introduced itself a regression that's fixed in this commit by partially reverting commit 796f88.

This fixes #2001.