### PR TITLE
feature: `ImageSource` supports loading psd files

### DIFF
--- a/src/Models/ImageDecoder.cs
+++ b/src/Models/ImageDecoder.cs
@@ -6,5 +6,6 @@
         Builtin,
         Pfim,
         Tiff,
+        StbImage,
     }
 }

--- a/src/SourceGit.csproj
+++ b/src/SourceGit.csproj
@@ -59,6 +59,7 @@
     <PackageReference Include="LiveChartsCore.SkiaSharpView.Avalonia" Version="2.0.0" />
     <PackageReference Include="OpenAI" Version="2.10.0" />
     <PackageReference Include="Pfim" Version="0.11.4" />
+    <PackageReference Include="StbImageSharp" Version="2.30.15" />
 
     <ProjectReference Include="../depends/AvaloniaEdit/src/AvaloniaEdit.TextMate/AvaloniaEdit.TextMate.csproj" />
   </ItemGroup>

--- a/src/ViewModels/ImageSource.cs
+++ b/src/ViewModels/ImageSource.cs
@@ -9,6 +9,7 @@ using Avalonia.Media.Imaging;
 using Avalonia.Platform;
 using BitMiracle.LibTiff.Classic;
 using Pfim;
+using StbImageSharp;
 
 namespace SourceGit.ViewModels
 {
@@ -32,6 +33,7 @@ namespace SourceGit.ViewModels
                 ".ico" or ".bmp" or ".gif" or ".jpg" or ".jpeg" or ".png" or ".webp" => Models.ImageDecoder.Builtin,
                 ".tga" or ".dds" => Models.ImageDecoder.Pfim,
                 ".tif" or ".tiff" => Models.ImageDecoder.Tiff,
+                ".psd" => Models.ImageDecoder.StbImage,
                 _ => Models.ImageDecoder.None,
             };
         }
@@ -77,6 +79,8 @@ namespace SourceGit.ViewModels
                             return DecodeWithPfim(stream, size);
                         case Models.ImageDecoder.Tiff:
                             return DecodeWithTiff(stream, size);
+                        case Models.ImageDecoder.StbImage:
+                            return DecodeWithStbImage(stream, size);
                     }
                 }
                 catch (Exception e)
@@ -189,6 +193,20 @@ namespace SourceGit.ViewModels
                 Marshal.Copy(pixels, 0, frameBuffer.Address, pixels.Length);
                 return new ImageSource(bitmap, size);
             }
+        }
+
+        private static ImageSource DecodeWithStbImage(Stream stream, long size)
+        {
+            var image = ImageResult.FromStream(stream, ColorComponents.RedGreenBlueAlpha);
+
+            var data = image.Data;
+            var stride = image.Width * (int)image.Comp;
+
+            var ptr = Marshal.UnsafeAddrOfPinnedArrayElement(data, 0);
+            var pixelSize = new PixelSize(image.Width, image.Height);
+            var dpi = new Vector(96, 96);
+            var bitmap = new Bitmap(PixelFormat.Rgba8888, AlphaFormat.Unpremul, ptr, pixelSize, dpi, stride);
+            return new ImageSource(bitmap, size);
         }
     }
 }


### PR DESCRIPTION
Implements #2290.

Uses [StbImageSharp](https://github.com/StbSharp/StbImageSharp) which is a [public domain](https://github.com/StbSharp/StbImageSharp#license) C# port (not wrapper) of [stb_image.h](https://github.com/nothings/stb/blob/master/stb_image.h)