### PR TITLE
chore: Upgrade OpenAI package to v2.9.0

### DIFF
--- a/src/SourceGit.csproj
+++ b/src/SourceGit.csproj
@@ -57,7 +57,7 @@
     <PackageReference Include="BitMiracle.LibTiff.NET" Version="2.4.660" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
     <PackageReference Include="LiveChartsCore.SkiaSharpView.Avalonia" Version="2.0.0-rc6.1" />
-    <PackageReference Include="OpenAI" Version="2.8.0" />
+    <PackageReference Include="OpenAI" Version="2.9.1" />
     <PackageReference Include="Pfim" Version="0.11.4" />
 
     <ProjectReference Include="../depends/AvaloniaEdit/src/AvaloniaEdit.TextMate/AvaloniaEdit.TextMate.csproj"/>


### PR DESCRIPTION
- Upgrade OpenAI package dependency to version 2.9.0.