### PR TITLE
feature: add Ctrl+O global hotkey to open/init repository

### DIFF
--- a/src/Resources/Locales/en_US.axaml
+++ b/src/Resources/Locales/en_US.axaml
@@ -499,6 +499,7 @@
   <x:String x:Key="Text.Hotkeys.Global.GotoNextTab" xml:space="preserve">Go to next tab</x:String>
   <x:String x:Key="Text.Hotkeys.Global.GotoPrevTab" xml:space="preserve">Go to previous tab</x:String>
   <x:String x:Key="Text.Hotkeys.Global.NewTab" xml:space="preserve">Create new tab</x:String>
+  <x:String x:Key="Text.Hotkeys.Global.OpenOrInit" xml:space="preserve">Open repository</x:String>
   <x:String x:Key="Text.Hotkeys.Global.OpenPreferences" xml:space="preserve">Open Preferences dialog</x:String>
   <x:String x:Key="Text.Hotkeys.Global.ShowWorkspaceDropdownMenu" xml:space="preserve">Show workspace dropdown menu</x:String>
   <x:String x:Key="Text.Hotkeys.Global.SwitchTab" xml:space="preserve">Switch active tab</x:String>

--- a/src/Resources/Locales/ja_JP.axaml
+++ b/src/Resources/Locales/ja_JP.axaml
@@ -491,6 +491,7 @@
   <x:String x:Key="Text.Hotkeys.Global.GotoNextTab" xml:space="preserve">次のタブに移動</x:String>
   <x:String x:Key="Text.Hotkeys.Global.GotoPrevTab" xml:space="preserve">前のタブに移動</x:String>
   <x:String x:Key="Text.Hotkeys.Global.NewTab" xml:space="preserve">新しいタブを作成</x:String>
+  <x:String x:Key="Text.Hotkeys.Global.OpenOrInit" xml:space="preserve">リポジトリを開く</x:String>
   <x:String x:Key="Text.Hotkeys.Global.OpenPreferences" xml:space="preserve">設定ダイアログを開く</x:String>
   <x:String x:Key="Text.Hotkeys.Global.ShowWorkspaceDropdownMenu" xml:space="preserve">ワークスペースのドロップダウンメニューを表示</x:String>
   <x:String x:Key="Text.Hotkeys.Global.SwitchTab" xml:space="preserve">アクティブなタブを切り替え</x:String>

--- a/src/Views/Hotkeys.axaml
+++ b/src/Views/Hotkeys.axaml
@@ -45,7 +45,7 @@
                    FontSize="{Binding Source={x:Static vm:Preferences.Instance}, Path=DefaultFontSize, Converter={x:Static c:DoubleConverters.Increase}}"
                    Margin="0,0,0,8"/>
 
-        <Grid RowDefinitions="20,20,20,20,20,20,20,20,20,20" ColumnDefinitions="150,*">
+        <Grid RowDefinitions="20,20,20,20,20,20,20,20,20,20,20" ColumnDefinitions="150,*">
           <TextBlock Grid.Row="0" Grid.Column="0" Classes="bold" Text="{OnPlatform Ctrl+\,, macOS=⌘+\,}"/>
           <TextBlock Grid.Row="0" Grid.Column="1" Margin="16,0,0,0" Text="{DynamicResource Text.Hotkeys.Global.OpenPreferences}"/>
 
@@ -64,17 +64,20 @@
           <TextBlock Grid.Row="5" Grid.Column="0" Classes="bold" Text="{OnPlatform Ctrl+N, macOS=⌘+N}"/>
           <TextBlock Grid.Row="5" Grid.Column="1" Margin="16,0,0,0" Text="{DynamicResource Text.Hotkeys.Global.Clone}" />
 
-          <TextBlock Grid.Row="6" Grid.Column="0" Classes="bold" Text="{OnPlatform Ctrl+Alt+P, macOS=⌘+⌥+P}"/>
-          <TextBlock Grid.Row="6" Grid.Column="1" Margin="16,0,0,0" Text="{DynamicResource Text.Hotkeys.Global.ShowWorkspaceDropdownMenu}" />
+          <TextBlock Grid.Row="6" Grid.Column="0" Classes="bold" Text="{OnPlatform Ctrl+O, macOS=⌘+O}"/>
+          <TextBlock Grid.Row="6" Grid.Column="1" Margin="16,0,0,0" Text="{DynamicResource Text.Hotkeys.Global.OpenOrInit}" />
 
