### PR TITLE
feature: Move cache to its own directory to follow XDG standards.

### DIFF
--- a/src/Models/AvatarManager.cs
+++ b/src/Models/AvatarManager.cs
@@ -44,7 +44,7 @@ namespace SourceGit.Models
 
         public void Start()
         {
-            _storePath = Path.Combine(Native.OS.DataDir, "avatars");
+            _storePath = Path.Combine(Native.OS.CacheDir, "avatars");
             if (!Directory.Exists(_storePath))
                 Directory.CreateDirectory(_storePath);
 

--- a/src/Models/IpcChannel.cs
+++ b/src/Models/IpcChannel.cs
@@ -16,7 +16,7 @@ namespace SourceGit.Models
         {
             try
             {
-                _singletonLock = File.Open(Path.Combine(Native.OS.DataDir, "process.lock"), FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None);
+                _singletonLock = File.Open(Path.Combine(Native.OS.RuntimeDir, "process.lock"), FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None);
                 IsFirstInstance = true;
                 _server = new NamedPipeServerStream(
                     "SourceGitIPCChannel" + Environment.UserName,

--- a/src/SourceGit.csproj
+++ b/src/SourceGit.csproj
@@ -63,6 +63,7 @@
     <PackageReference Include="Pfim" Version="0.11.4" />
     <PackageReference Include="TextMateSharp" Version="2.0.2" />
     <PackageReference Include="TextMateSharp.Grammars" Version="2.0.2" />
+    <PackageReference Include="Xdg.Directories" Version="0.1.2" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Cache should not be in the same directory as the configuration. It mostly only applies to linux.

See here for what each folder maps to https://xdg-net.github.io/Xdg.Directories/docs/defaults.html