### PR TITLE
enhance: worktree and branch UI improvements, rename remote branch, remove tracking reference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ ehthumbs_vista.db
 
 bin/
 obj/
+publish/
 # ignore ci node files
 node_modules/
 package.json

--- a/src/Resources/Locales/de_DE.axaml
+++ b/src/Resources/Locales/de_DE.axaml
@@ -324,6 +324,7 @@ $1, $2, … Werte der Eingabe-Steuerelemente</x:String>
   <x:String x:Key="Text.DeleteBranch.Branch" xml:space="preserve">Branch:</x:String>
   <x:String x:Key="Text.DeleteBranch.IsRemoteTip" xml:space="preserve">Du bist dabei, einen Remote-Branch zu löschen!!!</x:String>
   <x:String x:Key="Text.DeleteBranch.WithTrackingRemote" xml:space="preserve">Auch Remote-Branch ${0}$ löschen</x:String>
+  <x:String x:Key="Text.DeleteBranch.WithWorktree" xml:space="preserve">Auch Worktree unter ${0}$ entfernen</x:String>
   <x:String x:Key="Text.DeleteMultiBranch" xml:space="preserve">Mehrere Branches löschen</x:String>
   <x:String x:Key="Text.DeleteMultiBranch.Tip" xml:space="preserve">Du versuchst, mehrere Branches auf einmal zu löschen. Kontrolliere dies sorgfältig, bevor du fortfährst!</x:String>
   <x:String x:Key="Text.DeleteMultiTags" xml:space="preserve">Mehrere Tags löschen</x:String>
@@ -719,6 +720,7 @@ $1, $2, … Werte der Eingabe-Steuerelemente</x:String>
   <x:String x:Key="Text.RenameBranch.Name" xml:space="preserve">Neuer Name:</x:String>
   <x:String x:Key="Text.RenameBranch.Name.Placeholder" xml:space="preserve">Eindeutiger Name für diesen Branch</x:String>
   <x:String x:Key="Text.RenameBranch.Target" xml:space="preserve">Branch:</x:String>
+  <x:String x:Key="Text.RenameBranch.WithTrackingRemote" xml:space="preserve">Auch Remote-Branch ${0}$ umbenennen</x:String>
   <x:String x:Key="Text.Repository.Abort" xml:space="preserve">ABBRECHEN</x:String>
   <x:String x:Key="Text.Repository.AutoFetching" xml:space="preserve">Änderungen automatisch von Remote fetchen…</x:String>
   <x:String x:Key="Text.Repository.BranchSort" xml:space="preserve">Sortieren</x:String>

--- a/src/Resources/Locales/en_US.axaml
+++ b/src/Resources/Locales/en_US.axaml
@@ -338,6 +338,7 @@
   <x:String x:Key="Text.DeleteBranch.Branch" xml:space="preserve">Branch:</x:String>
   <x:String x:Key="Text.DeleteBranch.IsRemoteTip" xml:space="preserve">You are about to delete a remote branch!!!</x:String>
   <x:String x:Key="Text.DeleteBranch.WithTrackingRemote" xml:space="preserve">Also delete remote branch ${0}$</x:String>
+  <x:String x:Key="Text.DeleteBranch.WithWorktree" xml:space="preserve">Also remove worktree at ${0}$</x:String>
   <x:String x:Key="Text.DeleteMultiBranch" xml:space="preserve">Delete Multiple Branches</x:String>
   <x:String x:Key="Text.DeleteMultiBranch.Tip" xml:space="preserve">You are trying to delete multiple branches at one time. Be sure to double-check before taking action!</x:String>
   <x:String x:Key="Text.DeleteMultiTags" xml:space="preserve">Delete Multiple Tags</x:String>
@@ -748,6 +749,7 @@
   <x:String x:Key="Text.RenameBranch.Name" xml:space="preserve">New Name:</x:String>
   <x:String x:Key="Text.RenameBranch.Name.Placeholder" xml:space="preserve">Unique name for this branch</x:String>
   <x:String x:Key="Text.RenameBranch.Target" xml:space="preserve">Branch:</x:String>
+  <x:String x:Key="Text.RenameBranch.WithTrackingRemote" xml:space="preserve">Also rename remote branch ${0}$</x:String>
   <x:String x:Key="Text.Repository.Abort" xml:space="preserve">ABORT</x:String>
   <x:String x:Key="Text.Repository.AutoFetching" xml:space="preserve">Auto fetching changes from remotes...</x:String>
   <x:String x:Key="Text.Repository.BranchSort" xml:space="preserve">Sort</x:String>

--- a/src/Resources/Locales/en_US.axaml
+++ b/src/Resources/Locales/en_US.axaml
@@ -82,6 +82,7 @@
   <x:String x:Key="Text.BranchCM.Push" xml:space="preserve">Push ${0}$</x:String>
   <x:String x:Key="Text.BranchCM.Rebase" xml:space="preserve">Rebase ${0}$ on ${1}$...</x:String>
   <x:String x:Key="Text.BranchCM.Rename" xml:space="preserve">Rename ${0}$...</x:String>
+  <x:String x:Key="Text.BranchCM.RemoveTracking" xml:space="preserve">Remove Tracking Reference</x:String>
   <x:String x:Key="Text.BranchCM.ResetToSelectedCommit" xml:space="preserve">Reset ${0}$ to ${1}$...</x:String>
   <x:String x:Key="Text.BranchCM.SwitchToWorktree" xml:space="preserve">Switch to ${0}$ (worktree)</x:String>
   <x:String x:Key="Text.BranchCM.Tracking" xml:space="preserve">Set Tracking Branch...</x:String>
@@ -750,6 +751,7 @@
   <x:String x:Key="Text.RenameBranch.Name.Placeholder" xml:space="preserve">Unique name for this branch</x:String>
   <x:String x:Key="Text.RenameBranch.Target" xml:space="preserve">Branch:</x:String>
   <x:String x:Key="Text.RenameBranch.WithTrackingRemote" xml:space="preserve">Also rename remote branch ${0}$</x:String>
+  <x:String x:Key="Text.RenameRemoteBranch" xml:space="preserve">Rename Remote Branch</x:String>
   <x:String x:Key="Text.Repository.Abort" xml:space="preserve">ABORT</x:String>
   <x:String x:Key="Text.Repository.AutoFetching" xml:space="preserve">Auto fetching changes from remotes...</x:String>
   <x:String x:Key="Text.Repository.BranchSort" xml:space="preserve">Sort</x:String>

--- a/src/Resources/Locales/en_US.axaml
+++ b/src/Resources/Locales/en_US.axaml
@@ -8,7 +8,7 @@
   <x:String x:Key="Text.AddToIgnore" xml:space="preserve">Add File(s) To Ignore</x:String>
   <x:String x:Key="Text.AddToIgnore.Pattern" xml:space="preserve">Pattern:</x:String>
   <x:String x:Key="Text.AddToIgnore.Storage" xml:space="preserve">Storage File:</x:String>
-  <x:String x:Key="Text.AddWorktree" xml:space="preserve">Add Worktree</x:String>
+  <x:String x:Key="Text.AddWorktree" xml:space="preserve">Worktree</x:String>
   <x:String x:Key="Text.AddWorktree.Location" xml:space="preserve">Location:</x:String>
   <x:String x:Key="Text.AddWorktree.Location.Placeholder" xml:space="preserve">Path for this worktree. Relative path is supported.</x:String>
   <x:String x:Key="Text.AddWorktree.Name" xml:space="preserve">Branch Name:</x:String>
@@ -205,8 +205,8 @@
   <x:String x:Key="Text.Compare.WithHead" xml:space="preserve">Compare with HEAD</x:String>
   <x:String x:Key="Text.Configure" xml:space="preserve">Repository Configure</x:String>
   <x:String x:Key="Text.Configure.CommitMessageTemplate" xml:space="preserve">COMMIT TEMPLATE</x:String>
-  <x:String x:Key="Text.Configure.CommitMessageTemplate.BuiltinVars" xml:space="preserve">Built-in parameters: 
-  
+  <x:String x:Key="Text.Configure.CommitMessageTemplate.BuiltinVars" xml:space="preserve">Built-in parameters:
+
   ${branch_name} Current local branch name.
   ${files_num} Number of changed files
   ${files} Paths of changed files
@@ -217,8 +217,8 @@
   <x:String x:Key="Text.Configure.CommitMessageTemplate.Name" xml:space="preserve">Template Name:</x:String>
   <x:String x:Key="Text.Configure.CustomAction" xml:space="preserve">CUSTOM ACTION</x:String>
   <x:String x:Key="Text.Configure.CustomAction.Arguments" xml:space="preserve">Arguments:</x:String>
