### PR TITLE
enhance: better word division for highlighting

### DIFF
--- a/src/Models/TextInlineChange.cs
+++ b/src/Models/TextInlineChange.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Globalization;
 
 namespace SourceGit.Models
 {
@@ -24,6 +25,13 @@ namespace SourceGit.Models
             DeletedLeft,
             AddedRight,
             AddedLeft,
+        }
+
+        private enum CharCategory : byte
+        {
+            Other,       // default: whitespace, control, punctuation, symbols, etc.
+            Letter,      // Ll/Lu/Lt/Lm + digit: ASCII and euro letters (latin, greek, cyrillic, etc.)
+            OtherLetter, // Lo: CJK, hiragana, katakana, hangul, Thai, Arabic, etc.
         }
 
         private class EditResult
@@ -100,22 +108,25 @@ namespace SourceGit.Models
             var start = 0;
             var size = text.Length;
             var chunks = new List<Chunk>();
-            var delims = new HashSet<char>(" \t+-*/=!,:;.'\"/?|&#@%`<>()[]{}\\".ToCharArray());
+            if (size == 0)
+                return chunks;
 
-            for (int i = 0; i < size; i++)
+            var prev = GetCategory(text[0]);
+
+            for (var i = 1; i < size; i++)
             {
                 var ch = text[i];
-                if (delims.Contains(ch))
+                var category = GetCategory(ch);
+                if (prev != category || category == CharCategory.Other)
                 {
-                    if (start != i)
-                        AddChunk(chunks, hashes, text.Substring(start, i - start), start);
-                    AddChunk(chunks, hashes, text.Substring(i, 1), i);
-                    start = i + 1;
+                    AddChunk(chunks, hashes, text[start..i], start);
+                    start = i;
                 }
+                prev = category;
             }
 
             if (start < size)
-                AddChunk(chunks, hashes, text.Substring(start), start);
+                AddChunk(chunks, hashes, text[start..], start);
             return chunks;
         }
 
@@ -302,5 +313,33 @@ namespace SourceGit.Models
             }
             chunks.Add(new Chunk(hash, start, data.Length));
         }
+
+        private static CharCategory[] BuildCategoryCache()
+        {
+            // Pre-compute category for all char values.
+            // All entries default to Other (0).
+            var cache = new CharCategory[65536];
+            for (int i = 0; i < 65536; i++)
+            {
+                var ch = (char)i;
+                // Unicode Lo: CJK, hiragana, katakana, hangul, Thai, Arabic, Hebrew, etc.
+                // → group consecutive chars into one chunk (no space delimiter in these languages)
+                if (char.GetUnicodeCategory(ch) == UnicodeCategory.OtherLetter)
+                    cache[i] = CharCategory.OtherLetter;
+
+                // Unicode Ll/Lu/Lt/Lm + digit: latin, greek, cyrillic and their diacritic variants
+                // → group consecutive chars into one chunk (words in space-delimited languages)
+                else if (char.IsLetterOrDigit(ch))
+                    cache[i] = CharCategory.Letter;
+
+                // everything else (whitespace, control, punctuation, symbols) → Other (default)
+            }
+
+            return cache;
+        }
+
+        private static CharCategory GetCategory(char ch) => s_charCategoryCache[ch];
+
+        private static readonly CharCategory[] s_charCategoryCache = BuildCategoryCache();
     }
 }


### PR DESCRIPTION
## Summary

Improve inline diff highlighting by replacing the ASCII delimiter–based
word division with a Unicode category–based approach, primarily to
produce more precise highlights in languages like Japanese and Chinese.

### Problem

The previous implementation splits text at a fixed set of delimiter
characters (spaces, tabs, and common ASCII symbols such as `+-*/=!,;`).
Non-delimiter characters — including CJK ideographs, Hiragana, and
Katakana — are never treated as boundaries, so a small change within
Japanese or Chinese text causes the entire surrounding phrase to be
highlighted as changed.

### Solution

Each character is classified into one of three categories. Consecutive
characters of the same category are grouped into one chunk, except for
the `Other` category which retains the same per-character behavior as
the previous implementation:

| Category | Characters | Chunking |
|---|---|---|
| `Letter` | Latin, Greek, Cyrillic and diacritic variants (é, ü, ß…) | grouped |
| `OtherLetter` | CJK, Hiragana, Katakana, Hangul, Thai, Arabic, etc. | grouped |
| `Other` | Whitespace, punctuation, symbols — same as previous delimiters | per character |

CJK punctuation (。、「」…) falls into `Other` and acts as a natural
boundary between `OtherLetter` chunks, making highlighted changes
more precise without requiring language-specific word segmentation.

Category values for all 65,536 `char` values are pre-computed into a
static read-only array at startup for lock-free O(1) lookup.

### Japanese — before / after

| Before | After |
|---|---|
| ![Japanese before](https://github.com/user-attachments/assets/7d480e56-cb43-406d-a4ea-423c781c7f89) | ![Japanese after](https://github.com/user-attachments/assets/856daba0-0844-4971-96fa-fea9bfc995c0) |

### English — no regression

| Before | After |
|---|---|
| ![English before](https://github.com/user-attachments/assets/635e9781-90bf-4949-8b0d-cba7d73bc380) | ![English after](https://github.com/user-attachments/assets/66cf10b7-4f6d-4abd-883f-9b1c10810cfb) |

## Check point

- Japanese diff: divided by non CJK character mixed in sentence without space character.
- Japanese diff: CJK punctuation correctly splits chunks at sentence boundaries
- ASCII operators and punctuation: per-character precision preserved (`/` vs `*`, `==` vs `!=`, etc.)
- European words with diacritics (`café`, `über`…): treated as single word chunks
