### PR TITLE
feature: add 12-hour datetime formats

### DIFF
--- a/src/Models/DateTimeFormat.cs
+++ b/src/Models/DateTimeFormat.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace SourceGit.Models
 {
@@ -30,20 +31,39 @@ namespace SourceGit.Models
             get => Supported[ActiveIndex];
         }
 
-        public static readonly List<DateTimeFormat> Supported = new List<DateTimeFormat>
+        public static readonly List<DateTimeFormat> Supported = GenerateSupported().ToList();
+
+        private static IEnumerable<DateTimeFormat> GenerateSupported()
         {
-            new DateTimeFormat("yyyy/MM/dd", "yyyy/MM/dd, HH:mm:ss"),
-            new DateTimeFormat("yyyy.MM.dd", "yyyy.MM.dd, HH:mm:ss"),
-            new DateTimeFormat("yyyy-MM-dd", "yyyy-MM-dd, HH:mm:ss"),
-            new DateTimeFormat("MM/dd/yyyy", "MM/dd/yyyy, HH:mm:ss"),
-            new DateTimeFormat("MM.dd.yyyy", "MM.dd.yyyy, HH:mm:ss"),
-            new DateTimeFormat("MM-dd-yyyy", "MM-dd-yyyy, HH:mm:ss"),
-            new DateTimeFormat("dd/MM/yyyy", "dd/MM/yyyy, HH:mm:ss"),
-            new DateTimeFormat("dd.MM.yyyy", "dd.MM.yyyy, HH:mm:ss"),
-            new DateTimeFormat("dd-MM-yyyy", "dd-MM-yyyy, HH:mm:ss"),
-            new DateTimeFormat("MMM d yyyy", "MMM d yyyy, HH:mm:ss"),
-            new DateTimeFormat("d MMM yyyy", "d MMM yyyy, HH:mm:ss"),
-        };
+            var dateFormats = new string[]
+            {
+                "yyyy/MM/dd",
+                "yyyy.MM.dd",
+                "yyyy-MM-dd",
+                "MM/dd/yyyy",
+                "MM.dd.yyyy",
+                "MM-dd-yyyy",
+                "dd/MM/yyyy",
+                "dd.MM.yyyy",
+                "dd-MM-yyyy",
+                "MMM d yyyy",
+                "d MMM yyyy",
+            };
+
+            var timeFormats = new string[]
+            {
+                "HH:mm:ss",
+                "h:mm:ss tt",
+            };
+
+            foreach (var timeFormat in timeFormats)
+            {
+                foreach (var dateFormat in dateFormats)
+                {
+                    yield return new DateTimeFormat(dateFormat, dateFormat + ", " + timeFormat);
+                }
+            }
+        }
 
         private static readonly DateTime _example = new DateTime(2025, 1, 31, 8, 0, 0, DateTimeKind.Local);
     }


### PR DESCRIPTION
I think it would be nice to have 12-hour time format options in the history so this is my attempt at adding it. Though, I'm not sure if this is the cleanest way to do it since each new time format grows the list of options exponentially. So, I'm open to suggestions if there's a better way to display the options.
<img width="678" height="654" alt="Screenshot_20260311_220306" src="https://github.com/user-attachments/assets/72f3d146-880f-4bba-a04f-c5616c205ae3" />