-  <x:String x:Key="Text.Configure.CustomAction.Arguments.Tip" xml:space="preserve">Built-in parameters: 
-  
+  <x:String x:Key="Text.Configure.CustomAction.Arguments.Tip" xml:space="preserve">Built-in parameters:
+
   ${REPO} Repository's path
   ${REMOTE} Selected remote or selected branch's remote
   ${BRANCH} Selected branch, without ${REMOTE} part for remote branches
@@ -306,7 +306,7 @@
   <x:String x:Key="Text.CopyAllText" xml:space="preserve">Copy All Text</x:String>
   <x:String x:Key="Text.CopyFullPath" xml:space="preserve">Copy Full Path</x:String>
   <x:String x:Key="Text.CopyPath" xml:space="preserve">Copy Path</x:String>
-  <x:String x:Key="Text.CreateBranch" xml:space="preserve">Create Branch...</x:String>
+  <x:String x:Key="Text.CreateBranch" xml:space="preserve">Branch...</x:String>
   <x:String x:Key="Text.CreateBranch.BasedOn" xml:space="preserve">Based On:</x:String>
   <x:String x:Key="Text.CreateBranch.Checkout" xml:space="preserve">Check out the created branch</x:String>
   <x:String x:Key="Text.CreateBranch.LocalChanges" xml:space="preserve">Local Changes:</x:String>
@@ -780,7 +780,7 @@
   <x:String x:Key="Text.Repository.LocalBranches" xml:space="preserve">LOCAL BRANCHES</x:String>
   <x:String x:Key="Text.Repository.MoreOptions" xml:space="preserve">More options...</x:String>
   <x:String x:Key="Text.Repository.NavigateToCurrentHead" xml:space="preserve">Navigate to HEAD</x:String>
-  <x:String x:Key="Text.Repository.NewBranch" xml:space="preserve">Create Branch</x:String>
+  <x:String x:Key="Text.Repository.NewBranch" xml:space="preserve">Branch</x:String>
   <x:String x:Key="Text.Repository.Notifications.Clear" xml:space="preserve">CLEAR NOTIFICATIONS</x:String>
   <x:String x:Key="Text.Repository.OnlyHighlightCurrentBranchInGraph" xml:space="preserve">Only highlight current branch</x:String>
   <x:String x:Key="Text.Repository.OpenAsFolder" xml:space="preserve">Open as Folder</x:String>
@@ -818,7 +818,7 @@
   <x:String x:Key="Text.Repository.ViewLogs" xml:space="preserve">View Logs</x:String>
   <x:String x:Key="Text.Repository.Visit" xml:space="preserve">Visit '{0}' in Browser</x:String>
   <x:String x:Key="Text.Repository.Worktrees" xml:space="preserve">WORKTREES</x:String>
-  <x:String x:Key="Text.Repository.Worktrees.Add" xml:space="preserve">Add Worktree</x:String>
+  <x:String x:Key="Text.Repository.Worktrees.Add" xml:space="preserve">Worktree</x:String>
   <x:String x:Key="Text.Repository.Worktrees.Prune" xml:space="preserve">Prune</x:String>
   <x:String x:Key="Text.RepositoryURL" xml:space="preserve">Git Repository URL</x:String>
   <x:String x:Key="Text.Reset" xml:space="preserve">Reset Current Branch To Revision</x:String>

--- a/src/Resources/Locales/es_ES.axaml
+++ b/src/Resources/Locales/es_ES.axaml
@@ -341,6 +341,7 @@
   <x:String x:Key="Text.DeleteBranch.Branch" xml:space="preserve">Rama:</x:String>
   <x:String x:Key="Text.DeleteBranch.IsRemoteTip" xml:space="preserve">¡Estás a punto de eliminar una rama remota!</x:String>
   <x:String x:Key="Text.DeleteBranch.WithTrackingRemote" xml:space="preserve">También eliminar la rama remota ${0}$</x:String>
+  <x:String x:Key="Text.DeleteBranch.WithWorktree" xml:space="preserve">También eliminar el worktree en ${0}$</x:String>
   <x:String x:Key="Text.DeleteMultiBranch" xml:space="preserve">Eliminar Múltiples Ramas</x:String>
   <x:String x:Key="Text.DeleteMultiBranch.Tip" xml:space="preserve">Estás intentando eliminar múltiples ramas a la vez. ¡Asegúrate de comprobar dos veces antes de realizar esta acción!</x:String>
   <x:String x:Key="Text.DeleteMultiTags" xml:space="preserve">Eliminar Múltiples Etiquetas</x:String>
@@ -750,6 +751,7 @@
   <x:String x:Key="Text.RenameBranch.Name" xml:space="preserve">Nuevo Nombre:</x:String>
   <x:String x:Key="Text.RenameBranch.Name.Placeholder" xml:space="preserve">Nombre único para esta rama</x:String>
   <x:String x:Key="Text.RenameBranch.Target" xml:space="preserve">Rama:</x:String>
+  <x:String x:Key="Text.RenameBranch.WithTrackingRemote" xml:space="preserve">Renombrar también la rama remota ${0}$</x:String>
   <x:String x:Key="Text.Repository.Abort" xml:space="preserve">ABORTAR</x:String>
   <x:String x:Key="Text.Repository.AutoFetching" xml:space="preserve">Auto fetching cambios desde remotos...</x:String>
   <x:String x:Key="Text.Repository.BranchSort" xml:space="preserve">Ordenar</x:String>

--- a/src/Resources/Locales/fr_FR.axaml
+++ b/src/Resources/Locales/fr_FR.axaml
@@ -311,6 +311,7 @@
   <x:String x:Key="Text.DeleteBranch.Branch" xml:space="preserve">Branche :</x:String>
   <x:String x:Key="Text.DeleteBranch.IsRemoteTip" xml:space="preserve">Vous êtes sur le point de supprimer une branche distante !!!</x:String>
   <x:String x:Key="Text.DeleteBranch.WithTrackingRemote" xml:space="preserve">Supprimer également la branche distante ${0}$</x:String>
+  <x:String x:Key="Text.DeleteBranch.WithWorktree" xml:space="preserve">Supprimer également le worktree à ${0}$</x:String>
   <x:String x:Key="Text.DeleteMultiBranch" xml:space="preserve">Supprimer plusieurs branches</x:String>
   <x:String x:Key="Text.DeleteMultiBranch.Tip" xml:space="preserve">Vous essayez de supprimer plusieurs branches à la fois. Assurez-vous de revérifier avant de procéder !</x:String>
   <x:String x:Key="Text.DeleteMultiTags" xml:space="preserve">Supprimer plusieurs tags</x:String>
@@ -672,6 +673,7 @@
   <x:String x:Key="Text.RenameBranch.Name" xml:space="preserve">Nouveau nom :</x:String>
   <x:String x:Key="Text.RenameBranch.Name.Placeholder" xml:space="preserve">Nom unique pour cette branche</x:String>
   <x:String x:Key="Text.RenameBranch.Target" xml:space="preserve">Branche :</x:String>
+  <x:String x:Key="Text.RenameBranch.WithTrackingRemote" xml:space="preserve">Renommer également la branche distante ${0}$</x:String>
   <x:String x:Key="Text.Repository.Abort" xml:space="preserve">ABORT</x:String>
   <x:String x:Key="Text.Repository.AutoFetching" xml:space="preserve">Fetch automatique des changements depuis les dépôts...</x:String>
   <x:String x:Key="Text.Repository.BranchSort" xml:space="preserve">Trier</x:String>

--- a/src/Resources/Locales/id_ID.axaml
+++ b/src/Resources/Locales/id_ID.axaml
@@ -295,6 +295,7 @@
   <x:String x:Key="Text.DeleteBranch.Branch" xml:space="preserve">Branch:</x:String>
   <x:String x:Key="Text.DeleteBranch.IsRemoteTip" xml:space="preserve">Anda akan menghapus remote branch!!!</x:String>
   <x:String x:Key="Text.DeleteBranch.WithTrackingRemote" xml:space="preserve">Juga hapus remote branch ${0}$</x:String>
+  <x:String x:Key="Text.DeleteBranch.WithWorktree" xml:space="preserve">Juga hapus worktree di ${0}$</x:String>
   <x:String x:Key="Text.DeleteMultiBranch" xml:space="preserve">Hapus Beberapa Branch</x:String>
   <x:String x:Key="Text.DeleteMultiBranch.Tip" xml:space="preserve">Anda akan menghapus beberapa branch sekaligus. Pastikan untuk memeriksa ulang sebelum bertindak!</x:String>
   <x:String x:Key="Text.DeleteMultiTags" xml:space="preserve">Hapus Beberapa Tag</x:String>
