### PR TITLE
Add master to GH Actions triggers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,9 @@
 name: Continuous Integration
 on:
   push:
-    branches: [develop]
+    branches: [develop, master]
   pull_request:
-    branches: [develop]
+    branches: [develop, master]
   workflow_dispatch:
   workflow_call:
 jobs:

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -1,9 +1,9 @@
 name: Format Check
 on:
   push:
-    branches: [develop]
+    branches: [develop, master]
   pull_request:
-    branches: [develop]
+    branches: [develop, master]
   workflow_dispatch:
   workflow_call:
 

--- a/.github/workflows/localization-check.yml
+++ b/.github/workflows/localization-check.yml
@@ -1,7 +1,7 @@
 name: Localization Check
 on:
   push:
-    branches: [develop]
+    branches: [develop, master]
     paths:
       - 'src/Resources/Locales/**'
   workflow_dispatch:


### PR DESCRIPTION
The default branch here is master instead of development, so (by default) Pull Requests will target master and our GitHub Actions will not be triggered.

See my first PRs, for example, this one: https://github.com/sourcegit-scm/sourcegit/pull/2206