### PR TITLE
feat: embed Git commit hash in build and display in About dialog

### DIFF
--- a/src/SourceGit.csproj
+++ b/src/SourceGit.csproj
@@ -32,6 +32,22 @@
     <DefineConstants>$(DefineConstants);DISABLE_UPDATE_DETECTION</DefineConstants>
   </PropertyGroup>
 
+  <Target Name="SetGitCommitHash" BeforeTargets="BeforeBuild"
+          Condition="Exists('$(MSBuildProjectDirectory)\..\.git')">
+    <Exec Command="git -C &quot;$(MSBuildProjectDirectory)&quot; describe --always --dirty=-dirty --abbrev=8 --match='___nonexistent___'"
+          ConsoleToMSBuild="true" StandardOutputImportance="low">
+      <Output TaskParameter="ConsoleOutput" PropertyName="GitCommitHash" />
+    </Exec>
+    <WriteLinesToFile
+      File="$(IntermediateOutputPath)GitCommitHash.g.cs"
+      Lines="[assembly: System.Reflection.AssemblyMetadata(&quot;GitCommitHash&quot;, &quot;$(GitCommitHash)&quot;)]"
+      Overwrite="true"
+      Condition="'$(GitCommitHash)' != ''" />
+    <ItemGroup Condition="'$(GitCommitHash)' != ''">
+      <Compile Include="$(IntermediateOutputPath)GitCommitHash.g.cs" />
+    </ItemGroup>
+  </Target>
+
   <ItemGroup>
     <AssemblyMetadata Include="BuildDate" Value="$([System.DateTime]::Now.ToString('o'))" />
   </ItemGroup>

--- a/src/SourceGit.csproj
+++ b/src/SourceGit.csproj
@@ -35,15 +35,17 @@
   <Target Name="SetGitCommitHash" BeforeTargets="BeforeBuild"
           Condition="Exists('$(MSBuildProjectDirectory)\..\.git')">
     <Exec Command="git -C &quot;$(MSBuildProjectDirectory)&quot; describe --always --dirty=-dirty --abbrev=8 --match='___nonexistent___'"
-          ConsoleToMSBuild="true" StandardOutputImportance="low">
+          ConsoleToMSBuild="true" StandardOutputImportance="low"
+          ContinueOnError="true">
       <Output TaskParameter="ConsoleOutput" PropertyName="GitCommitHash" />
+      <Output TaskParameter="ExitCode" PropertyName="_GitExitCode" />
     </Exec>
     <WriteLinesToFile
       File="$(IntermediateOutputPath)GitCommitHash.g.cs"
       Lines="[assembly: System.Reflection.AssemblyMetadata(&quot;GitCommitHash&quot;, &quot;$(GitCommitHash)&quot;)]"
       Overwrite="true"
-      Condition="'$(GitCommitHash)' != ''" />
-    <ItemGroup Condition="'$(GitCommitHash)' != ''">
+      Condition="'$(_GitExitCode)' == '0' And '$(GitCommitHash)' != ''" />
+    <ItemGroup Condition="'$(_GitExitCode)' == '0' And '$(GitCommitHash)' != ''">
       <Compile Include="$(IntermediateOutputPath)GitCommitHash.g.cs" />
     </ItemGroup>
   </Target>

--- a/src/Views/About.axaml
+++ b/src/Views/About.axaml
@@ -71,6 +71,7 @@
         </StackPanel>
 
         <TextBlock x:Name="TxtReleaseDate" Margin="0,28,0,0" Foreground="{DynamicResource Brush.FG2}"/>
+        <TextBlock x:Name="TxtGitHash" Margin="0,2,0,0" Foreground="{DynamicResource Brush.FG2}"/>
         <TextBlock x:Name="TxtCopyright" Margin="0,2,0,0" Foreground="{DynamicResource Brush.FG2}"/>
       </StackPanel>
     </StackPanel>

--- a/src/Views/About.axaml.cs
+++ b/src/Views/About.axaml.cs
@@ -23,7 +23,10 @@ namespace SourceGit.Views
                 if (attr.Key.Equals("BuildDate", StringComparison.OrdinalIgnoreCase) && DateTime.TryParse(attr.Value, out var date))
                 {
                     TxtReleaseDate.Text = App.Text("About.ReleaseDate", Models.DateTimeFormat.Format(date, true));
-                    break;
+                }
+                else if (attr.Key.Equals("GitCommitHash", StringComparison.OrdinalIgnoreCase))
+                {
+                    TxtGitHash.Text = $"Build: {attr.Value}";
                 }
             }
 


### PR DESCRIPTION
## Summary
- Embed the short git commit hash (8-char) at build time via MSBuild target, with `-dirty` suffix when the working tree has uncommitted changes
- Display the hash as `Build: {hash}` in the About dialog
- Gracefully handle missing `.git` directory or missing `git` executable (skips embedding without build failure)

## How it works
An MSBuild target runs `git describe --always --dirty=-dirty --abbrev=8 --match='___nonexistent___'` before each build and writes the result to a generated C# file compiled into the assembly as `AssemblyMetadata("GitCommitHash", ...)`. The About page reads this metadata at runtime.

## Test Plan
- [x] `dotnet build` and `dotnet publish -c Release` succeed with no warnings
- [x] About dialog displays `Build: {hash}` or `Build: {hash}-dirty`
- [x] Building without `.git` directory does not fail
- [x] Building with `.git` but without `git` installed does not fail