@@ -644,6 +645,7 @@
   <x:String x:Key="Text.RenameBranch.Name" xml:space="preserve">Nama Baru:</x:String>
   <x:String x:Key="Text.RenameBranch.Name.Placeholder" xml:space="preserve">Nama unik untuk branch ini</x:String>
   <x:String x:Key="Text.RenameBranch.Target" xml:space="preserve">Branch:</x:String>
+  <x:String x:Key="Text.RenameBranch.WithTrackingRemote" xml:space="preserve">Juga ganti nama remote branch ${0}$</x:String>
   <x:String x:Key="Text.Repository.Abort" xml:space="preserve">BATALKAN</x:String>
   <x:String x:Key="Text.Repository.AutoFetching" xml:space="preserve">Auto fetch perubahan dari remote...</x:String>
   <x:String x:Key="Text.Repository.BranchSort" xml:space="preserve">Urut</x:String>

--- a/src/Resources/Locales/it_IT.axaml
+++ b/src/Resources/Locales/it_IT.axaml
@@ -323,6 +323,7 @@ ${pure_files:N} Come ${files:N}, ma senza cartelle</x:String>
   <x:String x:Key="Text.DeleteBranch.Branch" xml:space="preserve">Branch:</x:String>
   <x:String x:Key="Text.DeleteBranch.IsRemoteTip" xml:space="preserve">Stai per eliminare un branch remoto!!!</x:String>
   <x:String x:Key="Text.DeleteBranch.WithTrackingRemote" xml:space="preserve">Elimina anche il branch remoto ${0}$</x:String>
+  <x:String x:Key="Text.DeleteBranch.WithWorktree" xml:space="preserve">Rimuovi anche il worktree a ${0}$</x:String>
   <x:String x:Key="Text.DeleteMultiBranch" xml:space="preserve">Elimina Branch Multipli</x:String>
   <x:String x:Key="Text.DeleteMultiBranch.Tip" xml:space="preserve">Stai per eliminare più branch contemporaneamente. Controlla attentamente prima di procedere!</x:String>
   <x:String x:Key="Text.DeleteMultiTags" xml:space="preserve">Elimina Tag Multipli</x:String>
@@ -715,6 +716,7 @@ ${pure_files:N} Come ${files:N}, ma senza cartelle</x:String>
   <x:String x:Key="Text.RenameBranch.Name" xml:space="preserve">Nuovo Nome:</x:String>
   <x:String x:Key="Text.RenameBranch.Name.Placeholder" xml:space="preserve">Nome univoco per questo branch</x:String>
   <x:String x:Key="Text.RenameBranch.Target" xml:space="preserve">Branch:</x:String>
+  <x:String x:Key="Text.RenameBranch.WithTrackingRemote" xml:space="preserve">Rinomina anche il branch remoto ${0}$</x:String>
   <x:String x:Key="Text.Repository.Abort" xml:space="preserve">ANNULLA</x:String>
   <x:String x:Key="Text.Repository.AutoFetching" xml:space="preserve">Recupero automatico delle modifiche dai remoti...</x:String>
   <x:String x:Key="Text.Repository.BranchSort" xml:space="preserve">Ordina</x:String>

--- a/src/Resources/Locales/ja_JP.axaml
+++ b/src/Resources/Locales/ja_JP.axaml
@@ -324,6 +324,7 @@
   <x:String x:Key="Text.DeleteBranch.Branch" xml:space="preserve">ブランチ:</x:String>
   <x:String x:Key="Text.DeleteBranch.IsRemoteTip" xml:space="preserve">リモートブランチを削除しようとしています！！！</x:String>
   <x:String x:Key="Text.DeleteBranch.WithTrackingRemote" xml:space="preserve">リモートブランチの ${0}$ も削除</x:String>
+  <x:String x:Key="Text.DeleteBranch.WithWorktree" xml:space="preserve">ワークツリー ${0}$ も削除</x:String>
   <x:String x:Key="Text.DeleteMultiBranch" xml:space="preserve">複数のブランチを削除</x:String>
   <x:String x:Key="Text.DeleteMultiBranch.Tip" xml:space="preserve">複数のブランチをまとめて削除しようとしています。操作を行う前によく確認してください！</x:String>
   <x:String x:Key="Text.DeleteMultiTags" xml:space="preserve">複数のタグを削除</x:String>
@@ -721,6 +722,7 @@
   <x:String x:Key="Text.RenameBranch.Name" xml:space="preserve">新しい名前:</x:String>
   <x:String x:Key="Text.RenameBranch.Name.Placeholder" xml:space="preserve">このブランチに付ける一意な名前</x:String>
   <x:String x:Key="Text.RenameBranch.Target" xml:space="preserve">ブランチ:</x:String>
+  <x:String x:Key="Text.RenameBranch.WithTrackingRemote" xml:space="preserve">リモートブランチ ${0}$ もリネーム</x:String>
   <x:String x:Key="Text.Repository.Abort" xml:space="preserve">中止</x:String>
   <x:String x:Key="Text.Repository.AutoFetching" xml:space="preserve">リモートから変更を自動取得しています...</x:String>
   <x:String x:Key="Text.Repository.BranchSort" xml:space="preserve">並べ替え</x:String>

--- a/src/Resources/Locales/ko_KR.axaml
+++ b/src/Resources/Locales/ko_KR.axaml
@@ -294,6 +294,7 @@
   <x:String x:Key="Text.DeleteBranch.Branch" xml:space="preserve">브랜치:</x:String>
   <x:String x:Key="Text.DeleteBranch.IsRemoteTip" xml:space="preserve">원격 브랜치를 삭제하려고 합니다!!!</x:String>
   <x:String x:Key="Text.DeleteBranch.WithTrackingRemote" xml:space="preserve">원격 브랜치 ${0}$도 함께 삭제</x:String>
+  <x:String x:Key="Text.DeleteBranch.WithWorktree" xml:space="preserve">워크트리 ${0}$도 함께 제거</x:String>
   <x:String x:Key="Text.DeleteMultiBranch" xml:space="preserve">여러 브랜치 삭제</x:String>
   <x:String x:Key="Text.DeleteMultiBranch.Tip" xml:space="preserve">한 번에 여러 브랜치를 삭제하려고 합니다. 실행하기 전에 다시 한번 확인하세요!</x:String>
   <x:String x:Key="Text.DeleteMultiTags" xml:space="preserve">여러 태그 삭제</x:String>
@@ -645,6 +646,7 @@
   <x:String x:Key="Text.RenameBranch.Name" xml:space="preserve">새 이름:</x:String>
   <x:String x:Key="Text.RenameBranch.Name.Placeholder" xml:space="preserve">이 브랜치의 고유한 이름</x:String>
   <x:String x:Key="Text.RenameBranch.Target" xml:space="preserve">브랜치:</x:String>
+  <x:String x:Key="Text.RenameBranch.WithTrackingRemote" xml:space="preserve">원격 브랜치 ${0}$도 함께 이름 변경</x:String>
   <x:String x:Key="Text.Repository.Abort" xml:space="preserve">중단</x:String>
   <x:String x:Key="Text.Repository.AutoFetching" xml:space="preserve">원격에서 변경 사항 자동 Fetch 중...</x:String>
   <x:String x:Key="Text.Repository.BranchSort" xml:space="preserve">정렬</x:String>

--- a/src/Resources/Locales/pt_BR.axaml
+++ b/src/Resources/Locales/pt_BR.axaml
@@ -223,6 +223,7 @@
   <x:String x:Key="Text.DeleteBranch.Branch" xml:space="preserve">Branch:</x:String>
   <x:String x:Key="Text.DeleteBranch.IsRemoteTip" xml:space="preserve">Você está prestes a excluir uma branch remota!!!</x:String>
   <x:String x:Key="Text.DeleteBranch.WithTrackingRemote" xml:space="preserve">Também excluir branch remoto ${0}$</x:String>
+  <x:String x:Key="Text.DeleteBranch.WithWorktree" xml:space="preserve">Também remover worktree em ${0}$</x:String>
   <x:String x:Key="Text.DeleteMultiBranch" xml:space="preserve">Excluir Múltiplos Branches</x:String>
   <x:String x:Key="Text.DeleteMultiBranch.Tip" xml:space="preserve">Você está tentando excluir vários branches de uma vez. Certifique-se de verificar antes de agir!</x:String>
   <x:String x:Key="Text.DeleteRemote" xml:space="preserve">Excluir Remoto</x:String>
@@ -511,6 +512,7 @@
   <x:String x:Key="Text.RenameBranch.Name" xml:space="preserve">Novo Nome:</x:String>
   <x:String x:Key="Text.RenameBranch.Name.Placeholder" xml:space="preserve">Nome único para este branch</x:String>
   <x:String x:Key="Text.RenameBranch.Target" xml:space="preserve">Branch:</x:String>
