### PR TITLE
fix: preserve commit selection after reword

### DIFF
--- a/src/ViewModels/Histories.cs
+++ b/src/ViewModels/Histories.cs
@@ -66,7 +66,13 @@ namespace SourceGit.ViewModels
                 if (SetProperty(ref _commits, value))
                 {
                     if (value.Count > 0 && lastSelected != null)
-                        SelectedCommit = value.Find(x => x.SHA == lastSelected.SHA);
+                    {
+                        var selected = value.Find(x => x.SHA == lastSelected.SHA);
+                        if (selected == null && lastSelected.IsCurrentHead)
+                            selected = value.Find(x => x.IsCurrentHead);
+
+                        SelectedCommit = selected;
+                    }
                 }
             }
         }


### PR DESCRIPTION
- keep the history list selection on the rewritten HEAD commit after using Reword
- fall back to the new current HEAD when the previously selected commit SHA no longer exists after refresh