### PR TITLE
feature: allow enabling 3-way merge when applying a patch

### DIFF
--- a/src/Commands/Apply.cs
+++ b/src/Commands/Apply.cs
@@ -4,7 +4,7 @@ namespace SourceGit.Commands
 {
     public class Apply : Command
     {
-        public Apply(string repo, string file, bool ignoreWhitespace, string whitespaceMode, string extra)
+        public Apply(string repo, string file, bool ignoreWhitespace, string whitespaceMode, bool threeWayMerge, string extra)
         {
             WorkingDirectory = repo;
             Context = repo;
@@ -16,6 +16,9 @@ namespace SourceGit.Commands
                 builder.Append("--ignore-whitespace ");
             else
                 builder.Append("--whitespace=").Append(whitespaceMode).Append(' ');
+
+            if (threeWayMerge)
+                builder.Append("--3way ");
 
             if (!string.IsNullOrEmpty(extra))
                 builder.Append(extra).Append(' ');

--- a/src/Resources/Locales/en_US.axaml
+++ b/src/Resources/Locales/en_US.axaml
@@ -27,6 +27,7 @@
   <x:String x:Key="Text.Apply.File" xml:space="preserve">Patch File:</x:String>
   <x:String x:Key="Text.Apply.File.Placeholder" xml:space="preserve">Select .patch file to apply</x:String>
   <x:String x:Key="Text.Apply.IgnoreWS" xml:space="preserve">Ignore whitespace changes</x:String>
+  <x:String x:Key="Text.Apply.3Way" xml:space="preserve">3-Way Merge</x:String>
   <x:String x:Key="Text.Apply.Title" xml:space="preserve">Apply Patch</x:String>
   <x:String x:Key="Text.Apply.WS" xml:space="preserve">Whitespace:</x:String>
   <x:String x:Key="Text.ApplyStash" xml:space="preserve">Apply Stash</x:String>

--- a/src/ViewModels/Apply.cs
+++ b/src/ViewModels/Apply.cs
@@ -26,6 +26,12 @@ namespace SourceGit.ViewModels
             set;
         }
 
+        public bool ThreeWayMerge
+        {
+            get => _threeWayMerge;
+            set => SetProperty(ref _threeWayMerge, value);
+        }
+
         public Apply(Repository repo)
         {
             _repo = repo;
@@ -49,7 +55,7 @@ namespace SourceGit.ViewModels
             var log = _repo.CreateLog("Apply Patch");
             Use(log);
 
-            var succ = await new Commands.Apply(_repo.FullPath, _patchFile, _ignoreWhiteSpace, SelectedWhiteSpaceMode.Arg, null)
+            var succ = await new Commands.Apply(_repo.FullPath, _patchFile, _ignoreWhiteSpace, SelectedWhiteSpaceMode.Arg, _threeWayMerge, null)
                 .Use(log)
                 .ExecAsync();
 
@@ -60,5 +66,6 @@ namespace SourceGit.ViewModels
         private readonly Repository _repo = null;
         private string _patchFile = string.Empty;
         private bool _ignoreWhiteSpace = true;
+        private bool _threeWayMerge = false;
     }
 }

--- a/src/ViewModels/StashesPage.cs
+++ b/src/ViewModels/StashesPage.cs
@@ -253,7 +253,7 @@ namespace SourceGit.ViewModels
                 return;
 
             var log = _repo.CreateLog($"Apply changes from '{_selectedStash.Name}'");
-            await new Commands.Apply(_repo.FullPath, saveTo, true, string.Empty, string.Empty)
+            await new Commands.Apply(_repo.FullPath, saveTo, true, string.Empty, false, string.Empty)
                 .Use(log)
                 .ExecAsync();
 

--- a/src/Views/Apply.axaml
+++ b/src/Views/Apply.axaml
@@ -18,7 +18,7 @@
                  Text="{DynamicResource Text.Apply.Title}"/>
     </StackPanel>
 
-    <Grid Margin="0,16,0,0" RowDefinitions="32,32,32" ColumnDefinitions="120,*">
+    <Grid Margin="0,16,0,0" RowDefinitions="32,32,32,32" ColumnDefinitions="120,*">
       <TextBlock Grid.Column="0"
                  HorizontalAlignment="Right" VerticalAlignment="Center"
                  Margin="0,0,8,0"
@@ -77,6 +77,11 @@
                 Content="{DynamicResource Text.Apply.IgnoreWS}"
                 IsChecked="{Binding IgnoreWhiteSpace, Mode=TwoWay}"
                 ToolTip.Tip="--ignore-whitespace"/>
+
+      <CheckBox Grid.Row="3" Grid.Column="1"
+                Content="{DynamicResource Text.Apply.3Way}"
+                IsChecked="{Binding ThreeWayMerge, Mode=TwoWay}"
+                ToolTip.Tip="--3way"/>
     </Grid>
   </StackPanel>
 </UserControl>

--- a/src/Views/TextDiffView.axaml.cs
+++ b/src/Views/TextDiffView.axaml.cs
@@ -1508,7 +1508,7 @@ namespace SourceGit.Views
                 diff.GeneratePatchFromSelectionSingleSide(change, treeGuid, selection, false, chunk.IsOldSide, tmpFile);
             }
 
-            await new Commands.Apply(repo.FullPath, tmpFile, true, "nowarn", "--cache --index").ExecAsync();
+            await new Commands.Apply(repo.FullPath, tmpFile, true, "nowarn", false, "--cache --index").ExecAsync();
             File.Delete(tmpFile);
 
             vm.BlockNavigation.UpdateByChunk(chunk);
@@ -1539,7 +1539,7 @@ namespace SourceGit.Views
             else
                 diff.GeneratePatchFromSelectionSingleSide(change, treeGuid, selection, true, chunk.IsOldSide, tmpFile);
 
-            await new Commands.Apply(repo.FullPath, tmpFile, true, "nowarn", "--cache --index --reverse").ExecAsync();
+            await new Commands.Apply(repo.FullPath, tmpFile, true, "nowarn", false, "--cache --index --reverse").ExecAsync();
             File.Delete(tmpFile);
 
             vm.BlockNavigation.UpdateByChunk(chunk);
@@ -1577,7 +1577,7 @@ namespace SourceGit.Views
                 diff.GeneratePatchFromSelectionSingleSide(change, treeGuid, selection, true, chunk.IsOldSide, tmpFile);
             }
 
-            await new Commands.Apply(repo.FullPath, tmpFile, true, "nowarn", "--reverse").ExecAsync();
+            await new Commands.Apply(repo.FullPath, tmpFile, true, "nowarn", false, "--reverse").ExecAsync();
             File.Delete(tmpFile);
 
             vm.BlockNavigation.UpdateByChunk(chunk);


### PR DESCRIPTION
Allow enabling the [`--3way`](https://git-scm.com/docs/git-apply#Documentation/git-apply.txt---3way) merge option when applying a patch to a repository.

This can be very helpful if a patch can not be cleanly applied, as it will still do a partial merge and allow you to resolve merge conflicts manually.

<img width="593" height="275" alt="image" src="https://github.com/user-attachments/assets/39b0662f-7457-4c2f-979b-c4624f0523c8" />
