### PR TITLE
Add Ghostty to Linux terminals

### DIFF
--- a/src/Models/ShellOrTerminal.cs
+++ b/src/Models/ShellOrTerminal.cs
@@ -60,6 +60,7 @@ namespace SourceGit.Models
                     new ShellOrTerminal("foot", "Foot", "foot"),
                     new ShellOrTerminal("wezterm", "WezTerm", "wezterm", "start --cwd ."),
                     new ShellOrTerminal("ptyxis", "Ptyxis", "ptyxis", "--new-window --working-directory=."),
+                    new ShellOrTerminal("ghostty", "Ghostty", "ghostty"),
                     new ShellOrTerminal("kitty", "kitty", "kitty"),
                     new ShellOrTerminal("custom", "Custom", ""),
                 };


### PR DESCRIPTION
Ghostty was added to the list of macOS terminals in #928 last year, it seems to make sense that if it supports a cross-platform terminal on one platform, it should on all.

Putting it above kitty just to be consistent with the order of the mac list.