### PR TITLE
feature: add added/removed line counts to diff view

### DIFF
--- a/src/Commands/Diff.cs
+++ b/src/Commands/Diff.cs
@@ -194,6 +194,7 @@ namespace SourceGit.Commands
                         return;
                     }
 
+                    _result.TextDiff.DeletedLines++;
                     _last = new Models.TextDiffLine(Models.TextDiffLineType.Deleted, line.Substring(1), _oldLine, 0);
                     _deleted.Add(_last);
                     _oldLine++;
@@ -207,6 +208,7 @@ namespace SourceGit.Commands
                         return;
                     }
 
+                    _result.TextDiff.AddedLines++;
                     _last = new Models.TextDiffLine(Models.TextDiffLineType.Added, line.Substring(1), 0, _newLine);
                     _added.Add(_last);
                     _newLine++;

--- a/src/Models/DiffResult.cs
+++ b/src/Models/DiffResult.cs
@@ -55,6 +55,8 @@ namespace SourceGit.Models
     {
         public List<TextDiffLine> Lines { get; set; } = new List<TextDiffLine>();
         public int MaxLineNumber = 0;
+        public int AddedLines { get; set; } = 0;
+        public int DeletedLines { get; set; } = 0;
 
         public TextDiffSelection MakeSelection(int startLine, int endLine, bool isCombined, bool isOldSide)
         {

--- a/src/ViewModels/TextDiffContext.cs
+++ b/src/ViewModels/TextDiffContext.cs
@@ -28,6 +28,8 @@ namespace SourceGit.ViewModels
     {
         public Models.DiffOption Option => _option;
         public Models.TextDiff Data => _data;
+        public int AddedLines => _data?.AddedLines ?? 0;
+        public int DeletedLines => _data?.DeletedLines ?? 0;
 
         public Vector ScrollOffset
         {

--- a/src/Views/DiffView.axaml
+++ b/src/Views/DiffView.axaml
@@ -67,7 +67,29 @@
             <ContentControl Content="{Binding Content, Mode=OneWay}" IsVisible="{Binding IsTextDiff}">
               <ContentControl.DataTemplates>
                 <DataTemplate DataType="vm:TextDiffContext">
-                  <TextBlock Margin="0,0,0,0" FontSize="11" Text="{Binding BlockNavigation.Indicator}"/>
+                  <StackPanel Orientation="Horizontal" Spacing="6" VerticalAlignment="Center">
+                    <TextBlock Margin="0,0,0,0" FontSize="11" Text="{Binding BlockNavigation.Indicator}"/>
+                    <Border Height="16"
+                            Background="{DynamicResource Brush.Diff.AddedBG}"
+                            CornerRadius="8"
+                            VerticalAlignment="Center"
+                            IsVisible="{Binding AddedLines, Converter={x:Static c:IntConverters.IsGreaterThanZero}}">
+                      <TextBlock FontSize="10"
+                                 Margin="8,0"
+                                 Foreground="{DynamicResource Brush.FG1}"
+                                 Text="{Binding AddedLines, StringFormat=+{0}}"/>
+                    </Border>
+                    <Border Height="16"
+                            Background="{DynamicResource Brush.Diff.DeletedBG}"
+                            CornerRadius="8"
+                            VerticalAlignment="Center"
+                            IsVisible="{Binding DeletedLines, Converter={x:Static c:IntConverters.IsGreaterThanZero}}">
+                      <TextBlock FontSize="10"
+                                 Margin="8,0"
+                                 Foreground="{DynamicResource Brush.FG1}"
+                                 Text="{Binding DeletedLines, StringFormat=-{0}}"/>
+                    </Border>
+                  </StackPanel>
                 </DataTemplate>
               </ContentControl.DataTemplates>
             </ContentControl>


### PR DESCRIPTION
Adds added/removed line counts to the diff view only. I considered totals for the entire change set, but didn’t want to add extra overhead, so I kept it scoped to the diff view.

This is my first PR, sorry if I missed any steps and let me know if there are any issues with this. Thanks!

<img width="1630" height="470" alt="image" src="https://github.com/user-attachments/assets/3260e183-4abf-4c25-8974-1ad5d76b4391" />
