### PR TITLE
fix: last line change may disable hunk operation in two-side diff

### DIFF
--- a/src/Views/TextDiffView.axaml.cs
+++ b/src/Views/TextDiffView.axaml.cs
@@ -1183,7 +1183,8 @@ namespace SourceGit.Views
                     endLine.GetTextLineVisualYPosition(endLine.TextLines[^1], VisualYPosition.TextBottom) - view.VerticalOffset :
                     view.Bounds.Height;
 
-                diff.ConvertsToCombinedRange(ref startIdx, ref endIdx, IsOld);
+                startIdx = diff.ConvertToCombined(startIdx);
+                endIdx = diff.ConvertToCombined(endIdx);
                 TrySetChunk(new(rectStartY, rectEndY - rectStartY, startIdx, endIdx, false, IsOld));
             }
             else
@@ -1229,7 +1230,8 @@ namespace SourceGit.Views
                     endLine.GetTextLineVisualYPosition(endLine.TextLines[^1], VisualYPosition.TextBottom) - view.VerticalOffset :
                     view.Bounds.Height;
 
-                diff.ConvertsToCombinedRange(ref startIdx, ref endIdx, IsOld);
+                startIdx = diff.ConvertToCombined(startIdx);
+                endIdx = diff.ConvertToCombined(endIdx);
                 TrySetChunk(new(rectStartY, rectEndY - rectStartY, startIdx, endIdx, true, false));
             }
         }


### PR DESCRIPTION
If the last line is deleted or added, it was impossible to stage, unstage or discard the last hunk in a two-side diff view, if the hunk was selected on the side where the last line is missing (that's the left side for added lines and the right side for deleted lines).

Since the button(s) for hunk operations are on the right side of the diff view, it was easier to trigger this bug for a deleted last line.

This bug was introduced in commit 6511d15c01 while rewriting the text diff views.

This fixes the bug mentioned in https://github.com/sourcegit-scm/sourcegit/issues/1950#issuecomment-3630580428.