### PR TITLE
fix: add an missing argument of linux package's desktop entry

### DIFF
--- a/build/resources/_common/applications/sourcegit.desktop
+++ b/build/resources/_common/applications/sourcegit.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Name=SourceGit
 Comment=Open-source & Free Git GUI Client
-Exec=/opt/sourcegit/sourcegit
+Exec=/opt/sourcegit/sourcegit %u
 Icon=/usr/share/icons/sourcegit.png
 Terminal=false
 Type=Application

--- a/conventional_commit.json
+++ b/conventional_commit.json
@@ -1,0 +1,7 @@
+[
+  {
+    "Name": "Linux Package's Desktop Entry Exec Argument Missing Fixes",
+    "Type": "Fix",
+    "Description": "Adding an missing argument of linux package's desktop entry"
+  }
+]

--- a/conventional_commit.json
+++ b/conventional_commit.json
@@ -1,7 +1,0 @@
-[
-  {
-    "Name": "Linux Package's Desktop Entry Exec Argument Missing Fixes",
-    "Type": "Fix",
-    "Description": "Adding an missing argument of linux package's desktop entry"
-  }
-]


### PR DESCRIPTION
I have added the missing argument of linux desktop entry
- Now it can open directory with an app