+  <x:String x:Key="Text.RenameBranch.WithTrackingRemote" xml:space="preserve">Também renomear o branch remoto ${0}$</x:String>
   <x:String x:Key="Text.Repository.Abort" xml:space="preserve">ABORTAR</x:String>
   <x:String x:Key="Text.Repository.AutoFetching" xml:space="preserve">Buscando automaticamente mudanças dos remotos...</x:String>
   <x:String x:Key="Text.Repository.Clean" xml:space="preserve">Limpar (GC &amp; Podar)</x:String>

--- a/src/Resources/Locales/ru_RU.axaml
+++ b/src/Resources/Locales/ru_RU.axaml
@@ -341,6 +341,7 @@
   <x:String x:Key="Text.DeleteBranch.Branch" xml:space="preserve">Ветка:</x:String>
   <x:String x:Key="Text.DeleteBranch.IsRemoteTip" xml:space="preserve">Вы собираетесь удалить внешнюю ветку!!!</x:String>
   <x:String x:Key="Text.DeleteBranch.WithTrackingRemote" xml:space="preserve">Также удалите внешнюю ветку ${0}$</x:String>
+  <x:String x:Key="Text.DeleteBranch.WithWorktree" xml:space="preserve">Также удалить рабочую директорию ${0}$</x:String>
   <x:String x:Key="Text.DeleteMultiBranch" xml:space="preserve">Удаление нескольких веток</x:String>
   <x:String x:Key="Text.DeleteMultiBranch.Tip" xml:space="preserve">Вы пытаетесь удалить несколько веток одновременно. Обязательно перепроверьте, прежде чем предпринимать какие-либо действия!</x:String>
   <x:String x:Key="Text.DeleteMultiTags" xml:space="preserve">Удалить несколько меток</x:String>
@@ -751,6 +752,7 @@
   <x:String x:Key="Text.RenameBranch.Name" xml:space="preserve">Новое имя:</x:String>
   <x:String x:Key="Text.RenameBranch.Name.Placeholder" xml:space="preserve">Уникальное имя для данной ветки</x:String>
   <x:String x:Key="Text.RenameBranch.Target" xml:space="preserve">Ветка:</x:String>
+  <x:String x:Key="Text.RenameBranch.WithTrackingRemote" xml:space="preserve">Также переименовать удаленную ветку ${0}$</x:String>
   <x:String x:Key="Text.Repository.Abort" xml:space="preserve">Отказ</x:String>
   <x:String x:Key="Text.Repository.AutoFetching" xml:space="preserve">Автоматическое извлечение изменений с внешних репозиторий...</x:String>
   <x:String x:Key="Text.Repository.BranchSort" xml:space="preserve">Сортировать</x:String>

--- a/src/Resources/Locales/ta_IN.axaml
+++ b/src/Resources/Locales/ta_IN.axaml
@@ -203,6 +203,7 @@
   <x:String x:Key="Text.DeleteBranch.Branch" xml:space="preserve">கிளை:</x:String>
   <x:String x:Key="Text.DeleteBranch.IsRemoteTip" xml:space="preserve">நீங்கள் ஒரு தொலை கிளையை நீக்கப் போகிறீர்கள்!!!</x:String>
   <x:String x:Key="Text.DeleteBranch.WithTrackingRemote" xml:space="preserve">தொலை ${0}$ கிளையையும் நீக்கு</x:String>
+  <x:String x:Key="Text.DeleteBranch.WithWorktree" xml:space="preserve">${0}$ வேலை மரத்தையும் அகற்று</x:String>
   <x:String x:Key="Text.DeleteMultiBranch" xml:space="preserve">பல கிளைகளை நீக்கு</x:String>
   <x:String x:Key="Text.DeleteMultiBranch.Tip" xml:space="preserve">நீங்கள் ஒரே நேரத்தில் பல கிளைகளை நீக்க முயற்சிக்கிறீர்கள் நடவடிக்கை எடுப்பதற்கு முன் மீண்டும் சரிபார்!</x:String>
   <x:String x:Key="Text.DeleteRemote" xml:space="preserve">தொலையை நீக்கு</x:String>
@@ -513,6 +514,7 @@
   <x:String x:Key="Text.RenameBranch.Name" xml:space="preserve">புதிய பெயர்:</x:String>
   <x:String x:Key="Text.RenameBranch.Name.Placeholder" xml:space="preserve">இந்தக் கிளைக்கான தனித்துவமான பெயர்</x:String>
   <x:String x:Key="Text.RenameBranch.Target" xml:space="preserve">கிளை:</x:String>
+  <x:String x:Key="Text.RenameBranch.WithTrackingRemote" xml:space="preserve">தொலை ${0}$ கிளையின் பெயரையும் மாற்று</x:String>
   <x:String x:Key="Text.Repository.Abort" xml:space="preserve">நிறுத்து</x:String>
   <x:String x:Key="Text.Repository.AutoFetching" xml:space="preserve">தொலைகளிலிருந்து மாற்றங்களைத் தானாகப் பெறுதல்...</x:String>
   <x:String x:Key="Text.Repository.Clean" xml:space="preserve">சுத்தப்படுத்தல்(சீசி &amp; கத்தரித்தல்)</x:String>

--- a/src/Resources/Locales/uk_UA.axaml
+++ b/src/Resources/Locales/uk_UA.axaml
@@ -207,6 +207,7 @@
   <x:String x:Key="Text.DeleteBranch.Branch" xml:space="preserve">Гілка:</x:String>
   <x:String x:Key="Text.DeleteBranch.IsRemoteTip" xml:space="preserve">Ви збираєтеся видалити віддалену гілку!!!</x:String>
   <x:String x:Key="Text.DeleteBranch.WithTrackingRemote" xml:space="preserve">Також видалити віддалену гілку ${0}$</x:String>
+  <x:String x:Key="Text.DeleteBranch.WithWorktree" xml:space="preserve">Також видалити робочу директорію ${0}$</x:String>
   <x:String x:Key="Text.DeleteMultiBranch" xml:space="preserve">Видалити кілька гілок</x:String>
   <x:String x:Key="Text.DeleteMultiBranch.Tip" xml:space="preserve">Ви намагаєтеся видалити кілька гілок одночасно. Перевірте ще раз перед виконанням!</x:String>
   <x:String x:Key="Text.DeleteRemote" xml:space="preserve">Видалити віддалене сховище</x:String>
@@ -517,6 +518,7 @@
   <x:String x:Key="Text.RenameBranch.Name" xml:space="preserve">Нова назва:</x:String>
   <x:String x:Key="Text.RenameBranch.Name.Placeholder" xml:space="preserve">Унікальна назва для цієї гілки</x:String>
   <x:String x:Key="Text.RenameBranch.Target" xml:space="preserve">Гілка:</x:String>
+  <x:String x:Key="Text.RenameBranch.WithTrackingRemote" xml:space="preserve">Також перейменувати віддалену гілку ${0}$</x:String>
   <x:String x:Key="Text.Repository.Abort" xml:space="preserve">ПЕРЕРВАТИ</x:String>
   <x:String x:Key="Text.Repository.AutoFetching" xml:space="preserve">Автоматичне отримання змін з віддалених сховищ...</x:String>
   <x:String x:Key="Text.Repository.Clean" xml:space="preserve">Очистка (GC &amp; Prune)</x:String>

--- a/src/Resources/Locales/zh_CN.axaml
+++ b/src/Resources/Locales/zh_CN.axaml
@@ -342,6 +342,7 @@
   <x:String x:Key="Text.DeleteBranch.Branch" xml:space="preserve">分支名 ：</x:String>
   <x:String x:Key="Text.DeleteBranch.IsRemoteTip" xml:space="preserve">您正在删除远程上的分支，请务必小心！！！</x:String>
   <x:String x:Key="Text.DeleteBranch.WithTrackingRemote" xml:space="preserve">同时删除远程分支 ${0}$</x:String>
+  <x:String x:Key="Text.DeleteBranch.WithWorktree" xml:space="preserve">同时删除工作树 ${0}$</x:String>
   <x:String x:Key="Text.DeleteMultiBranch" xml:space="preserve">删除多个分支</x:String>
   <x:String x:Key="Text.DeleteMultiBranch.Tip" xml:space="preserve">您正在尝试一次性删除多个分支，请务必仔细检查后再执行操作！</x:String>
   <x:String x:Key="Text.DeleteMultiTags" xml:space="preserve">删除多个标签</x:String>
@@ -752,6 +753,7 @@
   <x:String x:Key="Text.RenameBranch.Name" xml:space="preserve">新的名称 ：</x:String>
   <x:String x:Key="Text.RenameBranch.Name.Placeholder" xml:space="preserve">新的分支名不能与现有分支名相同</x:String>
   <x:String x:Key="Text.RenameBranch.Target" xml:space="preserve">分支 ：</x:String>
