### PR TITLE
enhance: Left/Right arrow key navigation in tree views

### DIFF
--- a/src/Views/ChangeCollectionView.axaml.cs
+++ b/src/Views/ChangeCollectionView.axaml.cs
@@ -8,6 +8,7 @@ using Avalonia.Controls.Primitives;
 using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Media;
+using Avalonia.Threading;
 using Avalonia.VisualTree;
 
 namespace SourceGit.Views
@@ -84,6 +85,8 @@ namespace SourceGit.Views
             ScrollIntoView(target);
             if (ContainerFromItem(target) is Control container)
                 container.Focus();
+            else
+                Dispatcher.UIThread.Post(() => (ContainerFromItem(target) as Control)?.Focus(), DispatcherPriority.Loaded);
         }
 
         private static ViewModels.ChangeTreeNode FindParentRow(IList<ViewModels.ChangeTreeNode> rows, ViewModels.ChangeTreeNode node)

--- a/src/Views/ChangeCollectionView.axaml.cs
+++ b/src/Views/ChangeCollectionView.axaml.cs
@@ -35,18 +35,74 @@ namespace SourceGit.Views
 
         protected override void OnKeyDown(KeyEventArgs e)
         {
-            if (SelectedItems is [ViewModels.ChangeTreeNode node])
+            if (e.KeyModifiers == KeyModifiers.None &&
+                (e.Key == Key.Left || e.Key == Key.Right) &&
+                SelectedItems is [ViewModels.ChangeTreeNode node] &&
+                this.FindAncestorOfType<ChangeCollectionView>() is { Content: ViewModels.ChangeCollectionAsTree tree } view)
             {
-                if (((e.Key == Key.Left && node.IsExpanded) || (e.Key == Key.Right && !node.IsExpanded)) &&
-                    e.KeyModifiers == KeyModifiers.None)
+                if (e.Key == Key.Left)
                 {
-                    this.FindAncestorOfType<ChangeCollectionView>()?.ToggleNodeIsExpanded(node);
-                    e.Handled = true;
+                    if (node.IsFolder && node.IsExpanded)
+                    {
+                        view.ToggleNodeIsExpanded(node);
+                    }
+                    else
+                    {
+                        var parent = FindParentRow(tree.Rows, node);
+                        if (parent != null)
+                            MoveSelectionTo(parent);
+                    }
                 }
+                else
+                {
+                    if (node.IsFolder && !node.IsExpanded)
+                    {
+                        view.ToggleNodeIsExpanded(node);
+                    }
+                    else if (node.IsFolder)
+                    {
+                        var idx = tree.Rows.IndexOf(node);
+                        if (idx >= 0 && idx + 1 < tree.Rows.Count)
+                        {
+                            var child = tree.Rows[idx + 1];
+                            if (child.Depth == node.Depth + 1)
+                                MoveSelectionTo(child);
+                        }
+                    }
+                }
+
+                e.Handled = true;
             }
 
             if (!e.Handled && e.Key != Key.Space && e.Key != Key.Enter)
                 base.OnKeyDown(e);
+        }
+
+        private void MoveSelectionTo(ViewModels.ChangeTreeNode target)
+        {
+            SelectedItem = target;
+            ScrollIntoView(target);
+            if (ContainerFromItem(target) is Control container)
+                container.Focus();
+        }
+
+        private static ViewModels.ChangeTreeNode FindParentRow(IList<ViewModels.ChangeTreeNode> rows, ViewModels.ChangeTreeNode node)
+        {
+            if (node.Depth == 0)
+                return null;
+
+            var idx = rows.IndexOf(node);
+            if (idx <= 0)
+                return null;
+
+            var parentDepth = node.Depth - 1;
+            for (int i = idx - 1; i >= 0; i--)
+            {
+                if (rows[i].Depth == parentDepth)
+                    return rows[i];
+            }
+
+            return null;
         }
     }
 

