### PR TITLE
fix: remove duplicate branch when overwriting existing branch

### DIFF
--- a/src/ViewModels/Repository.cs
+++ b/src/ViewModels/Repository.cs
@@ -777,6 +777,7 @@ namespace SourceGit.ViewModels
             _watcher?.MarkBranchUpdated();
             _watcher?.MarkWorkingCopyUpdated();
 
+            _branches.RemoveAll(b => b.IsLocal && b.FriendlyName.Equals(created.FriendlyName, StringComparison.Ordinal));
             _branches.Add(created);
 
             if (checkout)


### PR DESCRIPTION
When using OverwriteExisting to reset a local branch to upstream, the branch list showed two duplicate entries because the old branch object was not removed before adding the new one.

<img width="493" height="331" alt="image" src="https://github.com/user-attachments/assets/42f9e1f3-2763-4b38-972c-0fb9ef089749" />