-          <TextBlock Grid.Row="7" Grid.Column="0" Classes="bold" Text="{OnPlatform Ctrl+P, macOS=⌘+P}"/>
-          <TextBlock Grid.Row="7" Grid.Column="1" Margin="16,0,0,0" Text="{DynamicResource Text.Hotkeys.Global.SwitchTab}" />
+          <TextBlock Grid.Row="7" Grid.Column="0" Classes="bold" Text="{OnPlatform Ctrl+Alt+P, macOS=⌘+⌥+P}"/>
+          <TextBlock Grid.Row="7" Grid.Column="1" Margin="16,0,0,0" Text="{DynamicResource Text.Hotkeys.Global.ShowWorkspaceDropdownMenu}" />
 
-          <TextBlock Grid.Row="8" Grid.Column="0" Classes="bold" Text="{OnPlatform 'Ctrl+-/=', macOS='⌘+-/='}"/>
-          <TextBlock Grid.Row="8" Grid.Column="1" Margin="16,0,0,0" Text="{DynamicResource Text.Hotkeys.Global.Zoom}" />
+          <TextBlock Grid.Row="8" Grid.Column="0" Classes="bold" Text="{OnPlatform Ctrl+P, macOS=⌘+P}"/>
+          <TextBlock Grid.Row="8" Grid.Column="1" Margin="16,0,0,0" Text="{DynamicResource Text.Hotkeys.Global.SwitchTab}" />
 
-          <TextBlock Grid.Row="9" Grid.Column="0" Classes="bold" Text="{OnPlatform Ctrl+Q, macOS=⌘+Q}"/>
-          <TextBlock Grid.Row="9" Grid.Column="1" Margin="16,0,0,0" Text="{DynamicResource Text.Quit}" />
+          <TextBlock Grid.Row="9" Grid.Column="0" Classes="bold" Text="{OnPlatform 'Ctrl+-/=', macOS='⌘+-/='}"/>
+          <TextBlock Grid.Row="9" Grid.Column="1" Margin="16,0,0,0" Text="{DynamicResource Text.Hotkeys.Global.Zoom}" />
+
+          <TextBlock Grid.Row="10" Grid.Column="0" Classes="bold" Text="{OnPlatform Ctrl+Q, macOS=⌘+Q}"/>
+          <TextBlock Grid.Row="10" Grid.Column="1" Margin="16,0,0,0" Text="{DynamicResource Text.Quit}" />
         </Grid>
 
         <TextBlock Text="{DynamicResource Text.Hotkeys.Repo}"

--- a/src/Views/Launcher.axaml.cs
+++ b/src/Views/Launcher.axaml.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.IO;
+using System.Threading.Tasks;
 
 using Avalonia;
 using Avalonia.Controls;
@@ -7,6 +9,7 @@ using Avalonia.Interactivity;
 using Avalonia.Markup.Xaml.MarkupExtensions;
 using Avalonia.Media;
 using Avalonia.Platform;
+using Avalonia.Platform.Storage;
 using Avalonia.VisualTree;
 
 namespace SourceGit.Views
@@ -104,6 +107,56 @@ namespace SourceGit.Views
                 WindowState = _lastWindowState;
             else
                 Activate();
+        }
+
+        public async Task OpenLocalRepository()
+        {
+            var vm = App.GetLauncher();
+            var activePage = vm.ActivePage;
+            if (activePage == null || !activePage.CanCreatePopup())
+                return;
+
+            var topLevel = TopLevel.GetTopLevel(this);
+            if (topLevel == null)
+                return;
+
+            var preference = ViewModels.Preferences.Instance;
+            var workspace = preference.GetActiveWorkspace();
+            var initDir = workspace.DefaultCloneDir;
+            if (string.IsNullOrEmpty(initDir) || !Directory.Exists(initDir))
+                initDir = preference.GitDefaultCloneDir;
+
+            var options = new FolderPickerOpenOptions() { AllowMultiple = false };
+            if (Directory.Exists(initDir))
+            {
+                var folder = await topLevel.StorageProvider.TryGetFolderFromPathAsync(initDir);
+                options.SuggestedStartLocation = folder;
+            }
+
+            try
+            {
+                var selected = await topLevel.StorageProvider.OpenFolderPickerAsync(options);
+                if (selected.Count == 1)
+                {
+                    var folder = selected[0];
+                    var folderPath = folder is { Path: { IsAbsoluteUri: true } path } ? path.LocalPath : folder?.Path.ToString();
+                    var repoPath = await ViewModels.Welcome.Instance.GetRepositoryRootAsync(folderPath);
+                    if (!string.IsNullOrEmpty(repoPath))
+                    {
+                        await ViewModels.Welcome.Instance.AddRepositoryAsync(repoPath, null, false, true);
+                        ViewModels.Welcome.Instance.Refresh();
+                    }
+                    else if (Directory.Exists(folderPath))
+                    {
+                        var test = await new Commands.QueryRepositoryRootPath(folderPath).GetResultAsync();
+                        ViewModels.Welcome.Instance.InitRepository(folderPath, null, test.StdErr);
+                    }
+                }
+            }
+            catch (Exception exception)
+            {
+                Models.Notification.Send(null, $"Failed to open repository: {exception.Message}", true);
+            }
         }
 
         protected override async void OnOpened(EventArgs e)