+  <x:String x:Key="Text.RenameBranch.WithTrackingRemote" xml:space="preserve">同时重命名远程分支 ${0}$</x:String>
   <x:String x:Key="Text.Repository.Abort" xml:space="preserve">终止合并</x:String>
   <x:String x:Key="Text.Repository.AutoFetching" xml:space="preserve">自动拉取远端变更中...</x:String>
   <x:String x:Key="Text.Repository.BranchSort" xml:space="preserve">排序方式</x:String>

--- a/src/Resources/Locales/zh_TW.axaml
+++ b/src/Resources/Locales/zh_TW.axaml
@@ -342,6 +342,7 @@
   <x:String x:Key="Text.DeleteBranch.Branch" xml:space="preserve">分支名稱:</x:String>
   <x:String x:Key="Text.DeleteBranch.IsRemoteTip" xml:space="preserve">您正在刪除遠端上的分支，請務必小心!</x:String>
   <x:String x:Key="Text.DeleteBranch.WithTrackingRemote" xml:space="preserve">同時刪除遠端分支 ${0}$</x:String>
+  <x:String x:Key="Text.DeleteBranch.WithWorktree" xml:space="preserve">同時刪除工作樹 ${0}$</x:String>
   <x:String x:Key="Text.DeleteMultiBranch" xml:space="preserve">刪除多個分支</x:String>
   <x:String x:Key="Text.DeleteMultiBranch.Tip" xml:space="preserve">您正在嘗試一次性刪除多個分支，請務必仔細檢查後再刪除!</x:String>
   <x:String x:Key="Text.DeleteMultiTags" xml:space="preserve">刪除多個標籤</x:String>
@@ -752,6 +753,7 @@
   <x:String x:Key="Text.RenameBranch.Name" xml:space="preserve">新名稱:</x:String>
   <x:String x:Key="Text.RenameBranch.Name.Placeholder" xml:space="preserve">新的分支名稱不能與現有分支名稱相同</x:String>
   <x:String x:Key="Text.RenameBranch.Target" xml:space="preserve">分支:</x:String>
+  <x:String x:Key="Text.RenameBranch.WithTrackingRemote" xml:space="preserve">同時重新命名遠端分支 ${0}$</x:String>
   <x:String x:Key="Text.Repository.Abort" xml:space="preserve">中止</x:String>
   <x:String x:Key="Text.Repository.AutoFetching" xml:space="preserve">自動提取遠端變更中...</x:String>
   <x:String x:Key="Text.Repository.BranchSort" xml:space="preserve">排序</x:String>

--- a/src/ViewModels/DeleteBranch.cs
+++ b/src/ViewModels/DeleteBranch.cs
@@ -100,8 +100,20 @@ namespace SourceGit.ViewModels
             }
             else
             {
+                var oldUpstream = Target.FullName;
                 await DeleteRemoteBranchAsync(Target, log);
                 _repo.UIStates.RemoveHistoryFilter(Target.FullName, Models.FilterType.RemoteBranch);
+
+                // Unset tracking on any local branches that were tracking this remote branch
+                foreach (var local in _repo.Branches)
+                {
+                    if (local.IsLocal && local.Upstream == oldUpstream)
+                    {
+                        await new Commands.Branch(_repo.FullPath, local.Name)
+                            .Use(log)
+                            .SetUpstreamAsync(null);
+                    }
+                }
             }
 
             log.Complete();

--- a/src/ViewModels/DeleteBranch.cs
+++ b/src/ViewModels/DeleteBranch.cs
@@ -75,6 +75,18 @@ namespace SourceGit.ViewModels
             {
                 var worktreePath = Target.WorktreePath;
 
+                // Remove the worktree first, since git refuses to delete a branch
+                // that is checked out in another worktree.
+                if (_alsoRemoveWorktree && !string.IsNullOrEmpty(worktreePath))
+                {
+                    await new Commands.Worktree(_repo.FullPath)
+                        .Use(log)
+                        .RemoveAsync(worktreePath, true);
+                    await new Commands.Worktree(_repo.FullPath)
+                        .Use(log)
+                        .PruneAsync();
+                }
+
                 await new Commands.Branch(_repo.FullPath, Target.Name)
                     .Use(log)
                     .DeleteLocalAsync();
@@ -84,16 +96,6 @@ namespace SourceGit.ViewModels
                 {
                     await DeleteRemoteBranchAsync(TrackingRemoteBranch, log);
                     _repo.UIStates.RemoveHistoryFilter(TrackingRemoteBranch.FullName, Models.FilterType.RemoteBranch);
-                }
-
-                if (_alsoRemoveWorktree && !string.IsNullOrEmpty(worktreePath))
-                {
-                    await new Commands.Worktree(_repo.FullPath)
-                        .Use(log)
-                        .RemoveAsync(worktreePath, true);
-                    await new Commands.Worktree(_repo.FullPath)
-                        .Use(log)
-                        .PruneAsync();
                 }
             }
             else

--- a/src/ViewModels/DeleteBranch.cs
+++ b/src/ViewModels/DeleteBranch.cs
@@ -26,6 +26,24 @@ namespace SourceGit.ViewModels
             set => SetProperty(ref _alsoDeleteTrackingRemote, value);
         }
 
+        public string DeleteWorktreeTip
+        {
+            get;
+            private set;
+        }
+
+        public bool AlsoRemoveWorktree
+        {
+            get => _alsoRemoveWorktree;
+            set => SetProperty(ref _alsoRemoveWorktree, value);
+        }
+
+        public bool HasWorktree
+        {
+            get;
+            private set;
+        }
+
         public DeleteBranch(Repository repo, Models.Branch branch)
         {
             _repo = repo;
@@ -36,6 +54,12 @@ namespace SourceGit.ViewModels
                 TrackingRemoteBranch = repo.Branches.Find(x => x.FullName == branch.Upstream);
                 if (TrackingRemoteBranch != null)
                     DeleteTrackingRemoteTip = App.Text("DeleteBranch.WithTrackingRemote", TrackingRemoteBranch.FriendlyName);
+            }
+
+            if (branch.HasWorktree)
+            {
+                HasWorktree = true;
+                DeleteWorktreeTip = App.Text("DeleteBranch.WithWorktree", branch.WorktreePath);
             }
         }
 
@@ -49,6 +73,8 @@ namespace SourceGit.ViewModels
 
             if (Target.IsLocal)
             {
+                var worktreePath = Target.WorktreePath;
+
                 await new Commands.Branch(_repo.FullPath, Target.Name)
                     .Use(log)
                     .DeleteLocalAsync();
@@ -58,6 +84,16 @@ namespace SourceGit.ViewModels
                 {
                     await DeleteRemoteBranchAsync(TrackingRemoteBranch, log);
                     _repo.UIStates.RemoveHistoryFilter(TrackingRemoteBranch.FullName, Models.FilterType.RemoteBranch);
+                }
+
+                if (_alsoRemoveWorktree && !string.IsNullOrEmpty(worktreePath))
+                {
+                    await new Commands.Worktree(_repo.FullPath)
+                        .Use(log)
+                        .RemoveAsync(worktreePath, false);
+                    await new Commands.Worktree(_repo.FullPath)
+                        .Use(log)
+                        .PruneAsync();
                 }
             }
             else
@@ -91,5 +127,6 @@ namespace SourceGit.ViewModels
 
         private readonly Repository _repo = null;
         private bool _alsoDeleteTrackingRemote = false;
+        private bool _alsoRemoveWorktree = false;
     }
 }

--- a/src/ViewModels/DeleteBranch.cs
+++ b/src/ViewModels/DeleteBranch.cs
@@ -90,7 +90,7 @@ namespace SourceGit.ViewModels
                 {
                     await new Commands.Worktree(_repo.FullPath)
                         .Use(log)
-                        .RemoveAsync(worktreePath, false);
+                        .RemoveAsync(worktreePath, true);
                     await new Commands.Worktree(_repo.FullPath)
                         .Use(log)
                         .PruneAsync();

--- a/src/ViewModels/RenameBranch.cs
+++ b/src/ViewModels/RenameBranch.cs
@@ -28,6 +28,12 @@ namespace SourceGit.ViewModels
             set => SetProperty(ref _alsoRenameRemote, value);
         }
 
+        public bool CanRenameRemote
+        {
+            get;
+            private set;
+        }
+
         [Required(ErrorMessage = "Branch name is required!!!")]
         [RegularExpression(@"^[\w\-/\.#\+]+$", ErrorMessage = "Bad branch name format!")]
         [CustomValidation(typeof(RenameBranch), nameof(ValidateBranchName))]
