### PR TITLE
fix: prevent NullReferenceException in CommandLog.AppendLine after completion

### DIFF
--- a/src/ViewModels/CommandLog.cs
+++ b/src/ViewModels/CommandLog.cs
@@ -62,6 +62,9 @@ namespace SourceGit.ViewModels
             }
             else
             {
+                if (IsComplete || _builder == null)
+                    return;
+
                 var newline = line ?? string.Empty;
                 _builder.AppendLine(newline);
 


### PR DESCRIPTION
## Root Cause

Commit `40765826c` introduced `CheckAccess()` fast paths in `AppendLine` and `Complete`, breaking the execution ordering previously guaranteed by always dispatching to the UI thread.

Before `40765826c`, both `AppendLine` and `Complete` unconditionally used `Dispatcher.UIThread.Invoke()`, ensuring they executed in queue order — a queued `AppendLine` would always run before a later-queued `Complete`.

After `40765826c`, `Complete()` runs immediately when called from the UI thread instead of queueing. However, `AppendLine` calls from background threads (via `HandleOutput` → `AsyncStreamReader`) are still queued to the UI thread. When `Complete()` runs first (on the UI thread) and sets `_builder = null`, the previously queued `AppendLine` calls later hit the null `_builder`, causing a `NullReferenceException`.

## Fix

Add a guard in `AppendLine` to silently drop invocations that arrive after the log has been completed, checking both `IsComplete` and `_builder == null`.

## Test Plan

- [x] Normal git operations (fetch, pull, push, commit) complete without crash
- [x] Rapid consecutive commands do not trigger the race condition
- [x] Command log content remains correct in the log window

🤖 Generated with [Claude Code](https://claude.com/claude-code)