@@ -219,6 +272,13 @@ namespace SourceGit.Views
                 if (e.Key == Key.W)
                 {
                     vm.CloseTab(null);
+                    e.Handled = true;
+                    return;
+                }
+
+                if (e.Key == Key.O)
+                {
+                    await OpenLocalRepository();
                     e.Handled = true;
                     return;
                 }

--- a/src/Views/WelcomeToolbar.axaml
+++ b/src/Views/WelcomeToolbar.axaml
@@ -19,7 +19,14 @@
         <Path Width="16" Height="16" Data="{StaticResource Icons.Clone}" Margin="0,4,0,0"/>
       </Button>
 
-      <Button Classes="icon_button" Width="32" Click="OpenLocalRepository" ToolTip.Tip="{DynamicResource Text.Welcome.OpenOrInit}">
+      <Button Classes="icon_button" Width="32" Click="OpenLocalRepository">
+        <ToolTip.Tip>
+          <TextBlock>
+            <Run Text="{DynamicResource Text.Welcome.OpenOrInit}"/>
+            <Run Text=" "/>
+            <Run Text="{OnPlatform Ctrl+O, macOS=⌘+O}" FontSize="11" Foreground="{DynamicResource MenuFlyoutItemKeyboardAcceleratorTextForeground}"/>
+          </TextBlock>
+        </ToolTip.Tip>
         <Path Width="14" Height="14" Data="{StaticResource Icons.Folder.Open}" Margin="0,2,0,0"/>
       </Button>
 

--- a/src/Views/WelcomeToolbar.axaml.cs
+++ b/src/Views/WelcomeToolbar.axaml.cs
@@ -1,9 +1,5 @@
-using System;
-using System.IO;
-
 using Avalonia.Controls;
 using Avalonia.Interactivity;
-using Avalonia.Platform.Storage;
 
 namespace SourceGit.Views
 {
@@ -21,47 +17,10 @@ namespace SourceGit.Views
                 return;
 
             var topLevel = TopLevel.GetTopLevel(this);
-            if (topLevel == null)
+            if (topLevel is not Launcher launcher)
                 return;
 
-            var preference = ViewModels.Preferences.Instance;
-            var workspace = preference.GetActiveWorkspace();
-            var initDir = workspace.DefaultCloneDir;
-            if (string.IsNullOrEmpty(initDir) || !Directory.Exists(initDir))
-                initDir = preference.GitDefaultCloneDir;
-
-            var options = new FolderPickerOpenOptions() { AllowMultiple = false };
-            if (Directory.Exists(initDir))
-            {
-                var folder = await topLevel.StorageProvider.TryGetFolderFromPathAsync(initDir);
-                options.SuggestedStartLocation = folder;
-            }
-
-            try
-            {
-                var selected = await topLevel.StorageProvider.OpenFolderPickerAsync(options);
-                if (selected.Count == 1)
-                {
-                    var folder = selected[0];
-                    var folderPath = folder is { Path: { IsAbsoluteUri: true } path } ? path.LocalPath : folder?.Path.ToString();
-                    var repoPath = await ViewModels.Welcome.Instance.GetRepositoryRootAsync(folderPath);
-                    if (!string.IsNullOrEmpty(repoPath))
-                    {
-                        await ViewModels.Welcome.Instance.AddRepositoryAsync(repoPath, null, false, true);
-                        ViewModels.Welcome.Instance.Refresh();
-                    }
-                    else if (Directory.Exists(folderPath))
-                    {
-                        var test = await new Commands.QueryRepositoryRootPath(folderPath).GetResultAsync();
-                        ViewModels.Welcome.Instance.InitRepository(folderPath, null, test.StdErr);
-                    }
-                }
-            }
-            catch (Exception exception)
-            {
-                Models.Notification.Send(null, $"Failed to open repository: {exception.Message}", true);
-            }
-
+            await launcher.OpenLocalRepository();
             e.Handled = true;
         }
     }


### PR DESCRIPTION
This fix add a global hotkey, Ctrl-O, that allows you to perform actions that were previously only possible on the Welcome screen, from anywhere.

- Add global Ctrl+O (Cmd+O on macOS) hotkey for opening a repository.
- Move dialog operation logic `OpenLocalRepository()`  from WelcomeToolbar to Launcher, and use it by global hotkey and button action in WlcomeToolbar.
- Add hotkey text to "Open repository" button tooltip in welcome view.
- Add new hotkey text in Hotkeys dialog as resource (en_US, ja_JP).