--- a/src/Views/RevisionFileTreeView.axaml.cs
+++ b/src/Views/RevisionFileTreeView.axaml.cs
@@ -126,17 +126,17 @@ namespace SourceGit.Views
             {
                 if (e.KeyModifiers == KeyModifiers.None &&
                     (e.Key == Key.Left || e.Key == Key.Right) &&
-                    this.FindAncestorOfType<RevisionFileTreeView>() is { } tree)
+                    this.FindAncestorOfType<RevisionFileTreeView>() is { } view)
                 {
                     if (e.Key == Key.Left)
                     {
                         if (node.IsFolder && node.IsExpanded)
                         {
-                            await tree.ToggleNodeIsExpandedAsync(node);
+                            await view.ToggleNodeIsExpandedAsync(node);
                         }
                         else
                         {
-                            var parent = FindParentRow(tree.Rows, node);
+                            var parent = FindParentRow(view.Rows, node);
                             if (parent != null)
                                 MoveSelectionTo(parent);
                         }
@@ -145,14 +145,14 @@ namespace SourceGit.Views
                     {
                         if (node.IsFolder && !node.IsExpanded)
                         {
-                            await tree.ToggleNodeIsExpandedAsync(node);
+                            await view.ToggleNodeIsExpandedAsync(node);
                         }
                         else if (node.IsFolder)
                         {
-                            var idx = tree.Rows.IndexOf(node);
-                            if (idx >= 0 && idx + 1 < tree.Rows.Count)
+                            var idx = view.Rows.IndexOf(node);
+                            if (idx >= 0 && idx + 1 < view.Rows.Count)
                             {
-                                var child = tree.Rows[idx + 1];
+                                var child = view.Rows[idx + 1];
                                 if (child.Depth == node.Depth + 1)
                                     MoveSelectionTo(child);
                             }

--- a/src/Views/RevisionFileTreeView.axaml.cs
+++ b/src/Views/RevisionFileTreeView.axaml.cs
@@ -123,13 +123,41 @@ namespace SourceGit.Views
 
             if (SelectedItem is ViewModels.RevisionFileTreeNode node)
             {
-                if (node.IsFolder &&
-                    e.KeyModifiers == KeyModifiers.None &&
-                    (node.IsExpanded && e.Key == Key.Left) || (!node.IsExpanded && e.Key == Key.Right))
+                if (e.KeyModifiers == KeyModifiers.None &&
+                    (e.Key == Key.Left || e.Key == Key.Right) &&
+                    this.FindAncestorOfType<RevisionFileTreeView>() is { } tree)
                 {
-                    var tree = this.FindAncestorOfType<RevisionFileTreeView>();
-                    if (tree != null)
-                        await tree.ToggleNodeIsExpandedAsync(node);
+                    if (e.Key == Key.Left)
+                    {
+                        if (node.IsFolder && node.IsExpanded)
+                        {
+                            await tree.ToggleNodeIsExpandedAsync(node);
+                        }
+                        else
+                        {
+                            var parent = FindParentRow(tree.Rows, node);
+                            if (parent != null)
+                                MoveSelectionTo(parent);
+                        }
+                    }
+                    else
+                    {
+                        if (node.IsFolder && !node.IsExpanded)
+                        {
+                            await tree.ToggleNodeIsExpandedAsync(node);
+                        }
+                        else if (node.IsFolder)
+                        {
+                            var idx = tree.Rows.IndexOf(node);
+                            if (idx >= 0 && idx + 1 < tree.Rows.Count)
+                            {
+                                var child = tree.Rows[idx + 1];
+                                if (child.Depth == node.Depth + 1)
+                                    MoveSelectionTo(child);
+                            }
+                        }
+                    }
+
                     e.Handled = true;
                 }
                 else if (e.Key == Key.C &&
@@ -181,6 +209,33 @@ namespace SourceGit.Views
 
             if (!e.Handled)
                 base.OnKeyDown(e);
+        }
+
+        private void MoveSelectionTo(ViewModels.RevisionFileTreeNode target)
+        {
+            SelectedItem = target;
+            ScrollIntoView(target);
+            if (ContainerFromItem(target) is Control container)
+                container.Focus();
+        }
+
+        private static ViewModels.RevisionFileTreeNode FindParentRow(IList<ViewModels.RevisionFileTreeNode> rows, ViewModels.RevisionFileTreeNode node)
+        {
+            if (node.Depth == 0)
+                return null;
+
+            var idx = rows.IndexOf(node);
+            if (idx <= 0)
+                return null;
+
+            var parentDepth = node.Depth - 1;
+            for (int i = idx - 1; i >= 0; i--)
+            {
+                if (rows[i].Depth == parentDepth)
+                    return rows[i];
+            }
+
+            return null;
         }
     }
 

--- a/src/Views/RevisionFileTreeView.axaml.cs
+++ b/src/Views/RevisionFileTreeView.axaml.cs
@@ -12,6 +12,7 @@ using Avalonia.Interactivity;
 using Avalonia.Layout;
 using Avalonia.Media;
 using Avalonia.Platform.Storage;
+using Avalonia.Threading;
 using Avalonia.VisualTree;
 
 namespace SourceGit.Views
@@ -217,6 +218,8 @@ namespace SourceGit.Views
             ScrollIntoView(target);
             if (ContainerFromItem(target) is Control container)
                 container.Focus();
+            else
+                Dispatcher.UIThread.Post(() => (ContainerFromItem(target) as Control)?.Focus(), DispatcherPriority.Loaded);
         }
 
         private static ViewModels.RevisionFileTreeNode FindParentRow(IList<ViewModels.RevisionFileTreeNode> rows, ViewModels.RevisionFileTreeNode node)


### PR DESCRIPTION
Adds Left/Right arrow key navigation in the tree view, both in Local Changes and in the Files tab of commit details. Behaves like VS Code / IntelliJ — Left collapses or walks up to the parent, Right expands or walks down to the first child.

### Local Changes

https://github.com/user-attachments/assets/43abdaa6-c680-49df-91ec-f99e3715dd31

### Files tab

https://github.com/user-attachments/assets/ac206f1b-42c1-4357-9f09-990038f406bf