### PR TITLE
feat: select next and previous files when staging chunks

### DIFF
--- a/src/Models/DiffResult.cs
+++ b/src/Models/DiffResult.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Text.RegularExpressions;
 using Avalonia.Media.Imaging;
+using SourceGit.ViewModels;
 
 namespace SourceGit.Models
 {
@@ -49,6 +50,7 @@ namespace SourceGit.Models
         public bool HasChanges { get; set; } = false;
         public int IgnoredAdds { get; set; } = 0;
         public int IgnoredDeletes { get; set; } = 0;
+        public bool HasRemainingChanges { get; set; } = false;
     }
 
     public partial class TextDiff
@@ -65,10 +67,17 @@ namespace SourceGit.Models
             for (int i = 0; i < startLine - 1; i++)
             {
                 var line = Lines[i];
-                if (line.Type == TextDiffLineType.Added)
-                    rs.IgnoredAdds++;
-                else if (line.Type == TextDiffLineType.Deleted)
-                    rs.IgnoredDeletes++;
+                switch (line.Type)
+                {
+                    case TextDiffLineType.Added:
+                        rs.IgnoredAdds++;
+                        rs.HasRemainingChanges = true;
+                        break;
+                    case TextDiffLineType.Deleted:
+                        rs.IgnoredDeletes++;
+                        rs.HasRemainingChanges = true;
+                        break;
+                }
             }
 
             for (int i = startLine - 1; i < endLine; i++)
@@ -89,6 +98,18 @@ namespace SourceGit.Models
                         rs.HasChanges = true;
                         break;
                     }
+                }
+            }
+
+            for (var i = endLine; i < Lines.Count; i++)
+            {
+                var line = Lines[i];
+                switch (line.Type)
+                {
+                    case TextDiffLineType.Added:
+                    case TextDiffLineType.Deleted:
+                        rs.HasRemainingChanges = true;
+                        break;
                 }
             }
 

--- a/src/Views/Repository.axaml.cs
+++ b/src/Views/Repository.axaml.cs
@@ -4,6 +4,7 @@ using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Interactivity;
+using Avalonia.VisualTree;
 
 namespace SourceGit.Views
 {
@@ -609,6 +610,18 @@ namespace SourceGit.Views
                 await repo.ExecBisectCommandAsync(button.Tag as string);
 
             e.Handled = true;
+        }
+        
+        public void SelectNextStagedChangeWithoutSelection()
+        {
+            this.FindDescendantOfType<WorkingCopy>()
+                ?.SelectNextStagedChangeWithoutSelection();
+        }
+
+        public void SelectNextUnstagedChangeWithoutSelection()
+        {
+            this.FindDescendantOfType<WorkingCopy>()
+                ?.SelectNextUnstagedChangeWithoutSelection();
         }
     }
 }

--- a/src/Views/TextDiffView.axaml.cs
+++ b/src/Views/TextDiffView.axaml.cs
@@ -1496,6 +1496,10 @@ namespace SourceGit.Views
             await new Commands.Apply(repo.FullPath, tmpFile, true, "nowarn", "--cache --index").ExecAsync();
             File.Delete(tmpFile);
 
+            if (!selection.HasRemainingChanges)
+            {
+                repoView.SelectNextUnstagedChangeWithoutSelection();
+            }
             repo.MarkWorkingCopyDirtyManually();
         }
 
@@ -1526,6 +1530,11 @@ namespace SourceGit.Views
             await new Commands.Apply(repo.FullPath, tmpFile, true, "nowarn", "--cache --index --reverse").ExecAsync();
             File.Delete(tmpFile);
 
+            if (!selection.HasRemainingChanges)
+            {
+                repoView.SelectNextStagedChangeWithoutSelection();
+            }            
+            
             repo.MarkWorkingCopyDirtyManually();
         }
 
@@ -1563,6 +1572,10 @@ namespace SourceGit.Views
             await new Commands.Apply(repo.FullPath, tmpFile, true, "nowarn", "--reverse").ExecAsync();
             File.Delete(tmpFile);
 
+            if (selection.HasRemainingChanges)
+            {
+                repoView.SelectNextUnstagedChangeWithoutSelection();
+            }
             repo.MarkWorkingCopyDirtyManually();
         }
     }

--- a/src/Views/WorkingCopy.axaml.cs
+++ b/src/Views/WorkingCopy.axaml.cs
@@ -79,6 +79,15 @@ namespace SourceGit.Views
             }
         }
 
+        public void SelectNextUnstagedChangeWithoutSelection()
+        {
+            if (DataContext is ViewModels.WorkingCopy vm)
+            {
+                var next = UnstagedChangesView.GetNextChangeWithoutSelection();
+                vm.SelectedUnstaged = next != null ? [next] : [];
+            }
+        }
+
         private async void OnStagedChangeDoubleTapped(object _, RoutedEventArgs e)
         {
             if (DataContext is ViewModels.WorkingCopy vm)
@@ -87,6 +96,15 @@ namespace SourceGit.Views
                 await vm.UnstageChangesAsync(vm.SelectedStaged, next);
                 StagedChangesView.TakeFocus();
                 e.Handled = true;
+            }
+        }
+        
+        public void SelectNextStagedChangeWithoutSelection()
+        {
+            if (DataContext is ViewModels.WorkingCopy vm)
+            {
+                var next = StagedChangesView.GetNextChangeWithoutSelection();
+                vm.SelectedStaged = next != null ? [next] : [];
             }
         }
 


### PR DESCRIPTION
This is a rework of https://github.com/sourcegit-scm/sourcegit/pull/2022

**Old Behavior:** When staging chunks/hunks, there was only working copy refresh which which caused a loss of selection when staging the last chunk of the file. (same for unstaging and discarding). 

**New Beahvior:** We check whether the staged/unstaged/discarded chunk was the last change off the file. If yes, we forward the request to select the next file through the visual tree. 

Logic-wise this change does not change the behavior of how SourceGit select files. Unfortunately the ViewModels of the `ChangeCollectionView` are constructed in the specific views and are not part of the general ViewModel tree. 

Theoretically following architectural change would be possible: 

1. Move the `ChangeCollectionView.GetNextChangeWithoutSelection` to the `ViewModels.ChangeCollectionAsTree`, `ViewModels.ChangeCollectionAsGrid` and `ViewModels.ChangeCollectionAsList` (introducing a base interface with this method). 
2. Move the `CollectionChangeView.UpdateDataSource` into `ViewModels.WorkingCopy` and bind to the constructed viewmodels in `WorkingCopy.axaml`
3. Replace the "VisualTree traversal" with a "ViewModel traversal" by checking `repo.SelectedView` for a `ViewModels.WorkingCopy`

Or alternatively `RoutedEvents` could be used for decoupling.

Please let me know which path is the most desirable and I'll update things accordingly.  