@@ -47,7 +53,10 @@ namespace SourceGit.ViewModels
             {
                 TrackingRemoteBranch = repo.Branches.Find(x => x.FullName == target.Upstream);
                 if (TrackingRemoteBranch != null)
+                {
                     RenameRemoteTip = App.Text("RenameBranch.WithTrackingRemote", TrackingRemoteBranch.FriendlyName);
+                    CanRenameRemote = target.Head == TrackingRemoteBranch.Head;
+                }
             }
         }
 
@@ -89,13 +98,25 @@ namespace SourceGit.ViewModels
                 if (_alsoRenameRemote && TrackingRemoteBranch != null)
                 {
                     var remote = TrackingRemoteBranch.Remote;
-                    var pushNew = new Commands.Push(_repo.FullPath, remote, $"refs/heads/{_name}", false);
+                    var pushNew = new Commands.Push(_repo.FullPath, TrackingRemoteBranch.Head, remote, $"refs/heads/{_name}", false, false, false, false);
                     pushNew.Use(log);
                     await pushNew.RunAsync();
 
-                    var deleteOld = new Commands.Push(_repo.FullPath, remote, $"refs/heads/{oldName}", true);
+                    var deleteOld = new Commands.Push(_repo.FullPath, remote, $"refs/heads/{TrackingRemoteBranch.Name}", true);
                     deleteOld.Use(log);
                     await deleteOld.RunAsync();
+
+                    // Update local branch's tracking to the new remote branch
+                    var newUpstream = new Models.Branch
+                    {
+                        Name = _name,
+                        FullName = $"refs/remotes/{remote}/{_name}",
+                        Remote = remote,
+                        IsLocal = false,
+                    };
+                    await new Commands.Branch(_repo.FullPath, _name)
+                        .Use(log)
+                        .SetUpstreamAsync(newUpstream);
                 }
             }
 

--- a/src/ViewModels/RenameBranch.cs
+++ b/src/ViewModels/RenameBranch.cs
@@ -11,6 +11,23 @@ namespace SourceGit.ViewModels
             get;
         }
 
+        public Models.Branch TrackingRemoteBranch
+        {
+            get;
+        }
+
+        public string RenameRemoteTip
+        {
+            get;
+            private set;
+        }
+
+        public bool AlsoRenameRemote
+        {
+            get => _alsoRenameRemote;
+            set => SetProperty(ref _alsoRenameRemote, value);
+        }
+
         [Required(ErrorMessage = "Branch name is required!!!")]
         [RegularExpression(@"^[\w\-/\.#\+]+$", ErrorMessage = "Bad branch name format!")]
         [CustomValidation(typeof(RenameBranch), nameof(ValidateBranchName))]
@@ -25,6 +42,13 @@ namespace SourceGit.ViewModels
             _repo = repo;
             _name = target.Name;
             Target = target;
+
+            if (target.IsLocal && !string.IsNullOrEmpty(target.Upstream))
+            {
+                TrackingRemoteBranch = repo.Branches.Find(x => x.FullName == target.Upstream);
+                if (TrackingRemoteBranch != null)
+                    RenameRemoteTip = App.Text("RenameBranch.WithTrackingRemote", TrackingRemoteBranch.FriendlyName);
+            }
         }
 
         public static ValidationResult ValidateBranchName(string name, ValidationContext ctx)
@@ -52,15 +76,28 @@ namespace SourceGit.ViewModels
             var log = _repo.CreateLog($"Rename Branch '{Target.Name}'");
             Use(log);
 
-            var isCurrent = Target.IsCurrent;
-            var oldName = Target.FullName;
+            var oldName = Target.Name;
 
             var succ = await new Commands.Branch(_repo.FullPath, Target.Name)
                 .Use(log)
                 .RenameAsync(_name);
 
             if (succ)
+            {
                 _repo.RefreshAfterRenameBranch(Target, _name);
+
+                if (_alsoRenameRemote && TrackingRemoteBranch != null)
+                {
+                    var remote = TrackingRemoteBranch.Remote;
+                    var pushNew = new Commands.Push(_repo.FullPath, remote, $"refs/heads/{_name}", false);
+                    pushNew.Use(log);
+                    await pushNew.RunAsync();
+
+                    var deleteOld = new Commands.Push(_repo.FullPath, remote, $"refs/heads/{oldName}", true);
+                    deleteOld.Use(log);
+                    await deleteOld.RunAsync();
+                }
+            }
 
             log.Complete();
             return succ;
@@ -68,5 +105,6 @@ namespace SourceGit.ViewModels
 
         private readonly Repository _repo;
         private string _name;
+        private bool _alsoRenameRemote = false;
     }
 }

--- a/src/ViewModels/RenameRemoteBranch.cs
+++ b/src/ViewModels/RenameRemoteBranch.cs
@@ -1,0 +1,64 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.Threading.Tasks;
+
+namespace SourceGit.ViewModels
+{
+    public class RenameRemoteBranch : Popup
+    {
+        public Models.Branch Target
+        {
+            get;
+        }
+
+        [Required(ErrorMessage = "Branch name is required!!!")]
+        [RegularExpression(@"^[\w\-/\.#\+]+$", ErrorMessage = "Bad branch name format!")]
+        public string Name
+        {
+            get => _name;
+            set => SetProperty(ref _name, value, true);
+        }
+
+        public RenameRemoteBranch(Repository repo, Models.Branch target)
+        {
+            _repo = repo;
+            Target = target;
+            _name = target.Name;
+        }
+
+        public override async Task<bool> Sure()
+        {
+            if (Target.Name.Equals(_name, StringComparison.Ordinal))
+                return true;
+
+            using var lockWatcher = _repo.LockWatcher();
+            ProgressDescription = $"Rename remote branch '{Target.FriendlyName}'";
+
+            var log = _repo.CreateLog($"Rename Remote Branch '{Target.FriendlyName}'");
+            Use(log);
+
+            var remote = Target.Remote;
+            var succ = false;
+
+            // Push the current commit to the new branch name on the remote
+            var pushNew = new Commands.Push(_repo.FullPath, Target.Head, remote, $"refs/heads/{_name}", false, false, false, false);
+            pushNew.Use(log);
+            var pushOk = await pushNew.RunAsync();
+
+            if (pushOk)
+            {
+                // Delete the old remote branch
+                var deleteOld = new Commands.Push(_repo.FullPath, remote, $"refs/heads/{Target.Name}", true);
+                deleteOld.Use(log);
+                succ = await deleteOld.RunAsync();
+            }
+
+            log.Complete();
+            _repo.MarkBranchesDirtyManually();
+            return succ;
+        }
+
+        private readonly Repository _repo;
+        private string _name;
+    }
+}

--- a/src/ViewModels/RenameRemoteBranch.cs
+++ b/src/ViewModels/RenameRemoteBranch.cs
@@ -38,6 +38,8 @@ namespace SourceGit.ViewModels
             Use(log);
 
             var remote = Target.Remote;
+            var oldUpstream = Target.FullName;
+            var newUpstream = $"refs/remotes/{remote}/{_name}";
             var succ = false;
 
             // Push the current commit to the new branch name on the remote
@@ -51,6 +53,27 @@ namespace SourceGit.ViewModels
                 var deleteOld = new Commands.Push(_repo.FullPath, remote, $"refs/heads/{Target.Name}", true);
                 deleteOld.Use(log);
                 succ = await deleteOld.RunAsync();
+
+                // Update tracking of local branches that tracked the old remote branch
+                if (succ)
+                {
+                    foreach (var local in _repo.Branches)
+                    {
+                        if (local.IsLocal && local.Upstream == oldUpstream)
+                        {
+                            var trackingBranch = new Models.Branch
+                            {
+                                Name = _name,
+                                FullName = newUpstream,
+                                Remote = remote,
+                                IsLocal = false,
+                            };
+                            await new Commands.Branch(_repo.FullPath, local.Name)
+                                .Use(log)
+                                .SetUpstreamAsync(trackingBranch);
+                        }
+                    }
+                }
             }
 
             log.Complete();

--- a/src/ViewModels/Repository.cs
+++ b/src/ViewModels/Repository.cs
@@ -24,6 +24,8 @@ namespace SourceGit.ViewModels
             get;
         }
 
+        public string RepoName => System.IO.Path.GetFileName(FullPath);
+
         public string GitDir
         {
             get;

--- a/src/Views/BranchTree.axaml.cs
+++ b/src/Views/BranchTree.axaml.cs
@@ -992,6 +992,27 @@ namespace SourceGit.Views
                         e.Handled = true;
                     };
                     menu.Items.Add(tracking);
