### PR TITLE
fix: prevent MeasureOverride from returning Infinity to Avalonia layout (#2136)

### DIFF
--- a/src/Views/CommitRefsPresenter.cs
+++ b/src/Views/CommitRefsPresenter.cs
@@ -258,7 +258,7 @@ namespace SourceGit.Views
                 }
 
                 var requiredWidth = allowWrap && requiredHeight > 16.0
-                    ? availableSize.Width
+                    ? (double.IsInfinity(availableSize.Width) ? x + 2 : availableSize.Width)
                     : x + 2;
                 InvalidateVisual();
                 return new Size(requiredWidth, requiredHeight);

--- a/src/Views/ImageContainer.cs
+++ b/src/Views/ImageContainer.cs
@@ -90,7 +90,7 @@ namespace SourceGit.Views
                 return new Size(scale * imageSize.Width, scale * imageSize.Height);
             }
 
-            return availableSize;
+            return new Size(0, 0);
         }
     }
 
@@ -206,7 +206,7 @@ namespace SourceGit.Views
             var right = NewImage;
 
             if (left == null)
-                return right == null ? availableSize : GetDesiredSize(right.Size, availableSize);
+                return right == null ? new Size(0, 0) : GetDesiredSize(right.Size, availableSize);
 
             if (right == null)
                 return GetDesiredSize(left.Size, availableSize);
@@ -324,7 +324,7 @@ namespace SourceGit.Views
             var right = NewImage;
 
             if (left == null)
-                return right == null ? availableSize : GetDesiredSize(right.Size, availableSize);
+                return right == null ? new Size(0, 0) : GetDesiredSize(right.Size, availableSize);
 
             if (right == null)
                 return GetDesiredSize(left.Size, availableSize);
@@ -439,7 +439,7 @@ namespace SourceGit.Views
             var right = NewImage;
 
             if (left == null)
-                return right == null ? availableSize : GetDesiredSize(right.Size, availableSize);
+                return right == null ? new Size(0, 0) : GetDesiredSize(right.Size, availableSize);
 
             if (right == null)
                 return GetDesiredSize(left.Size, availableSize);

--- a/src/Views/StashSubjectPresenter.cs
+++ b/src/Views/StashSubjectPresenter.cs
@@ -120,7 +120,8 @@ namespace SourceGit.Views
             var typeface = new Typeface(FontFamily);
             var test = new FormattedText("fgl|", CultureInfo.CurrentCulture, FlowDirection.LeftToRight, typeface, FontSize, Brushes.White);
             var h = Math.Max(18, test.Height);
-            return new Size(availableSize.Width, h);
+            var w = double.IsInfinity(availableSize.Width) ? 0 : availableSize.Width;
+            return new Size(w, h);
         }
 
         [GeneratedRegex(@"^On ([^\s]+)\: ")]


### PR DESCRIPTION
When `VirtualizingStackPanel.ScrollIntoView()` measures items, it passes `Size.Infinity` as the available size. Several custom controls were passing `availableSize.Width` (or the entire `availableSize`) straight back in their `MeasureOverride` return value, which violates Avalonia's layout contract and throws InvalidOperationException.

This was most visible on the stash page: selecting stash the 13th+ (beyond the viewport, default window size would be 6+), switching away, then switching back would crash the app because `AutoScrollToSelectedItemIfNecessary` triggered `ScrollIntoView` on the virtualized item.

P.S.:
Also applied defensive fixes to `CommitRefsPresenter` and `ImageContainer`, which are not related to the reported crash but have the same contract violation — `MeasureOverride` may return Infinity under certain conditions, you can remove them if you want :

- `CommitRefsPresenter`: when `AllowWrap` is true, the wrapped branch returns availableSize.Width directly. In practice this branch is unreachable with Infinity input (wrapping never triggers when width is unbounded), but the code still references availableSize.Width in a return path, which is a latent contract violation.

- `ImageContainer`: return `availableSize` as-is when image properties are null. These controls are currently only used in diff views (not in virtualized lists), so the issue is unlikely to surface, but returning raw availableSize from MeasureOverride is always wrong per Avalonia's layout contract.
