### PR TITLE
feature: allow copying ref names from commit info panel

### DIFF
--- a/src/Views/CommitBaseInfo.axaml
+++ b/src/Views/CommitBaseInfo.axaml
@@ -194,13 +194,34 @@
 
           <!-- REFS -->
           <TextBlock Grid.Row="3" Grid.Column="0" Classes="info_label" VerticalAlignment="Top" Margin="0,4,0,0" Text="{DynamicResource Text.CommitDetail.Info.Refs}" IsVisible="{Binding HasDecorators}"/>
-          <Border Grid.Row="3" Grid.Column="1" Margin="12,0,0,0" MinHeight="24" IsVisible="{Binding HasDecorators}">
-            <v:CommitRefsPresenter Foreground="{DynamicResource Brush.FG1}"
-                                   FontSize="12"
-                                   AllowWrap="True"
-                                   Margin="0,4,0,0"
-                                   UseGraphColor="False"/>
-          </Border>
+          <ItemsControl Grid.Row="3" Grid.Column="1" Margin="12,4,0,0" ItemsSource="{Binding Decorators}" IsVisible="{Binding HasDecorators}">
+            <ItemsControl.ItemsPanel>
+              <ItemsPanelTemplate>
+                <WrapPanel Orientation="Horizontal"/>
+              </ItemsPanelTemplate>
+            </ItemsControl.ItemsPanel>
+
+            <ItemsControl.ItemTemplate>
+              <DataTemplate DataType="m:Decorator">
+                <StackPanel Orientation="Horizontal" Margin="0,0,16,4" VerticalAlignment="Center">
+                  <v:CommitRefsPresenter Decorator="{Binding}"
+                                         Foreground="{DynamicResource Brush.FG1}"
+                                         FontSize="12"
+                                         UseGraphColor="False"
+                                         VerticalAlignment="Center"/>
+                  <Button Classes="icon_button"
+                          Width="14" Height="14"
+                          Padding="0"
+                          Margin="2,0,0,0"
+                          Cursor="Hand"
+                          Click="OnCopyRefName"
+                          ToolTip.Tip="{DynamicResource Text.Copy}">
+                    <Path Width="10" Height="10" Data="{StaticResource Icons.Copy}" Fill="{DynamicResource Brush.FG2}"/>
+                  </Button>
+                </StackPanel>
+              </DataTemplate>
+            </ItemsControl.ItemTemplate>
+          </ItemsControl>
 
           <!-- Messages -->
           <TextBlock Grid.Row="4" Grid.Column="0" Classes="info_label" VerticalAlignment="Top" Margin="0,4,0,0" Text="{DynamicResource Text.CommitDetail.Info.Message}" />

--- a/src/Views/CommitBaseInfo.axaml.cs
+++ b/src/Views/CommitBaseInfo.axaml.cs
@@ -87,6 +87,14 @@ namespace SourceGit.Views
             _iconResetTimer?.Dispose();
         }
 
+        private async void OnCopyRefName(object sender, RoutedEventArgs e)
+        {
+            if (sender is Button { DataContext: Models.Decorator decorator })
+                await this.CopyTextAsync(decorator.Name);
+
+            e.Handled = true;
+        }
+
         private async void OnCopyCommitSHA(object sender, RoutedEventArgs e)
         {
             if (sender is Button { DataContext: Models.Commit commit })

--- a/src/Views/CommitRefsPresenter.cs
+++ b/src/Views/CommitRefsPresenter.cs
@@ -83,6 +83,15 @@ namespace SourceGit.Views
             set => SetValue(ShowTagsProperty, value);
         }
 
+        public static readonly StyledProperty<Models.Decorator> DecoratorProperty =
+            AvaloniaProperty.Register<CommitRefsPresenter, Models.Decorator>(nameof(Decorator));
+
+        public Models.Decorator Decorator
+        {
+            get => GetValue(DecoratorProperty);
+            set => SetValue(DecoratorProperty, value);
+        }
+
         static CommitRefsPresenter()
         {
             AffectsMeasure<CommitRefsPresenter>(
@@ -91,7 +100,8 @@ namespace SourceGit.Views
                 ForegroundProperty,
                 UseGraphColorProperty,
                 BackgroundProperty,
-                ShowTagsProperty);
+                ShowTagsProperty,
+                DecoratorProperty);
         }
 
         public Models.Decorator DecoratorAt(Point point)
@@ -174,16 +184,21 @@ namespace SourceGit.Views
         {
             _items.Clear();
 
-            if (DataContext is not Models.Commit commit)
+            var commit = DataContext as Models.Commit;
+            IList<Models.Decorator> refs;
+            if (Decorator != null)
+                refs = new[] { Decorator };
+            else if (commit != null)
+                refs = commit.Decorators;
+            else
                 return new Size(0, 0);
 
-            var refs = commit.Decorators;
             if (refs is { Count: > 0 })
             {
                 var typeface = new Typeface(FontFamily);
                 var typefaceBold = new Typeface(FontFamily, FontStyle.Normal, FontWeight.Bold);
                 var fg = Foreground;
-                var normalBG = UseGraphColor ? Models.CommitGraph.Pens[commit.Color].Brush : Brushes.Gray;
+                var normalBG = UseGraphColor && commit != null ? Models.CommitGraph.Pens[commit.Color].Brush : Brushes.Gray;
                 var labelSize = FontSize;
                 var requiredHeight = 16.0;
                 var x = 0.0;


### PR DESCRIPTION
Adds a small copy button next to each ref pill in the commit info panel. Clicking it copies the ref name (e.g. `main`, `origin/feature`) to the clipboard, matching the existing copy affordance on the SHA row.

<img width="748" height="256" alt="Screenshot 2026-05-05 at 14 02 30" src="https://github.com/user-attachments/assets/2bff0a20-460f-4281-8310-f0b51e6f0524" />


The Histories grid is intentionally untouched (copy buttons there would clutter the dense rows). One side effect to flag: wrap in the REFS row now happens between `[pill+button]` groups instead of inside one continuous presenter, which is the natural behavior for an `ItemsControl` + `WrapPanel` layout.

## Test plan

- [ ] Select a commit with refs and click a copy icon in the INFORMATION panel's REFS row — the ref name lands in the clipboard.
