### PR TITLE
feat: Add reset file commands to compare view (#3)

### DIFF
--- a/src/Commands/Remove.cs
+++ b/src/Commands/Remove.cs
@@ -1,0 +1,23 @@
+namespace SourceGit.Commands
+{
+    public class Remove : Command
+    {
+        public Remove(string repo)
+        {
+            WorkingDirectory = repo;
+            Context = repo;
+        }
+
+        public Remove File(string file)
+        {
+            Args = $"rm --force --ignore-unmatch -- {file.Quoted()}";
+            return this;
+        }
+
+        public Remove Files(string pathspecFromFile)
+        {
+            Args = $"rm --force --ignore-unmatch --pathspec-from-file={pathspecFromFile.Quoted()}";
+            return this;
+        }
+    }
+}

--- a/src/ViewModels/Histories.cs
+++ b/src/ViewModels/Histories.cs
@@ -206,7 +206,7 @@ namespace SourceGit.ViewModels
 
                 var end = commits[0] as Models.Commit;
                 var start = commits[1] as Models.Commit;
-                DetailContext = new RevisionCompare(_repo.FullPath, start, end);
+                DetailContext = new RevisionCompare(_repo.FullPath, _repo, start, end);
             }
             else
             {
@@ -403,7 +403,7 @@ namespace SourceGit.ViewModels
                 _repo.SearchCommitContext.Selected = null;
                 head = await new Commands.QuerySingleCommit(_repo.FullPath, "HEAD").GetResultAsync();
                 if (head != null)
-                    DetailContext = new RevisionCompare(_repo.FullPath, commit, head);
+                    DetailContext = new RevisionCompare(_repo.FullPath, _repo, commit, head);
 
                 return null;
             }
@@ -413,7 +413,7 @@ namespace SourceGit.ViewModels
 
         public void CompareWithWorktree(Models.Commit commit)
         {
-            DetailContext = new RevisionCompare(_repo.FullPath, commit, null);
+            DetailContext = new RevisionCompare(_repo.FullPath, _repo, commit, null);
         }
 
         private Repository _repo = null;

--- a/src/Views/CommitDetail.axaml.cs
+++ b/src/Views/CommitDetail.axaml.cs
@@ -335,7 +335,7 @@ namespace SourceGit.Views
                 resetToThisRevision.Icon = App.CreateMenuIcon("Icons.File.Checkout");
                 resetToThisRevision.Click += async (_, ev) =>
                 {
-                    await vm.ResetToThisRevisionAsync(change.Path);
+                    await vm.ResetToThisRevisionAsync(change);
                     ev.Handled = true;
                 };
 

--- a/src/Views/RevisionCompare.axaml.cs
+++ b/src/Views/RevisionCompare.axaml.cs
@@ -106,6 +106,32 @@ namespace SourceGit.Views
                     menu.Items.Add(new MenuItem() { Header = "-" });
                     menu.Items.Add(patch);
                     menu.Items.Add(new MenuItem() { Header = "-" });
+
+                    if (vm.CanResetFiles)
+                    {
+                        var resetToSource = new MenuItem();
+                        resetToSource.Header = App.Text("ChangeCM.CheckoutFirstParentRevision");
+                        resetToSource.Icon = App.CreateMenuIcon("Icons.File.Checkout");
+                        resetToSource.Click += async (_, ev) =>
+                        {
+                            await vm.ResetToSourceRevisionAsync(change);
+                            ev.Handled = true;
+                        };
+
+                        var resetToTarget = new MenuItem();
+                        resetToTarget.Header = App.Text("ChangeCM.CheckoutThisRevision");
+                        resetToTarget.Icon = App.CreateMenuIcon("Icons.File.Checkout");
+                        resetToTarget.Click += async (_, ev) =>
+                        {
+                            await vm.ResetToTargetRevisionAsync(change);
+                            ev.Handled = true;
+                        };
+
+                        menu.Items.Add(resetToSource);
+                        menu.Items.Add(resetToTarget);
+                        menu.Items.Add(new MenuItem() { Header = "-" });
+                    }
+
                     menu.Items.Add(copyPath);
                     menu.Items.Add(copyFullPath);
                 }
@@ -141,6 +167,32 @@ namespace SourceGit.Views
 
                     menu.Items.Add(patch);
                     menu.Items.Add(new MenuItem() { Header = "-" });
+
+                    if (vm.CanResetFiles)
+                    {
+                        var resetToSource = new MenuItem();
+                        resetToSource.Header = App.Text("ChangeCM.CheckoutFirstParentRevision");
+                        resetToSource.Icon = App.CreateMenuIcon("Icons.File.Checkout");
+                        resetToSource.Click += async (_, ev) =>
+                        {
+                            await vm.ResetMultipleToSourceRevisionAsync(selected);
+                            ev.Handled = true;
+                        };
+
+                        var resetToTarget = new MenuItem();
+                        resetToTarget.Header = App.Text("ChangeCM.CheckoutThisRevision");
+                        resetToTarget.Icon = App.CreateMenuIcon("Icons.File.Checkout");
+                        resetToTarget.Click += async (_, ev) =>
+                        {
+                            await vm.ResetMultipleToTargetRevisionAsync(selected);
+                            ev.Handled = true;
+                        };
+
+                        menu.Items.Add(resetToSource);
+                        menu.Items.Add(resetToTarget);
+                        menu.Items.Add(new MenuItem() { Header = "-" });
+                    }
+
                     menu.Items.Add(copyPath);
                     menu.Items.Add(copyFullPath);
                 }

--- a/src/Views/RevisionFileTreeView.axaml.cs
+++ b/src/Views/RevisionFileTreeView.axaml.cs
@@ -604,12 +604,14 @@ namespace SourceGit.Views
 
             if (!repo.IsBare)
             {
+                var change = vm.Changes.Find(x => x.Path == file.Path) ?? new Models.Change() { Index = Models.ChangeState.None, Path = file.Path };
+
                 var resetToThisRevision = new MenuItem();
                 resetToThisRevision.Header = App.Text("ChangeCM.CheckoutThisRevision");
                 resetToThisRevision.Icon = App.CreateMenuIcon("Icons.File.Checkout");
                 resetToThisRevision.Click += async (_, ev) =>
                 {
-                    await vm.ResetToThisRevisionAsync(file.Path);
+                    await vm.ResetToThisRevisionAsync(change);
                     ev.Handled = true;
                 };
 


### PR DESCRIPTION
Add reset file commands to compare view
---

Enable "Reset to Parent Revision" and "Reset to This Revision" commands in the compare view when selecting two commits. These commands now work for both single and multiple file selections in the compare view.

**also - fixed a bug for Added files and Removed files that had an error `pathspec did not match any file(s) known to git`**

- Add ResetToSourceRevisionAsync and ResetToTargetRevisionAsync methods
- Add ResetMultipleToSourceRevisionAsync and ResetMultipleToTargetRevisionAsync methods
- Update RevisionCompare constructor to accept Repository object for logging
- Add CanResetFiles property to check if reset operations are available
- Add reset menu items to context menu in RevisionCompare view
- Parent Revision resets to compare source (StartPoint)
- Current Revision resets to compare target (EndPoint)

---------