### PR TITLE
fix: sometimes no staged/unstaged changes were shown

### DIFF
--- a/src/ViewModels/WorkingCopy.cs
+++ b/src/ViewModels/WorkingCopy.cs
@@ -271,8 +271,6 @@ namespace SourceGit.ViewModels
                 return;
             }
 
-            _cached = changes;
-
             var lastSelectedUnstaged = new HashSet<string>();
             var lastSelectedStaged = new HashSet<string>();
             if (_selectedUnstaged is { Count: > 0 })
@@ -321,6 +319,7 @@ namespace SourceGit.ViewModels
                     return;
 
                 _isLoadingData = true;
+                _cached = changes;
                 HasUnsolvedConflicts = hasConflict;
                 VisibleUnstaged = visibleUnstaged;
                 VisibleStaged = visibleStaged;


### PR DESCRIPTION
Due to a race condition it was possible, that there were changes (the badge for LOCAL CHANGES showed a non-zero number), but there were no staged or unstaged files shown.

The problem was, that while loading the changes for the first time, the watcher could start the loading a second time.  The first loading was cancelled, but it could have already set the first instance variable.  Therefore, on the second load a shortcut was done, since there was seemingly no change.