### PR TITLE
feature: add Compare with default base on current branch menu

### DIFF
--- a/src/Commands/QueryDefaultBranch.cs
+++ b/src/Commands/QueryDefaultBranch.cs
@@ -1,0 +1,27 @@
+using System.Threading.Tasks;
+
+namespace SourceGit.Commands
+{
+    public class QueryDefaultBranch : Command
+    {
+        public QueryDefaultBranch(string repo, string remote)
+        {
+            WorkingDirectory = repo;
+            Context = repo;
+            Args = $"symbolic-ref --short refs/remotes/{remote}/HEAD";
+            RaiseError = false;
+        }
+
+        public string GetResult()
+        {
+            var rs = ReadToEnd();
+            return rs.IsSuccess ? rs.StdOut.Trim() : string.Empty;
+        }
+
+        public async Task<string> GetResultAsync()
+        {
+            var rs = await ReadToEndAsync().ConfigureAwait(false);
+            return rs.IsSuccess ? rs.StdOut.Trim() : string.Empty;
+        }
+    }
+}

--- a/src/Resources/Locales/en_US.axaml
+++ b/src/Resources/Locales/en_US.axaml
@@ -63,6 +63,7 @@
   <x:String x:Key="Text.BranchCM.Checkout" xml:space="preserve">Checkout ${0}$...</x:String>
   <x:String x:Key="Text.BranchCM.CompareTwo" xml:space="preserve">Compare selected 2 branches</x:String>
   <x:String x:Key="Text.BranchCM.CompareWith" xml:space="preserve">Compare with...</x:String>
+  <x:String x:Key="Text.BranchCM.CompareWithDefault" xml:space="preserve">Compare with ${0}$</x:String>
   <x:String x:Key="Text.BranchCM.CompareWithHead" xml:space="preserve">Compare with HEAD</x:String>
   <x:String x:Key="Text.BranchCM.CopyName" xml:space="preserve">Copy Branch Name</x:String>
   <x:String x:Key="Text.BranchCM.CreatePR" xml:space="preserve">Create PR...</x:String>

--- a/src/Views/BranchTree.axaml.cs
+++ b/src/Views/BranchTree.axaml.cs
@@ -733,6 +733,21 @@ namespace SourceGit.Views
 
                 menu.Items.Add(push);
 
+                menu.Items.Add(new MenuItem() { Header = "-" });
+
+                var defaultBase = ResolveDefaultBaseBranch(repo);
+                if (defaultBase != null && !defaultBase.FullName.Equals(branch.FullName, StringComparison.Ordinal))
+                {
+                    var compareWithDefault = new MenuItem();
+                    compareWithDefault.Header = App.Text("BranchCM.CompareWithDefault", defaultBase.FriendlyName);
+                    compareWithDefault.Icon = this.CreateMenuIcon("Icons.Compare");
+                    compareWithDefault.Click += (_, _) =>
+                    {
+                        this.ShowWindow(new ViewModels.Compare(repo, defaultBase, branch));
+                    };
+                    menu.Items.Add(compareWithDefault);
+                }
+
                 var compareWith = new MenuItem();
                 compareWith.Header = App.Text("BranchCM.CompareWith");
                 compareWith.Icon = this.CreateMenuIcon("Icons.Compare");
@@ -740,7 +755,6 @@ namespace SourceGit.Views
                 {
                     new ViewModels.CompareCommandPalette(repo, branch).Open();
                 };
-                menu.Items.Add(new MenuItem() { Header = "-" });
                 menu.Items.Add(compareWith);
             }
             else
@@ -1350,6 +1364,57 @@ namespace SourceGit.Views
 
             menu.Items.Add(custom);
             menu.Items.Add(new MenuItem() { Header = "-" });
+        }
+
+        // Resolves the repository's "default" branch (the equivalent of GitHub's default branch).
+        // Remote priority: Settings.DefaultRemote -> current branch's upstream remote -> first remote.
+        // Prefers the remote-tracking ref (e.g. origin/master) over a same-named local branch so
+        // the comparison is against the actual remote default. Returns null if the remote HEAD is
+        // unset or no remote exists.
+        private Models.Branch ResolveDefaultBaseBranch(ViewModels.Repository repo)
+        {
+            if (repo.Remotes.Count == 0)
+                return null;
+
+            // Prefer an explicitly-configured default remote ("upstream" in fork workflows),
+            // then fall back to the current branch's upstream remote, then the first remote.
+            string remoteName = null;
+            if (!string.IsNullOrEmpty(repo.Settings?.DefaultRemote))
+                remoteName = repo.Settings.DefaultRemote;
+
+            if (string.IsNullOrEmpty(remoteName))
+            {
+                var current = repo.CurrentBranch;
+                const int prefixLen = 13; // "refs/remotes/"
+                if (current != null && !string.IsNullOrEmpty(current.Upstream) && current.Upstream.Length > prefixLen)
+                {
+                    var sepIdx = current.Upstream.IndexOf('/', prefixLen);
+                    if (sepIdx > prefixLen)
+                        remoteName = current.Upstream.Substring(prefixLen, sepIdx - prefixLen);
+                }
+            }
+
+            if (string.IsNullOrEmpty(remoteName))
+                remoteName = repo.Remotes[0].Name;
+
+            var fullRef = new Commands.QueryDefaultBranch(repo.FullPath, remoteName).GetResult();
+            if (string.IsNullOrEmpty(fullRef))
+                return null;
+
+            // QueryDefaultBranch returns e.g. "origin/master". Prefer the remote-tracking ref
+            // (authoritative for "what is the default base on the remote?"), fall back to a
+            // local branch with the same short name only if the remote-tracking ref is absent.
+            var remoteTrackingRef = $"refs/remotes/{fullRef}";
+            var remoteMatch = repo.Branches.Find(b => !b.IsLocal && b.FullName.Equals(remoteTrackingRef, System.StringComparison.Ordinal));
+            if (remoteMatch != null)
+                return remoteMatch;
+
+            var slash = fullRef.IndexOf('/');
+            if (slash <= 0 || slash >= fullRef.Length - 1)
+                return null;
+
+            var shortName = fullRef.Substring(slash + 1);
+            return repo.Branches.Find(b => b.IsLocal && b.Name.Equals(shortName, System.StringComparison.Ordinal));
         }
 
         private bool _disableSelectionChangingEvent = false;


### PR DESCRIPTION
Other local branches in the sidebar already have a one-click "Compare with HEAD" entry, but the current branch's right-click only offers the free-form "Compare with..." palette. Adds a "Compare with `<default>`" entry that opens the existing Compare window pre-filled with the repo's default base branch.

<img width="1038" height="354" alt="Screenshot 2026-05-05 at 17 51 04" src="https://github.com/user-attachments/assets/06999c10-0f87-449e-b3eb-99343bb5f8a3" />


The default branch is resolved from `refs/remotes/<remote>/HEAD` (the same source GitHub/GitLab use), with the remote chosen via the same fallback order used elsewhere in the app: current branch's upstream remote → `Settings.DefaultRemote` → first remote. The entry is hidden when the remote HEAD is unset or when the resolved base equals the current branch (so it never shows "Compare master with master").

## Test plan

- [ ] Right-click the current branch and confirm "Compare with `<default>`" appears, opens the existing Compare window pre-filled.
