### PR TITLE
fix: center diff change indicators and fix width calculation

### DIFF
--- a/src/Views/TextDiffView.axaml.cs
+++ b/src/Views/TextDiffView.axaml.cs
@@ -155,7 +155,10 @@ namespace SourceGit.Views
                         }
 
                         if (indicator != null)
-                            context.DrawText(indicator, new Point(0, y - (indicator.Height * 0.5)));
+                        {
+                            var x = (Bounds.Width - indicator.Width) * 0.5;
+                            context.DrawText(indicator, new Point(x, y - (indicator.Height * 0.5)));
+                        }
                     }
                 }
             }
@@ -167,14 +170,21 @@ namespace SourceGit.Views
                     return new Size(0, 0);
 
                 var typeface = TextView.CreateTypeface();
-                var test = new FormattedText(
+                var minus = new FormattedText(
                     "-",
                     CultureInfo.CurrentCulture,
                     FlowDirection.LeftToRight,
                     typeface,
                     presenter.FontSize,
                     Brushes.White);
-                return new Size(test.Width, 0);
+                var plus = new FormattedText(
+                    "+",
+                    CultureInfo.CurrentCulture,
+                    FlowDirection.LeftToRight,
+                    typeface,
+                    presenter.FontSize,
+                    Brushes.White);
+                return new Size(Math.Max(minus.Width, plus.Width), 0);
             }
 
             protected override void OnDataContextChanged(EventArgs e)


### PR DESCRIPTION
## Problem

"+" indicator is not fully drawing in some fonts.

Example, with monospace font="IPAexGothic", Size=13:
<img width="222" height="283" alt="image" src="https://github.com/user-attachments/assets/31aaf475-e754-449e-88c5-ba837e0f9129" />

## Changes

- Center the +/- indicators horizontally in the diff gutter
- Use Math.Max(minus.Width, plus.Width) for accurate margin width instead of only measuring the '-' character

Fixed view:
<img width="232" height="277" alt="image" src="https://github.com/user-attachments/assets/03b576dd-3603-4553-bd82-971e9f20f864" />