+
+                    if (!string.IsNullOrEmpty(branch.Upstream))
+                    {
+                        var removeTracking = new MenuItem();
+                        removeTracking.Header = App.Text("BranchCM.RemoveTracking");
+                        removeTracking.Icon = this.CreateMenuIcon("Icons.Clear");
+                        removeTracking.Click += async (_, e) =>
+                        {
+                            if (repo.CanCreatePopup())
+                            {
+                                var log = repo.CreateLog("Remove Tracking Reference");
+                                await new Commands.Branch(repo.FullPath, branch.Name)
+                                    .Use(log)
+                                    .SetUpstreamAsync(null);
+                                log.Complete();
+                                repo.MarkBranchesDirtyManually();
+                            }
+                            e.Handled = true;
+                        };
+                        menu.Items.Add(removeTracking);
+                    }
                 }
             }
 
@@ -1202,6 +1223,17 @@ namespace SourceGit.Views
             }
 
             menu.Items.Add(new MenuItem() { Header = "-" });
+
+            var rename = new MenuItem();
+            rename.Header = App.Text("BranchCM.Rename", name);
+            rename.Icon = this.CreateMenuIcon("Icons.Rename");
+            rename.Click += (_, e) =>
+            {
+                if (repo.CanCreatePopup())
+                    repo.ShowPopup(new ViewModels.RenameRemoteBranch(repo, branch));
+                e.Handled = true;
+            };
+            menu.Items.Add(rename);
 
             var editDescription = new MenuItem();
             editDescription.Header = App.Text("BranchCM.EditDescription", branch.Name);

--- a/src/Views/DeleteBranch.axaml
+++ b/src/Views/DeleteBranch.axaml
@@ -18,7 +18,7 @@
                  Text="{DynamicResource Text.DeleteBranch}"/>
     </StackPanel>
 
-    <Grid Margin="0,16,8,0" RowDefinitions="32,Auto" ColumnDefinitions="120,*">
+    <Grid Margin="0,16,8,0" RowDefinitions="32,Auto,Auto" ColumnDefinitions="120,*">
       <TextBlock Grid.Row="0" Grid.Column="0" HorizontalAlignment="Right" Text="{DynamicResource Text.DeleteBranch.Branch}"/>
       <StackPanel Grid.Row="0" Grid.Column="1" Orientation="Horizontal">
         <Path Width="14" Height="14" Margin="8,0" Data="{StaticResource Icons.Branch}"/>
@@ -48,6 +48,13 @@
       <Border Grid.Row="1" Grid.Column="1" Height="32" IsVisible="{Binding TrackingRemoteBranch, Converter={x:Static ObjectConverters.IsNotNull}}">
         <CheckBox Margin="6,0,0,0" IsChecked="{Binding AlsoDeleteTrackingRemote, Mode=TwoWay}">
           <v:NameHighlightedTextBlock Text="{Binding DeleteTrackingRemoteTip}" VerticalAlignment="Center" />
+        </CheckBox>
+      </Border>
+
+      <Border Grid.Row="2" Grid.Column="1" Height="32"
+              IsVisible="{Binding HasWorktree}">
+        <CheckBox Margin="6,0,0,0" IsChecked="{Binding AlsoRemoveWorktree, Mode=TwoWay}">
+          <v:NameHighlightedTextBlock Text="{Binding DeleteWorktreeTip}" VerticalAlignment="Center" />
         </CheckBox>
       </Border>
     </Grid>

--- a/src/Views/RenameBranch.axaml
+++ b/src/Views/RenameBranch.axaml
@@ -41,7 +41,7 @@
 
       <Border Grid.Row="2" Grid.Column="1" Height="32"
               IsVisible="{Binding TrackingRemoteBranch, Converter={x:Static ObjectConverters.IsNotNull}}">
-        <CheckBox Margin="6,0,0,0" IsChecked="{Binding AlsoRenameRemote, Mode=TwoWay}">
+        <CheckBox Margin="6,0,0,0" IsChecked="{Binding AlsoRenameRemote, Mode=TwoWay}" IsEnabled="{Binding CanRenameRemote}">
           <v:NameHighlightedTextBlock Text="{Binding RenameRemoteTip}" VerticalAlignment="Center" />
         </CheckBox>
       </Border>

--- a/src/Views/RenameBranch.axaml
+++ b/src/Views/RenameBranch.axaml
@@ -18,7 +18,7 @@
                  Text="{DynamicResource Text.RenameBranch}"/>
     </StackPanel>
     
-    <Grid Margin="0,16,0,0" RowDefinitions="32,32" ColumnDefinitions="120,*">
+    <Grid Margin="0,16,0,0" RowDefinitions="32,32,Auto" ColumnDefinitions="120,*">
       <TextBlock Grid.Row="0" Grid.Column="0"
                  HorizontalAlignment="Right" VerticalAlignment="Center"
                  Margin="0,0,8,0"
@@ -38,6 +38,13 @@
                                 CornerRadius="3"
                                 Text="{Binding Name, Mode=TwoWay}"
                                 Watermark="{DynamicResource Text.RenameBranch.Name.Placeholder}"/>
+
+      <Border Grid.Row="2" Grid.Column="1" Height="32"
+              IsVisible="{Binding TrackingRemoteBranch, Converter={x:Static ObjectConverters.IsNotNull}}">
+        <CheckBox Margin="6,0,0,0" IsChecked="{Binding AlsoRenameRemote, Mode=TwoWay}">
+          <v:NameHighlightedTextBlock Text="{Binding RenameRemoteTip}" VerticalAlignment="Center" />
+        </CheckBox>
+      </Border>
     </Grid>
   </StackPanel>
 </UserControl>

--- a/src/Views/RenameRemoteBranch.axaml
+++ b/src/Views/RenameRemoteBranch.axaml
@@ -1,0 +1,43 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="using:SourceGit.ViewModels"
+             xmlns:v="using:SourceGit.Views"
+             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+             x:Class="SourceGit.Views.RenameRemoteBranch"
+             x:DataType="vm:RenameRemoteBranch">
+  <StackPanel Orientation="Vertical" Margin="8,0">
+    <StackPanel Orientation="Horizontal">
+      <Path Width="16" Height="16"
+            Data="{StaticResource Icons.Rename}"/>
+
+      <TextBlock FontSize="18"
+                 Margin="8,0,0,0"
+                 Classes="bold"
+                 Text="{DynamicResource Text.RenameRemoteBranch}"/>
+    </StackPanel>
+
+    <Grid Margin="0,16,0,0" RowDefinitions="32,32" ColumnDefinitions="120,*">
+      <TextBlock Grid.Row="0" Grid.Column="0"
+                 HorizontalAlignment="Right" VerticalAlignment="Center"
+                 Margin="0,0,8,0"
+                 Text="{DynamicResource Text.RenameBranch.Target}"/>
+      <StackPanel Grid.Row="0" Grid.Column="1" Orientation="Horizontal">
+        <Path Width="14" Height="14" Data="{StaticResource Icons.Branch}"/>
+        <TextBlock Text="{Binding Target.FriendlyName}" Margin="8,0,0,0" />
+      </StackPanel>
+
+      <TextBlock Grid.Row="1" Grid.Column="0"
+                 HorizontalAlignment="Right" VerticalAlignment="Center"
+                 Margin="0,0,8,0"
+                 Text="{DynamicResource Text.RenameBranch.Name}"/>
+      <v:BranchOrTagNameTextBox Grid.Row="1" Grid.Column="1"
+                                Height="26"
+                                VerticalAlignment="Center"
+                                CornerRadius="3"
+                                Text="{Binding Name, Mode=TwoWay}"
+                                Watermark="{DynamicResource Text.RenameBranch.Name.Placeholder}"/>
+    </Grid>
+  </StackPanel>
+</UserControl>

