### PR TITLE
fix: prevent ContainsIn flyout layout oscillation on low-perf devices

### DIFF
--- a/src/Views/CommitBaseInfo.axaml.cs
+++ b/src/Views/CommitBaseInfo.axaml.cs
@@ -106,12 +106,16 @@ namespace SourceGit.Views
         {
             if (DataContext is ViewModels.CommitDetail detail && sender is Button button)
             {
+                var containsIn = await detail.GetRefsContainsThisCommitAsync();
+                if (containsIn is not { Count: > 0 } || !button.IsEffectivelyVisible)
+                    return;
+
                 var tracking = new CommitRelationTracking();
+                tracking.SetData(containsIn);
+
                 var flyout = new Flyout();
                 flyout.Content = tracking;
                 flyout.ShowAt(button);
-
-                await tracking.SetDataAsync(detail);
             }
 
             e.Handled = true;

--- a/src/Views/CommitRelationTracking.axaml
+++ b/src/Views/CommitRelationTracking.axaml
@@ -3,7 +3,6 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:m="using:SourceGit.Models"
-             xmlns:v="using:SourceGit.Views"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:Class="SourceGit.Views.CommitRelationTracking">
   <Grid RowDefinitions="Auto,Auto,Auto">
@@ -30,7 +29,5 @@
         </ItemsControl.ItemTemplate>
       </ItemsControl>
     </ScrollViewer>
-
-    <v:LoadingIcon x:Name="LoadingIcon" Grid.Row="2" HorizontalAlignment="Center" Margin="0,8" Width="14" Height="14" IsVisible="False"/>
   </Grid>
 </UserControl>

--- a/src/Views/CommitRelationTracking.axaml.cs
+++ b/src/Views/CommitRelationTracking.axaml.cs
@@ -1,4 +1,4 @@
-using System.Threading.Tasks;
+using System.Collections.Generic;
 using Avalonia.Controls;
 
 namespace SourceGit.Views
@@ -10,12 +10,9 @@ namespace SourceGit.Views
             InitializeComponent();
         }
 
-        public async Task SetDataAsync(ViewModels.CommitDetail detail)
+        public void SetData(List<Models.Decorator> data)
         {
-            LoadingIcon.IsVisible = true;
-            var containsIn = await detail.GetRefsContainsThisCommitAsync();
-            Container.ItemsSource = containsIn;
-            LoadingIcon.IsVisible = false;
+            Container.ItemsSource = data;
         }
     }
 }


### PR DESCRIPTION
Load refs data before showing the flyout instead of loading asynchronously after it is already visible. This eliminates multiple layout passes (LoadingIcon toggle + ItemsSource update) that caused the flyout to visibly resize on slower machines.

Fixes #2175