### PR TITLE
Fix: Correct reset to parent revision functionality

### DIFF
--- a/src/ViewModels/CommitDetail.cs
+++ b/src/ViewModels/CommitDetail.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text.RegularExpressions;
@@ -316,13 +316,13 @@ namespace SourceGit.ViewModels
 
                 await new Commands.Checkout(_repo.FullPath)
                     .Use(log)
-                    .FileWithRevisionAsync(change.OriginalPath, _commit.SHA);
+                    .FileWithRevisionAsync(change.OriginalPath, $"{_commit.SHA}~1");
             }
             else
             {
                 await new Commands.Checkout(_repo.FullPath)
                     .Use(log)
-                    .FileWithRevisionAsync(change.Path, _commit.SHA);
+                    .FileWithRevisionAsync(change.Path, $"{_commit.SHA}~1");
             }
 
             log.Complete();


### PR DESCRIPTION
- Updated `ResetToParentRevisionAsync` to use `$"{_commit.SHA}~1"` for parent revision.
- Updated `ResetMultipleToParentRevisionAsync` to use `$"{_commit.SHA}~1"` for consistency.
- Removed UTF-8 BOM from `CommitDetail.cs` to ensure proper file encoding.