### PR TITLE
Align source revision in about dialog

### DIFF
--- a/src/Resources/Locales/zh_TW.axaml
+++ b/src/Resources/Locales/zh_TW.axaml
@@ -4,7 +4,7 @@
   </ResourceDictionary.MergedDictionaries>
 
   <x:String x:Key="Text.About" xml:space="preserve">關於</x:String>
-  <x:String x:Key="Text.About.GitSourceRevision" xml:space="preserve">構建於源代碼修訂版: </x:String>
+  <x:String x:Key="Text.About.GitSourceRevision" xml:space="preserve">原始碼版本:</x:String>
   <x:String x:Key="Text.About.Menu" xml:space="preserve">關於 SourceGit</x:String>
   <x:String x:Key="Text.About.ReleaseDate" xml:space="preserve">發行日期: {0}</x:String>
   <x:String x:Key="Text.About.ReleaseNotes" xml:space="preserve">版本說明</x:String>

--- a/src/Views/About.axaml
+++ b/src/Views/About.axaml
@@ -71,10 +71,10 @@
         </StackPanel>
 
         <TextBlock x:Name="TxtReleaseDate" Margin="0,28,0,0" Foreground="{DynamicResource Brush.FG2}"/>
-        
+
         <StackPanel x:Name="PnlGitSourceRevision" Orientation="Horizontal" Margin="0,2,0,0" IsVisible="False">
-          <TextBlock Foreground="{DynamicResource Brush.FG2}" Text="{DynamicResource Text.About.GitSourceRevision}"/>
-          <SelectableTextBlock x:Name="TxtGitSourceRevision" Margin="4,0,0,0" Foreground="{DynamicResource Brush.FG2}"/>
+          <TextBlock VerticalAlignment="Center" Foreground="{DynamicResource Brush.FG2}" Text="{DynamicResource Text.About.GitSourceRevision}"/>
+          <SelectableTextBlock x:Name="TxtGitSourceRevision" Margin="4,0,0,0" VerticalAlignment="Center" Foreground="{DynamicResource Brush.FG2}"/>
         </StackPanel>
 
         <TextBlock x:Name="TxtCopyright" Margin="0,2,0,0" Foreground="{DynamicResource Brush.FG2}"/>


### PR DESCRIPTION
This PR aligns the source revision text in the About dialog by setting `VerticalAlignment="Center"`

## Before
<img width="450" src="https://github.com/user-attachments/assets/4c6c9050-b6cc-492b-ac05-ffb7ff96f79b" />

## After
<img width="450" src="https://github.com/user-attachments/assets/332c6f7f-4cb6-43f7-8ea1-fd11465c5c93" />
