### PR TITLE
Clear notifications automatically

### DIFF
--- a/src/ViewModels/LauncherPage.cs
+++ b/src/ViewModels/LauncherPage.cs
@@ -132,14 +132,15 @@ namespace SourceGit.ViewModels
         {
             if (e.Action == NotifyCollectionChangedAction.Add)
             {
-                _clearNotificationsCancellationToken?.Cancel();
-                _clearNotificationsCancellationToken = new CancellationTokenSource();
                 ClearNotificationsAutomatically();
             }
         }
 
         private async void ClearNotificationsAutomatically()
         {
+            _clearNotificationsCancellationToken?.Cancel();
+            _clearNotificationsCancellationToken = new CancellationTokenSource();
+
             try
             {
                 await Task.Delay(TimeSpan.FromSeconds(5), _clearNotificationsCancellationToken.Token);

--- a/src/ViewModels/LauncherPage.cs
+++ b/src/ViewModels/LauncherPage.cs
@@ -53,6 +53,8 @@ namespace SourceGit.ViewModels
         {
             _node = node;
             _data = repo;
+            
+            Notifications.CollectionChanged += Notifications_CollectionChanged;
         }
 
         ~LauncherPage()

--- a/src/ViewModels/LauncherPage.cs
+++ b/src/ViewModels/LauncherPage.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Specialized;
+using System.Threading;
 using System.Threading.Tasks;
 using Avalonia.Collections;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -44,12 +46,18 @@ namespace SourceGit.ViewModels
 
             // New welcome page will clear the search filter before.
             Welcome.Instance.ClearSearchFilter();
+            Notifications.CollectionChanged += Notifications_CollectionChanged;
         }
 
         public LauncherPage(RepositoryNode node, Repository repo)
         {
             _node = node;
             _data = repo;
+        }
+
+        ~LauncherPage()
+        {
+            Notifications.CollectionChanged -= Notifications_CollectionChanged;
         }
 
         public void ClearNotifications()
@@ -118,5 +126,33 @@ namespace SourceGit.ViewModels
         private object _data = null;
         private Models.DirtyState _dirtyState = Models.DirtyState.None;
         private Popup _popup = null;
+        private CancellationTokenSource _clearNotificationsCancellationToken;
+
+        private void Notifications_CollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
+        {
+            if (e.Action == NotifyCollectionChangedAction.Add)
+            {
+                _clearNotificationsCancellationToken?.Cancel();
+                _clearNotificationsCancellationToken = new CancellationTokenSource();
+                ClearNotificationsAutomatically();
+            }
+        }
+
+        private async void ClearNotificationsAutomatically()
+        {
+            try
+            {
+                await Task.Delay(TimeSpan.FromSeconds(5), _clearNotificationsCancellationToken.Token);
+
+                if (!_clearNotificationsCancellationToken.Token.IsCancellationRequested)
+                {
+                    Notifications.Clear();
+                }
+            }
+            catch (TaskCanceledException)
+            {
+                // Ignore the exception if the task was canceled
+            }
+        }
     }
 }


### PR DESCRIPTION
I find it useful to let notifications go after a delay without having to clear them explicitly.

Backlog:
- [x] clear notifications after a delay without adding new ones
- [ ] expose this behavior at Preferences, disabled by default
- [ ] let the user customize the delay (5 s by default)