--- a/src/Views/RenameRemoteBranch.axaml.cs
+++ b/src/Views/RenameRemoteBranch.axaml.cs
@@ -1,0 +1,12 @@
+using Avalonia.Controls;
+
+namespace SourceGit.Views
+{
+    public partial class RenameRemoteBranch : UserControl
+    {
+        public RenameRemoteBranch()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/src/Views/RepositoryToolbar.axaml
+++ b/src/Views/RepositoryToolbar.axaml
@@ -108,6 +108,12 @@
     </StackPanel>
 
     <StackPanel Grid.Column="3" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,0,4,0">
+      <TextBlock Text="{Binding RepoName}"
+                 FontWeight="Bold"
+                 Foreground="{DynamicResource Brush.FG2}"
+                 VerticalAlignment="Center"
+                 Margin="0,0,4,0" />
+
       <Path Width="13" Height="13" Fill="{DynamicResource Brush.FG1}" Data="{StaticResource Icons.Branch}"/>
 
       <ContentControl Margin="6,0,0,0">

--- a/src/Views/RepositoryToolbar.axaml
+++ b/src/Views/RepositoryToolbar.axaml
@@ -27,7 +27,7 @@
     </StackPanel>
 
     <StackPanel Grid.Column="1" Orientation="Horizontal">
-      <Button Classes="icon_button" Width="32" Tapped="Fetch">
+      <Button Classes="icon_button" Padding="4,2" Tapped="Fetch">
         <ToolTip.Tip>
           <StackPanel Orientation="Vertical">
             <TextBlock Text="{DynamicResource Text.Fetch}"/>
@@ -35,10 +35,13 @@
           </StackPanel>
         </ToolTip.Tip>
 
-        <Path Width="14" Height="14" Data="{StaticResource Icons.Fetch}"/>
+        <StackPanel Orientation="Vertical" Spacing="1">
+          <Path Width="14" Height="14" Data="{StaticResource Icons.Fetch}"/>
+          <TextBlock Text="{DynamicResource Text.Fetch}" FontSize="10" HorizontalAlignment="Center" Foreground="{DynamicResource Brush.FG1}"/>
+        </StackPanel>
       </Button>
 
-      <Button Classes="icon_button" Width="32" Margin="16,0,0,0" Tapped="Pull" IsVisible="{Binding !IsBare}" IsEnabled="{Binding !IsBare}">
+      <Button Classes="icon_button" Margin="12,0,0,0" Padding="4,2" Tapped="Pull" IsVisible="{Binding !IsBare}" IsEnabled="{Binding !IsBare}">
         <ToolTip.Tip>
           <StackPanel Orientation="Vertical">
             <TextBlock Text="{DynamicResource Text.Pull}"/>
@@ -46,10 +49,13 @@
           </StackPanel>
         </ToolTip.Tip>
 
-        <Path Width="14" Height="14" Data="{StaticResource Icons.Pull}"/>
+        <StackPanel Orientation="Vertical" Spacing="1">
+          <Path Width="14" Height="14" Data="{StaticResource Icons.Pull}"/>
+          <TextBlock Text="{DynamicResource Text.Pull}" FontSize="10" HorizontalAlignment="Center" Foreground="{DynamicResource Brush.FG1}"/>
+        </StackPanel>
       </Button>
 
-      <Button Classes="icon_button" Width="32" Margin="16,0,0,0" Tapped="Push">
+      <Button Classes="icon_button" Margin="12,0,0,0" Padding="4,2" Tapped="Push">
         <ToolTip.Tip>
           <StackPanel Orientation="Vertical">
             <TextBlock Text="{DynamicResource Text.Push}"/>
@@ -57,10 +63,13 @@
           </StackPanel>
         </ToolTip.Tip>
 
-        <Path Width="14" Height="14" Data="{StaticResource Icons.Push}"/>
+        <StackPanel Orientation="Vertical" Spacing="1">
+          <Path Width="14" Height="14" Data="{StaticResource Icons.Push}"/>
+          <TextBlock Text="{DynamicResource Text.Push}" FontSize="10" HorizontalAlignment="Center" Foreground="{DynamicResource Brush.FG1}"/>
+        </StackPanel>
       </Button>
 
-      <Button Classes="icon_button" Width="32" Margin="16,0,0,0" Tapped="StashAll" IsVisible="{Binding !IsBare}">
+      <Button Classes="icon_button" Margin="12,0,0,0" Padding="4,2" Tapped="StashAll" IsVisible="{Binding !IsBare}">
         <ToolTip.Tip>
           <StackPanel Orientation="Vertical">
             <TextBlock Text="{DynamicResource Text.Stash}"/>
@@ -68,11 +77,31 @@
           </StackPanel>
         </ToolTip.Tip>
 
-        <Path Width="14" Height="14" Data="{StaticResource Icons.Stashes.Add}"/>
+        <StackPanel Orientation="Vertical" Spacing="1">
+          <Path Width="14" Height="14" Data="{StaticResource Icons.Stashes.Add}"/>
+          <TextBlock Text="{DynamicResource Text.Stash}" FontSize="10" HorizontalAlignment="Center" Foreground="{DynamicResource Brush.FG1}"/>
+        </StackPanel>
       </Button>
 
-      <Button Classes="icon_button" Width="32" Margin="16,0,0,0" Command="{Binding ApplyPatch}" IsVisible="{Binding !IsBare}" ToolTip.Tip="{DynamicResource Text.Apply}">
-        <Path Width="14" Height="14" Data="{StaticResource Icons.Diff}"/>
+      <Button Classes="icon_button" Margin="12,0,0,0" Padding="4,2" Command="{Binding ApplyPatch}" IsVisible="{Binding !IsBare}" ToolTip.Tip="{DynamicResource Text.Apply}">
+        <StackPanel Orientation="Vertical" Spacing="1">
+          <Path Width="14" Height="14" Data="{StaticResource Icons.Diff}"/>
+          <TextBlock Text="{DynamicResource Text.Apply}" FontSize="10" HorizontalAlignment="Center" Foreground="{DynamicResource Brush.FG1}"/>
+        </StackPanel>
+      </Button>
+
+      <Button Classes="icon_button" Margin="16,0,0,0" Padding="4,2" Tapped="OpenCreateBranch" IsVisible="{Binding !IsBare}" ToolTip.Tip="{DynamicResource Text.CreateBranch}">
+        <StackPanel Orientation="Vertical" Spacing="1">
+          <Path Width="14" Height="14" Data="{StaticResource Icons.Branch.Add}" />
+          <TextBlock Text="{DynamicResource Text.CreateBranch}" FontSize="10" HorizontalAlignment="Center" Foreground="{DynamicResource Brush.FG1}"/>
+        </StackPanel>
+      </Button>
+
+      <Button Classes="icon_button" Margin="12,0,0,0" Padding="4,2" Tapped="OpenAddWorktree" ToolTip.Tip="{DynamicResource Text.AddWorktree}">
+        <StackPanel Orientation="Vertical" Spacing="1">
+          <Path Width="14" Height="14" Data="{StaticResource Icons.Worktree.Add}" />
+          <TextBlock Text="{DynamicResource Text.AddWorktree}" FontSize="10" HorizontalAlignment="Center" Foreground="{DynamicResource Brush.FG1}"/>
+        </StackPanel>
       </Button>
 
       <Rectangle Width="1" Height="16"

--- a/src/Views/RepositoryToolbar.axaml.cs
+++ b/src/Views/RepositoryToolbar.axaml.cs
@@ -454,6 +454,24 @@ namespace SourceGit.Views
             }
         }
 
+        private void OpenCreateBranch(object sender, RoutedEventArgs ev)
+        {
+            if (DataContext is ViewModels.Repository { CurrentBranch: not null } repo && repo.CanCreatePopup())
+            {
+                repo.ShowPopup(new ViewModels.CreateBranch(repo, repo.CurrentBranch));
+                ev.Handled = true;
+            }
+        }
+
+        private void OpenAddWorktree(object sender, RoutedEventArgs ev)
+        {
+            if (DataContext is ViewModels.Repository repo && repo.CanCreatePopup())
+            {
+                repo.ShowPopup(new ViewModels.AddWorktree(repo));
+                ev.Handled = true;
+            }
+        }
+
         private void OpenCustomActionMenu(object sender, RoutedEventArgs ev)
         {
             if (DataContext is ViewModels.Repository repo && sender is Control control)


### PR DESCRIPTION
## Summary

### Branch Operations

**Rename remote branch**: New "Rename..." context menu on remote branches opens a popup that pushes the current commit to a new branch name on the remote, deletes the old one, and updates the tracking of any local branches that tracked the old remote branch.

**Remove tracking reference**: New "Remove Tracking Reference" context menu item on local branches that have an upstream set. Calls `git branch --unset-upstream` directly.

**Rename local branch with remote**: Checkbox "Also rename remote branch" in the rename dialog. Fixes:
- Correctly deletes the actual remote branch name (not the local branch name) when they differ
- Pushes the tracking remote's HEAD commit rather than the local ref
- Updates the local branch's upstream tracking to the new remote branch
- Checkbox is disabled when local and remote branches are at different commits (`CanRenameRemote` guard)

**Delete remote branch**: When deleting a remote branch directly, all local branches that were tracking it get their upstream unset automatically.

**Delete branch with worktree**: Confirmation checkbox to force-remove the worktree before deleting the branch (avoids git's rejection of deleting a branch checked out in a worktree).

### Toolbar
- Repository folder name shown in bold to the left of the current branch name.
- New Branch and Worktree toolbar buttons for quick access to create-branch and add-worktree dialogs.
- All 7 action buttons (Fetch, Pull, Push, Stash, Apply, Branch, Worktree) display text labels beneath their icons.

### Localization
- New resource strings added to en_US and all translated locale files.