### PR TITLE
fix: support utf-8 passphrases in askpass

### DIFF
--- a/src/Views/Askpass.axaml.cs
+++ b/src/Views/Askpass.axaml.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Text;
+using System.Security.Cryptography;
 
 using Avalonia.Input;
 using Avalonia.Interactivity;
@@ -27,7 +29,19 @@ namespace SourceGit.Views
         private void EnterPassword(object _1, RoutedEventArgs _2)
         {
             var passphrase = TxtPassphrase.Text ?? string.Empty;
-            Console.Out.WriteLine(passphrase);
+            byte[] passBytes = Encoding.UTF8.GetBytes(passphrase);
+            try
+            {
+                var outStream = Console.OpenStandardOutput();
+                outStream.Write(passBytes, 0, passBytes.Length);
+                outStream.WriteByte((byte)'\n');
+                outStream.Flush();
+            }
+            finally
+            {
+                CryptographicOperations.ZeroMemory(passBytes);
+                TxtPassphrase.Text = string.Empty;
+            }
             App.Quit(0);
         }
     }


### PR DESCRIPTION
This fixes passphrases who use utf-8 characters to be correctly passed further. Based on #2288 

I have tested this change on windows.