### PR TITLE
fix: Use correct null device path on Windows

### DIFF
--- a/src/Commands/Command.cs
+++ b/src/Commands/Command.cs
@@ -181,7 +181,7 @@ namespace SourceGit.Commands
 
             // If an SSH private key was provided, sets the environment.
             if (!start.Environment.ContainsKey("GIT_SSH_COMMAND") && !string.IsNullOrEmpty(SSHKey))
-                start.Environment.Add("GIT_SSH_COMMAND", $"ssh -i '{SSHKey}' -F '/dev/null'");
+                start.Environment.Add("GIT_SSH_COMMAND", $"ssh -i '{SSHKey}' -F '{Native.OS.NullDevice}'");
 
             // Force using en_US.UTF-8 locale
             if (OperatingSystem.IsLinux())

--- a/src/Models/DiffOption.cs
+++ b/src/Models/DiffOption.cs
@@ -39,7 +39,7 @@ namespace SourceGit.Models
                     case ChangeState.Added:
                     case ChangeState.Untracked:
                         _extra = "--no-index";
-                        _orgPath = "/dev/null";
+                        _orgPath = Native.OS.NullDevice;
                         break;
                 }
             }

--- a/src/Models/DiffResult.cs
+++ b/src/Models/DiffResult.cs
@@ -106,7 +106,7 @@ namespace SourceGit.Models
             if (!revert && !isTracked)
                 writer.WriteLine("new file mode 100644");
             writer.WriteLine($"index 00000000...{fileGuid}");
-            writer.WriteLine($"--- {(revert || isTracked ? $"a/{change.Path}" : "/dev/null")}");
+            writer.WriteLine($"--- {(revert || isTracked ? $"a/{change.Path}" : Native.OS.NullDevice)}");
             writer.WriteLine($"+++ b/{change.Path}");
 
             var additions = selection.EndLine - selection.StartLine;

--- a/src/Native/OS.cs
+++ b/src/Native/OS.cs
@@ -27,6 +27,14 @@ namespace SourceGit.Native
             void OpenWithDefaultEditor(string file);
         }
 
+        public static readonly string NullDevice = OperatingSystem.IsWindows() ? "NUL" : "/dev/null";
+
+        public static bool IsNullDevice(string path)
+        {
+            return path.Equals("/dev/null", StringComparison.Ordinal) ||
+                   path.Equals("NUL", StringComparison.OrdinalIgnoreCase);
+        }
+
         public static string DataDir
         {
             get;

--- a/src/ViewModels/DiffContext.cs
+++ b/src/ViewModels/DiffContext.cs
@@ -97,7 +97,7 @@ namespace SourceGit.ViewModels
                 _info = previous._info;
             }
 
-            if (string.IsNullOrEmpty(_option.OrgPath) || _option.OrgPath == "/dev/null")
+            if (string.IsNullOrEmpty(_option.OrgPath) || Native.OS.IsNullDevice(_option.OrgPath))
                 Title = _option.Path;
             else
                 Title = $"{_option.OrgPath} → {_option.Path}";
@@ -216,7 +216,7 @@ namespace SourceGit.ViewModels
                         }
                         else
                         {
-                            if (!oldPath.Equals("/dev/null", StringComparison.Ordinal))
+                            if (!Native.OS.IsNullDevice(oldPath))
                             {
                                 var oldImage = await ImageSource.FromRevisionAsync(_repo, "HEAD", oldPath, imgDecoder).ConfigureAwait(false);
                                 imgDiff.Old = oldImage.Bitmap;


### PR DESCRIPTION
In certain cases, when handling merges and conflicts through SourceGit on Windows, an undeletable NUL file may appear. I believe this is related to the code's fixed usage of `/dev/null`, hence I created this PR. However, I haven't found a stable way to reproduce this issue. I can only confirm that this modification doesn't affect diff operations effect.