### PR TITLE
fix: support visualstudio.com URLs for Azure DevOps pull requests

### DIFF
--- a/src/Models/Remote.cs
+++ b/src/Models/Remote.cs
@@ -130,7 +130,8 @@ namespace SourceGit.Models
                 return true;
             }
 
-            if (host.Contains("azure.com", StringComparison.Ordinal))
+            if (host.Contains("azure.com", StringComparison.Ordinal) ||
+                host.Contains("visualstudio.com", StringComparison.Ordinal))
             {
                 url = $"{baseURL}/pullrequestcreate?sourceRef={encodedBranch}";
                 return true;


### PR DESCRIPTION
### What was changed
Added support for `visualstudio.com` URLs when generating Azure DevOps pull request links.

### Why
Azure DevOps repositories can still be hosted under `*.visualstudio.com` domains, but these URLs were not recognized by SourceGit.  
As a result, the **Create Pull Request** button was not displayed for these repositories.

### How
Extended the host validation logic to accept both:
- `azure.com`
- `visualstudio.com`

This keeps backward compatibility and fixes PR URL generation for legacy Azure DevOps setups.
