### PR TITLE
feat(history): add commit lineage highlight with hover + selection

### DIFF
--- a/src/Converters/FilterModeConverters.cs
+++ b/src/Converters/FilterModeConverters.cs
@@ -15,5 +15,11 @@ namespace SourceGit.Converters
                     _ => Brushes.Transparent,
                 };
             });
+
+        public static readonly FuncValueConverter<Models.CommitGraphHighlighting, bool> HighlightModeToIsAllBright =
+            new FuncValueConverter<Models.CommitGraphHighlighting, bool>(v =>
+            {
+                return v == Models.CommitGraphHighlighting.All;
+            });
     }
 }

--- a/src/Models/Commit.cs
+++ b/src/Models/Commit.cs
@@ -27,6 +27,8 @@ namespace SourceGit.Models
         public bool IsMerged { get; set; } = false;
         public int Color { get; set; } = 0;
         public double LeftMargin { get; set; } = 0;
+        public int Index { get; set; } = -1;
+        public int PathIndex { get; set; } = -1;
 
         public bool IsCommitterVisible => !Author.Equals(Committer) || AuthorTime != CommitterTime;
         public bool IsCurrentHead => Decorators.Find(x => x.Type is DecoratorType.CurrentBranchHead or DecoratorType.CurrentCommitHead) != null;

--- a/src/Models/Commit.cs
+++ b/src/Models/Commit.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 
 namespace SourceGit.Models
@@ -11,6 +11,14 @@ namespace SourceGit.Models
         ByMessage,
         ByPath,
         ByContent,
+    }
+
+    public enum CommitLineageSearchMethod
+    {
+        None = 0,
+        ParentsOnly = 1,
+        ChildsOnly = 2,
+        FullLineage = 3,
     }
 
     public class Commit

--- a/src/Models/CommitGraph.cs
+++ b/src/Models/CommitGraph.cs
@@ -32,6 +32,9 @@ namespace SourceGit.Models
             public List<Point> Points { get; } = [];
             public int Color { get; } = color;
             public bool IsMerged { get; } = isMerged;
+            public bool IsHoveredRelated { get; set; } = false;
+            public int StartCommitIndex { get; set; } = -1;
+            public int EndCommitIndex { get; set; } = -1;
         }
 
         public class Link
@@ -41,6 +44,8 @@ namespace SourceGit.Models
             public Point End;
             public int Color;
             public bool IsMerged;
+            public int StartCommitIndex;
+            public int EndCommitIndex;
         }
 
         public enum DotType
@@ -75,6 +80,13 @@ namespace SourceGit.Models
             var offsetY = -halfHeight;
             var colorPicker = new ColorPicker();
 
+            var commitMap = new Dictionary<string, int>();
+            for (int i = 0; i < commits.Count; i++)
+            {
+                commits[i].Index = i;
+                commitMap[commits[i].SHA] = i;
+            }
+
             foreach (var commit in commits)
             {
                 PathHelper major = null;
@@ -103,12 +115,14 @@ namespace SourceGit.Models
                             else
                             {
                                 major.End(offsetX, offsetY, halfHeight);
+                                major.Path.EndCommitIndex = commit.Index;
                                 ended.Add(l);
                             }
                         }
                         else
                         {
                             l.End(major.LastX, offsetY, halfHeight);
+                            l.Path.EndCommitIndex = commit.Index;
                             ended.Add(l);
                         }
 
@@ -137,16 +151,27 @@ namespace SourceGit.Models
 
                     if (commit.Parents.Count > 0)
                     {
-                        major = new PathHelper(commit.Parents[0], isMerged, colorPicker.Next(), new Point(offsetX, offsetY));
+                        major = new PathHelper(commit.Parents[0], isMerged, colorPicker.Next(), new Point(offsetX, offsetY), commit.Index);
                         unsolved.Add(major);
                         temp.Paths.Add(major.Path);
                     }
                 }
                 else if (isMerged && !major.IsMerged && commit.Parents.Count > 0)
                 {
-                    major.ReplaceMerged();
+                    major.Path.EndCommitIndex = commit.Index;
+                    major.ReplaceMerged(commit.Index);
                     temp.Paths.Add(major.Path);
                 }
+                else if (major != null && commit.Parents.Count > 0)
+                {
+                    // Break at every commit to ensure path-aware highlight is precise.
+                    major.Path.EndCommitIndex = commit.Index;
+                    major.Replace(major.Path.Color, major.Path.IsMerged, commit.Index);
+                    temp.Paths.Add(major.Path);
+                }
+
+                if (major != null)
+                    commit.PathIndex = temp.Paths.IndexOf(major.Path);
 
                 // Calculate link position of this commit.
                 var position = new Point(major?.LastX ?? offsetX, offsetY);
@@ -172,7 +197,8 @@ namespace SourceGit.Models
                             if (isMerged && !parent.IsMerged)
                             {
                                 parent.Goto(parent.LastX, offsetY + halfHeight, halfHeight);
-                                parent.ReplaceMerged();
+                                parent.Path.EndCommitIndex = commit.Index;
+                                parent.ReplaceMerged(commit.Index);
                                 temp.Paths.Add(parent.Path);
                             }
 
@@ -183,6 +209,8 @@ namespace SourceGit.Models
                                 Control = new Point(parent.LastX, position.Y),
                                 Color = parent.Path.Color,
                                 IsMerged = isMerged,
+                                StartCommitIndex = commit.Index,
+                                EndCommitIndex = commitMap.GetValueOrDefault(parentHash, -1),
                             });
                         }
                         else
@@ -190,7 +218,7 @@ namespace SourceGit.Models
                             offsetX += unitWidth;
 
                             // Create new curve for parent commit that not includes before
-                            var l = new PathHelper(parentHash, isMerged, colorPicker.Next(), position, new Point(offsetX, position.Y + halfHeight));
+                            var l = new PathHelper(parentHash, isMerged, colorPicker.Next(), position, new Point(offsetX, position.Y + halfHeight), commit.Index);
                             unsolved.Add(l);
                             temp.Paths.Add(l.Path);
                         }
@@ -213,6 +241,7 @@ namespace SourceGit.Models
                     continue;
 
                 path.End((i + 0.5) * unitWidth + 4, endY + halfHeight, halfHeight);
+                path.Path.EndCommitIndex = commits.Count - 1;
             }
             unsolved.Clear();
 
@@ -249,7 +278,7 @@ namespace SourceGit.Models
 
             public bool IsMerged => Path.IsMerged;
 
-            public PathHelper(string next, bool isMerged, int color, Point start)
+            public PathHelper(string next, bool isMerged, int color, Point start, int startCommitIndex)
             {
                 Next = next;
                 LastX = start.X;
@@ -257,9 +286,10 @@ namespace SourceGit.Models
 
                 Path = new Path(color, isMerged);
                 Path.Points.Add(start);
+                Path.StartCommitIndex = startCommitIndex;
             }
 
-            public PathHelper(string next, bool isMerged, int color, Point start, Point to)
+            public PathHelper(string next, bool isMerged, int color, Point start, Point to, int startCommitIndex)
             {
                 Next = next;
                 LastX = to.X;
@@ -268,6 +298,7 @@ namespace SourceGit.Models
                 Path = new Path(color, isMerged);
                 Path.Points.Add(start);
                 Path.Points.Add(to);
+                Path.StartCommitIndex = startCommitIndex;
             }
 
             /// <summary>
@@ -348,14 +379,19 @@ namespace SourceGit.Models
             /// <summary>
             ///     End the current path and create a new from the end.
             /// </summary>
-            public void ReplaceMerged()
+            public void Replace(int newColor, bool isMerged, int startCommitIndex)
             {
-                var color = Path.Color;
                 Add(LastX, _lastY);
 
-                Path = new Path(color, true);
+                Path = new Path(newColor, isMerged);
                 Path.Points.Add(new Point(LastX, _lastY));
+                Path.StartCommitIndex = startCommitIndex;
                 _endY = 0;
+            }
+
+            public void ReplaceMerged(int startCommitIndex)
+            {
+                Replace(Path.Color, true, startCommitIndex);
             }
 
             private void Add(double x, double y)

--- a/src/Models/CommitGraph.cs
+++ b/src/Models/CommitGraph.cs
@@ -6,6 +6,14 @@ using Avalonia.Media;
 
 namespace SourceGit.Models
 {
+    public enum CommitGraphHighlighting
+    {
+        All,
+        CurrentBranchOnly,
+        SelectedLineageOnly,
+        CurrentBranchAndSelectedLineage,
+    }
+
     public record CommitGraphLayout(double StartY, double ClipWidth, double RowHeight);
 
     public class CommitGraph

--- a/src/Models/RepositoryUIStates.cs
+++ b/src/Models/RepositoryUIStates.cs
@@ -45,6 +45,12 @@ namespace SourceGit.Models
             set;
         } = false;
 
+        public bool HighlightSelectedLineageInHistory
+        {
+            get;
+            set;
+        } = false;
+
         public BranchSortMode LocalBranchSortMode
         {
             get;

--- a/src/Models/RepositoryUIStates.cs
+++ b/src/Models/RepositoryUIStates.cs
@@ -45,6 +45,12 @@ namespace SourceGit.Models
             set;
         } = CommitGraphHighlighting.All;
 
+        public CommitLineageSearchMethod LineageSearchMethod
+        {
+            get;
+            set;
+        } = CommitLineageSearchMethod.FullLineage;
+
         public BranchSortMode LocalBranchSortMode
         {
             get;

--- a/src/Models/RepositoryUIStates.cs
+++ b/src/Models/RepositoryUIStates.cs
@@ -39,17 +39,11 @@ namespace SourceGit.Models
             set;
         } = false;
 
-        public bool OnlyHighlightCurrentBranchInHistory
+        public CommitGraphHighlighting CommitGraphHighlighting
         {
             get;
             set;
-        } = false;
-
-        public bool HighlightSelectedLineageInHistory
-        {
-            get;
-            set;
-        } = false;
+        } = CommitGraphHighlighting.All;
 
         public BranchSortMode LocalBranchSortMode
         {

--- a/src/Resources/Locales/en_US.axaml
+++ b/src/Resources/Locales/en_US.axaml
@@ -641,6 +641,7 @@
   <x:String x:Key="Text.Preferences.Appearance.Theme" xml:space="preserve">Theme</x:String>
   <x:String x:Key="Text.Preferences.Appearance.ThemeOverrides" xml:space="preserve">Theme Overrides</x:String>
   <x:String x:Key="Text.Preferences.Appearance.UseAutoHideScrollBars" xml:space="preserve">Use auto-hide scrollbars</x:String>
+  <x:String x:Key="Text.Preferences.Appearance.EnableHoverViewTracking" xml:space="preserve">Enable hover view tracking</x:String>
   <x:String x:Key="Text.Preferences.Appearance.UseFixedTabWidth" xml:space="preserve">Use fixed tab width in titlebar</x:String>
   <x:String x:Key="Text.Preferences.Appearance.UseNativeWindowFrame" xml:space="preserve">Use native window frame</x:String>
   <x:String x:Key="Text.Preferences.DiffMerge" xml:space="preserve">DIFF/MERGE TOOL</x:String>

--- a/src/Resources/Locales/en_US.axaml
+++ b/src/Resources/Locales/en_US.axaml
@@ -206,8 +206,8 @@
   <x:String x:Key="Text.Compare.Commits.Tips" xml:space="preserve">Tips: You can cherry-pick selected commits if the other side is HEAD (using context menu).</x:String>
   <x:String x:Key="Text.Configure" xml:space="preserve">Repository Configure</x:String>
   <x:String x:Key="Text.Configure.CommitMessageTemplate" xml:space="preserve">COMMIT TEMPLATE</x:String>
-  <x:String x:Key="Text.Configure.CommitMessageTemplate.BuiltinVars" xml:space="preserve">Built-in parameters: 
-  
+  <x:String x:Key="Text.Configure.CommitMessageTemplate.BuiltinVars" xml:space="preserve">Built-in parameters:
+
   ${branch_name} Current local branch name.
   ${files_num} Number of changed files
   ${files} Paths of changed files
@@ -218,8 +218,8 @@
   <x:String x:Key="Text.Configure.CommitMessageTemplate.Name" xml:space="preserve">Template Name:</x:String>
   <x:String x:Key="Text.Configure.CustomAction" xml:space="preserve">CUSTOM ACTION</x:String>
   <x:String x:Key="Text.Configure.CustomAction.Arguments" xml:space="preserve">Arguments:</x:String>
-  <x:String x:Key="Text.Configure.CustomAction.Arguments.Tip" xml:space="preserve">Built-in parameters: 
-  
+  <x:String x:Key="Text.Configure.CustomAction.Arguments.Tip" xml:space="preserve">Built-in parameters:
+
   ${REPO} Repository's path
   ${REMOTE} Selected remote or selected branch's remote
   ${BRANCH} Selected branch, without ${REMOTE} part for remote branches
@@ -782,6 +782,7 @@
   <x:String x:Key="Text.Repository.NewBranch" xml:space="preserve">Create Branch</x:String>
   <x:String x:Key="Text.Repository.Notifications.Clear" xml:space="preserve">CLEAR NOTIFICATIONS</x:String>
   <x:String x:Key="Text.Repository.OnlyHighlightCurrentBranchInGraph" xml:space="preserve">Only highlight current branch</x:String>
+  <x:String x:Key="Text.Repository.HighlightSelectedLineageInGraph" xml:space="preserve">Highlight selected commit lineage</x:String>
   <x:String x:Key="Text.Repository.OpenAsFolder" xml:space="preserve">Open as Folder</x:String>
   <x:String x:Key="Text.Repository.OpenIn" xml:space="preserve">Open in {0}</x:String>
   <x:String x:Key="Text.Repository.OpenWithExternalTools" xml:space="preserve">Open in External Tools</x:String>

--- a/src/Resources/Locales/en_US.axaml
+++ b/src/Resources/Locales/en_US.axaml
@@ -491,6 +491,11 @@
   <x:String x:Key="Text.Histories.Header.CommitTime" xml:space="preserve">COMMIT TIME</x:String>
   <x:String x:Key="Text.Histories.Header.DateTime" xml:space="preserve">DATE TIME</x:String>
   <x:String x:Key="Text.Histories.Header.GraphAndSubject" xml:space="preserve">GRAPH &amp; SUBJECT</x:String>
+  <x:String x:Key="Text.Histories.Header.Highlights" xml:space="preserve">Highlighting Mode</x:String>
+  <x:String x:Key="Text.Histories.Header.Highlights.All" xml:space="preserve">Show All</x:String>
+  <x:String x:Key="Text.Histories.Header.Highlights.CurrentBranchOnly" xml:space="preserve">Current Branch Only</x:String>
+  <x:String x:Key="Text.Histories.Header.Highlights.SelectedLineageOnly" xml:space="preserve">Selected Lineage Only</x:String>
+  <x:String x:Key="Text.Histories.Header.Highlights.CurrentBranchAndSelectedLineage" xml:space="preserve">Current Branch &amp; Selected Lineage</x:String>
   <x:String x:Key="Text.Histories.Header.SHA" xml:space="preserve">SHA</x:String>
   <x:String x:Key="Text.Histories.Selected" xml:space="preserve">SELECTED {0} COMMITS</x:String>
   <x:String x:Key="Text.Histories.ShowColumns" xml:space="preserve">SHOW COLUMNS</x:String>

--- a/src/Resources/Locales/en_US.axaml
+++ b/src/Resources/Locales/en_US.axaml
@@ -496,6 +496,10 @@
   <x:String x:Key="Text.Histories.Header.Highlights.CurrentBranchOnly" xml:space="preserve">Current Branch Only</x:String>
   <x:String x:Key="Text.Histories.Header.Highlights.SelectedLineageOnly" xml:space="preserve">Selected Lineage Only</x:String>
   <x:String x:Key="Text.Histories.Header.Highlights.CurrentBranchAndSelectedLineage" xml:space="preserve">Current Branch &amp; Selected Lineage</x:String>
+  <x:String x:Key="Text.Histories.Header.Highlights.LineageMethod" xml:space="preserve">Lineage Search Method</x:String>
+  <x:String x:Key="Text.Histories.Header.Highlights.LineageMethod.ParentsOnly" xml:space="preserve">Ancestors Only</x:String>
+  <x:String x:Key="Text.Histories.Header.Highlights.LineageMethod.ChildsOnly" xml:space="preserve">Descendants Only</x:String>
+  <x:String x:Key="Text.Histories.Header.Highlights.LineageMethod.FullLineage" xml:space="preserve">Full Lineage</x:String>
   <x:String x:Key="Text.Histories.Header.SHA" xml:space="preserve">SHA</x:String>
   <x:String x:Key="Text.Histories.Selected" xml:space="preserve">SELECTED {0} COMMITS</x:String>
   <x:String x:Key="Text.Histories.ShowColumns" xml:space="preserve">SHOW COLUMNS</x:String>

--- a/src/Resources/Locales/zh_CN.axaml
+++ b/src/Resources/Locales/zh_CN.axaml
@@ -495,6 +495,11 @@
   <x:String x:Key="Text.Histories.Header.CommitTime" xml:space="preserve">提交时间</x:String>
   <x:String x:Key="Text.Histories.Header.DateTime" xml:space="preserve">日期时间</x:String>
   <x:String x:Key="Text.Histories.Header.GraphAndSubject" xml:space="preserve">路线图与主题</x:String>
+  <x:String x:Key="Text.Histories.Header.Highlights" xml:space="preserve">高亮模式</x:String>
+  <x:String x:Key="Text.Histories.Header.Highlights.All" xml:space="preserve">全部显示</x:String>
+  <x:String x:Key="Text.Histories.Header.Highlights.CurrentBranchOnly" xml:space="preserve">仅当前分支</x:String>
+  <x:String x:Key="Text.Histories.Header.Highlights.SelectedLineageOnly" xml:space="preserve">仅选中谱系</x:String>
+  <x:String x:Key="Text.Histories.Header.Highlights.CurrentBranchAndSelectedLineage" xml:space="preserve">当前分支与选中谱系</x:String>
   <x:String x:Key="Text.Histories.Header.SHA" xml:space="preserve">提交指纹</x:String>
   <x:String x:Key="Text.Histories.Selected" xml:space="preserve">已选中 {0} 项提交</x:String>
   <x:String x:Key="Text.Histories.ShowColumns" xml:space="preserve">显示列</x:String>

--- a/src/Resources/Locales/zh_CN.axaml
+++ b/src/Resources/Locales/zh_CN.axaml
@@ -500,6 +500,10 @@
   <x:String x:Key="Text.Histories.Header.Highlights.CurrentBranchOnly" xml:space="preserve">仅当前分支</x:String>
   <x:String x:Key="Text.Histories.Header.Highlights.SelectedLineageOnly" xml:space="preserve">仅选中谱系</x:String>
   <x:String x:Key="Text.Histories.Header.Highlights.CurrentBranchAndSelectedLineage" xml:space="preserve">当前分支与选中谱系</x:String>
+  <x:String x:Key="Text.Histories.Header.Highlights.LineageMethod" xml:space="preserve">谱系搜索方式</x:String>
+  <x:String x:Key="Text.Histories.Header.Highlights.LineageMethod.ParentsOnly" xml:space="preserve">仅祖先</x:String>
+  <x:String x:Key="Text.Histories.Header.Highlights.LineageMethod.ChildsOnly" xml:space="preserve">仅后代</x:String>
+  <x:String x:Key="Text.Histories.Header.Highlights.LineageMethod.FullLineage" xml:space="preserve">完整谱系</x:String>
   <x:String x:Key="Text.Histories.Header.SHA" xml:space="preserve">提交指纹</x:String>
   <x:String x:Key="Text.Histories.Selected" xml:space="preserve">已选中 {0} 项提交</x:String>
   <x:String x:Key="Text.Histories.ShowColumns" xml:space="preserve">显示列</x:String>

--- a/src/Resources/Locales/zh_CN.axaml
+++ b/src/Resources/Locales/zh_CN.axaml
@@ -645,6 +645,7 @@
   <x:String x:Key="Text.Preferences.Appearance.Theme" xml:space="preserve">主题</x:String>
   <x:String x:Key="Text.Preferences.Appearance.ThemeOverrides" xml:space="preserve">主题自定义</x:String>
   <x:String x:Key="Text.Preferences.Appearance.UseAutoHideScrollBars" xml:space="preserve">允许滚动条自动隐藏</x:String>
+  <x:String x:Key="Text.Preferences.Appearance.EnableHoverViewTracking" xml:space="preserve">开启悬停视图跟踪</x:String>
   <x:String x:Key="Text.Preferences.Appearance.UseFixedTabWidth" xml:space="preserve">主标签使用固定宽度</x:String>
   <x:String x:Key="Text.Preferences.Appearance.UseNativeWindowFrame" xml:space="preserve">使用系统默认窗体样式</x:String>
   <x:String x:Key="Text.Preferences.DiffMerge" xml:space="preserve">对比/合并工具</x:String>

--- a/src/Resources/Locales/zh_CN.axaml
+++ b/src/Resources/Locales/zh_CN.axaml
@@ -211,7 +211,7 @@
   <x:String x:Key="Text.Configure" xml:space="preserve">仓库配置</x:String>
   <x:String x:Key="Text.Configure.CommitMessageTemplate" xml:space="preserve">提交信息模板</x:String>
   <x:String x:Key="Text.Configure.CommitMessageTemplate.BuiltinVars" xml:space="preserve">内置变量：
-  
+
   ${branch_name} 当前分支名
   ${files_num} 变更文件数量
   ${files} 变更文件路径列表
@@ -223,7 +223,7 @@
   <x:String x:Key="Text.Configure.CustomAction" xml:space="preserve">自定义操作</x:String>
   <x:String x:Key="Text.Configure.CustomAction.Arguments" xml:space="preserve">命令行参数 ：</x:String>
   <x:String x:Key="Text.Configure.CustomAction.Arguments.Tip" xml:space="preserve">内置变量：
-  
+
   ${REPO} 仓库路径
   ${REMOTE} 选中的远程仓库或选中分支所属的远程仓库
   ${BRANCH} 选中的分支，对于远程分支不包含远程名
@@ -786,6 +786,7 @@
   <x:String x:Key="Text.Repository.NewBranch" xml:space="preserve">新建分支</x:String>
   <x:String x:Key="Text.Repository.Notifications.Clear" xml:space="preserve">清空通知列表</x:String>
   <x:String x:Key="Text.Repository.OnlyHighlightCurrentBranchInGraph" xml:space="preserve">仅高亮显示当前分支</x:String>
+  <x:String x:Key="Text.Repository.HighlightSelectedLineageInGraph" xml:space="preserve">高亮显示所选提交的血缘关系</x:String>
   <x:String x:Key="Text.Repository.OpenAsFolder" xml:space="preserve">本仓库（文件夹）</x:String>
   <x:String x:Key="Text.Repository.OpenIn" xml:space="preserve">在 {0} 中打开</x:String>
   <x:String x:Key="Text.Repository.OpenWithExternalTools" xml:space="preserve">使用外部工具打开</x:String>

--- a/src/Resources/Locales/zh_TW.axaml
+++ b/src/Resources/Locales/zh_TW.axaml
@@ -645,6 +645,7 @@
   <x:String x:Key="Text.Preferences.Appearance.Theme" xml:space="preserve">佈景主題</x:String>
   <x:String x:Key="Text.Preferences.Appearance.ThemeOverrides" xml:space="preserve">自訂主題</x:String>
   <x:String x:Key="Text.Preferences.Appearance.UseAutoHideScrollBars" xml:space="preserve">允許自動隱藏捲軸</x:String>
+  <x:String x:Key="Text.Preferences.Appearance.EnableHoverViewTracking" xml:space="preserve">開啟懸停視圖跟蹤</x:String>
   <x:String x:Key="Text.Preferences.Appearance.UseFixedTabWidth" xml:space="preserve">使用固定寬度的分頁標籤</x:String>
   <x:String x:Key="Text.Preferences.Appearance.UseNativeWindowFrame" xml:space="preserve">使用系統原生預設視窗樣式</x:String>
   <x:String x:Key="Text.Preferences.DiffMerge" xml:space="preserve">對比/合併工具</x:String>

--- a/src/Resources/Locales/zh_TW.axaml
+++ b/src/Resources/Locales/zh_TW.axaml
@@ -495,6 +495,11 @@
   <x:String x:Key="Text.Histories.Header.CommitTime" xml:space="preserve">提交時間</x:String>
   <x:String x:Key="Text.Histories.Header.DateTime" xml:space="preserve">日期時間</x:String>
   <x:String x:Key="Text.Histories.Header.GraphAndSubject" xml:space="preserve">路線圖與訊息標題</x:String>
+  <x:String x:Key="Text.Histories.Header.Highlights" xml:space="preserve">高亮模式</x:String>
+  <x:String x:Key="Text.Histories.Header.Highlights.All" xml:space="preserve">全部顯示</x:String>
+  <x:String x:Key="Text.Histories.Header.Highlights.CurrentBranchOnly" xml:space="preserve">僅目前分支</x:String>
+  <x:String x:Key="Text.Histories.Header.Highlights.SelectedLineageOnly" xml:space="preserve">僅選取譜系</x:String>
+  <x:String x:Key="Text.Histories.Header.Highlights.CurrentBranchAndSelectedLineage" xml:space="preserve">目前分支與選取譜系</x:String>
   <x:String x:Key="Text.Histories.Header.SHA" xml:space="preserve">提交編號</x:String>
   <x:String x:Key="Text.Histories.Selected" xml:space="preserve">已選取 {0} 項提交</x:String>
   <x:String x:Key="Text.Histories.ShowColumns" xml:space="preserve">顯示欄位</x:String>

--- a/src/Resources/Locales/zh_TW.axaml
+++ b/src/Resources/Locales/zh_TW.axaml
@@ -500,6 +500,10 @@
   <x:String x:Key="Text.Histories.Header.Highlights.CurrentBranchOnly" xml:space="preserve">僅目前分支</x:String>
   <x:String x:Key="Text.Histories.Header.Highlights.SelectedLineageOnly" xml:space="preserve">僅選取譜系</x:String>
   <x:String x:Key="Text.Histories.Header.Highlights.CurrentBranchAndSelectedLineage" xml:space="preserve">目前分支與選取譜系</x:String>
+  <x:String x:Key="Text.Histories.Header.Highlights.LineageMethod" xml:space="preserve">譜系搜尋方式</x:String>
+  <x:String x:Key="Text.Histories.Header.Highlights.LineageMethod.ParentsOnly" xml:space="preserve">僅祖先</x:String>
+  <x:String x:Key="Text.Histories.Header.Highlights.LineageMethod.ChildsOnly" xml:space="preserve">僅後代</x:String>
+  <x:String x:Key="Text.Histories.Header.Highlights.LineageMethod.FullLineage" xml:space="preserve">完整譜系</x:String>
   <x:String x:Key="Text.Histories.Header.SHA" xml:space="preserve">提交編號</x:String>
   <x:String x:Key="Text.Histories.Selected" xml:space="preserve">已選取 {0} 項提交</x:String>
   <x:String x:Key="Text.Histories.ShowColumns" xml:space="preserve">顯示欄位</x:String>

--- a/src/ViewModels/Histories.cs
+++ b/src/ViewModels/Histories.cs
@@ -81,8 +81,29 @@ namespace SourceGit.ViewModels
                 if (SetProperty(ref _hoveredCommitIndex, value))
                 {
                     if (value >= 0 && value < _commits.Count)
-                        HoveredLineageCommits = GetCommitLineage(_commits[(int)value],
-                            Models.CommitLineageSearchMethod.FullLineage, 1000);
+                    {
+                        var hoveredIndex = (int)value;
+                        var depth = 1000u;
+                        var topLimit = -1;
+                        var bottomLimit = -1;
+
+                        if (_visibleTopIndex >= 0 && _visibleBottomIndex >= _visibleTopIndex)
+                        {
+                            topLimit = _visibleTopIndex;
+                            bottomLimit = _visibleBottomIndex;
+
+                            // Add a small guard band to keep context around viewport edges.
+                            var dist = Math.Max(Math.Abs(hoveredIndex - topLimit), Math.Abs(bottomLimit - hoveredIndex));
+                            depth = (uint)Math.Max(500, dist + 32);
+                        }
+
+                        HoveredLineageCommits = GetCommitLineage(
+                            _commits[hoveredIndex],
+                            Models.CommitLineageSearchMethod.FullLineage,
+                            depth,
+                            topLimit,
+                            bottomLimit);
+                    }
                     else
                         HoveredLineageCommits = null;
                 }
@@ -298,6 +319,41 @@ namespace SourceGit.ViewModels
             return await new Commands.QuerySingleCommit(_repo.FullPath, sha)
                 .GetResultAsync()
                 .ConfigureAwait(false);
+        }
+
+        public void SetVisibleCommitRange(int topIndex, int bottomIndex)
+        {
+            // 扩展 viewport 上下各 100 行，保证高亮连续性
+            const int VIEWPORT_PADDING = 100;
+            int paddedTop = Math.Max(0, topIndex - VIEWPORT_PADDING);
+            int paddedBottom = Math.Min(_commits.Count - 1, bottomIndex + VIEWPORT_PADDING);
+
+            // 只有当滚动超过阈值时才触发 lineage 重新计算
+            const int SCROLL_THRESHOLD = 40; // 可根据实际体验调整
+            bool needUpdate = false;
+            if (_visibleTopIndex < 0 || _visibleBottomIndex < 0)
+            {
+                needUpdate = true;
+            }
+            else if (Math.Abs(paddedTop - _visibleTopIndex) > SCROLL_THRESHOLD ||
+                     Math.Abs(paddedBottom - _visibleBottomIndex) > SCROLL_THRESHOLD)
+            {
+                needUpdate = true;
+            }
+
+            if (needUpdate)
+            {
+                _visibleTopIndex = paddedTop;
+                _visibleBottomIndex = paddedBottom;
+                // 触发 hover lineage 重新计算（如果有 hover）
+                if (_hoveredCommitIndex >= 0 && _hoveredCommitIndex < _commits.Count)
+                {
+                    // 重新赋值以触发 setter
+                    var tmp = _hoveredCommitIndex;
+                    _hoveredCommitIndex = -1;
+                    HoveredCommitIndex = tmp;
+                }
+            }
         }
 
         public async Task<bool> CheckoutBranchByDecoratorAsync(Models.Decorator decorator)
@@ -533,7 +589,7 @@ namespace SourceGit.ViewModels
             if (_selectedCommits.Count == 0)
             {
                 _repo.SearchCommitContext.Selected = null;
-                DetailContext = new Models.Null();
+                DetailContext = null;
                 SelectedLineageCommits = null;
                 SelectedLineagePaths = null;
             }
@@ -572,7 +628,12 @@ namespace SourceGit.ViewModels
             }
         }
 
-        public HashSet<int> GetCommitLineage(Models.Commit commit, Models.CommitLineageSearchMethod method, uint depth = 100)
+        public HashSet<int> GetCommitLineage(
+            Models.Commit commit,
+            Models.CommitLineageSearchMethod method,
+            uint depth = 100,
+            int viewportTopIndex = -1,
+            int viewportBottomIndex = -1)
         {
             var active = new HashSet<int>();
             if (commit == null || method == Models.CommitLineageSearchMethod.None)
@@ -583,6 +644,13 @@ namespace SourceGit.ViewModels
             // GUI boundaries: only search within a limited range of commits to improve performance
             int topLimit = Math.Max(0, commit.Index - (int)depth);
             int bottomLimit = Math.Min(_commits.Count - 1, commit.Index + (int)depth);
+
+            // Viewport boundaries: tighten the traversal window to visible rows when available.
+            if (viewportTopIndex >= 0 && viewportBottomIndex >= viewportTopIndex)
+            {
+                topLimit = Math.Max(topLimit, viewportTopIndex);
+                bottomLimit = Math.Min(bottomLimit, viewportBottomIndex);
+            }
 
             // UP (Ancestors) - Moving to higher indices
             if (method == Models.CommitLineageSearchMethod.ParentsOnly || method == Models.CommitLineageSearchMethod.FullLineage)
@@ -657,6 +725,8 @@ namespace SourceGit.ViewModels
         private bool _isCollapseDetails = false;
         private HashSet<int> _selectedLineagePaths = null;
         private HashSet<int> _selectedLineageCommits = null;
+        private int _visibleTopIndex = -1;
+        private int _visibleBottomIndex = -1;
         private Dictionary<string, Models.Commit> _commitMap = new Dictionary<string, Models.Commit>();
         private Dictionary<string, List<Models.Commit>> _childrenMap = new Dictionary<string, List<Models.Commit>>();
     }

--- a/src/ViewModels/Histories.cs
+++ b/src/ViewModels/Histories.cs
@@ -80,7 +80,7 @@ namespace SourceGit.ViewModels
             {
                 if (SetProperty(ref _hoveredCommitIndex, value))
                 {
-                    if (value >= 0 && value < _commits.Count)
+                    if (Preferences.Instance.EnableHoverViewTracking && value >= 0 && value < _commits.Count)
                     {
                         var hoveredIndex = (int)value;
                         var depth = 1000u;

--- a/src/ViewModels/Histories.cs
+++ b/src/ViewModels/Histories.cs
@@ -401,6 +401,24 @@ namespace SourceGit.ViewModels
 
         private void PostCommitsChanged()
         {
+            _commitMap.Clear();
+            _childrenMap.Clear();
+            for (int i = 0; i < _commits.Count; i++)
+            {
+                var c = _commits[i];
+                c.Index = i;
+                _commitMap[c.SHA] = c;
+                foreach (var p in c.Parents)
+                {
+                    if (!_childrenMap.TryGetValue(p, out var list))
+                    {
+                        list = new List<Models.Commit>();
+                        _childrenMap[p] = list;
+                    }
+                    list.Add(c);
+                }
+            }
+
             if (_selectedCommits.Count == 0)
                 return;
 
@@ -466,6 +484,72 @@ namespace SourceGit.ViewModels
             }
         }
 
+        public HashSet<int> GetCommitLineage(Models.Commit commit, Models.CommitLineageSearchMethod method, uint depth = 100)
+        {
+            var active = new HashSet<int>();
+            if (commit == null || method == Models.CommitLineageSearchMethod.None)
+                return active;
+
+            active.Add(commit.Index);
+
+            // GUI boundaries: only search within a limited range of commits to improve performance
+            int topLimit = Math.Max(0, commit.Index - (int)depth);
+            int bottomLimit = Math.Min(_commits.Count - 1, commit.Index + (int)depth);
+
+            // UP (Ancestors) - Moving to higher indices
+            if (method == Models.CommitLineageSearchMethod.ParentsOnly || method == Models.CommitLineageSearchMethod.FullLineage)
+            {
+                var queueUp = new Queue<Models.Commit>();
+                queueUp.Enqueue(commit);
+                var visitedUp = new HashSet<string>();
+                visitedUp.Add(commit.SHA);
+                while (queueUp.Count > 0)
+                {
+                    var c = queueUp.Dequeue();
+                    foreach (var pSha in c.Parents)
+                    {
+                        if (_commitMap.TryGetValue(pSha, out var parent) && visitedUp.Add(pSha))
+                        {
+                            if (parent.Index <= bottomLimit)
+                            {
+                                active.Add(parent.Index);
+                                queueUp.Enqueue(parent);
+                            }
+                        }
+                    }
+                }
+            }
+
+            // DOWN (Descendants) - Moving to lower indices
+            if (method == Models.CommitLineageSearchMethod.ChildsOnly || method == Models.CommitLineageSearchMethod.FullLineage)
+            {
+                var queueDown = new Queue<Models.Commit>();
+                queueDown.Enqueue(commit);
+                var visitedDown = new HashSet<string>();
+                visitedDown.Add(commit.SHA);
+                while (queueDown.Count > 0)
+                {
+                    var c = queueDown.Dequeue();
+                    if (_childrenMap.TryGetValue(c.SHA, out var children))
+                    {
+                        foreach (var child in children)
+                        {
+                            if (visitedDown.Add(child.SHA))
+                            {
+                                if (child.Index >= topLimit)
+                                {
+                                    active.Add(child.Index);
+                                    queueDown.Enqueue(child);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            return active;
+        }
+
         private Repository _repo = null;
         private CommitDetailSharedData _commitDetailSharedData = null;
         private bool _isLoading = true;
@@ -481,5 +565,7 @@ namespace SourceGit.ViewModels
         private GridLength _topArea = new GridLength(1, GridUnitType.Star);
         private GridLength _bottomArea = new GridLength(1, GridUnitType.Star);
         private bool _isCollapseDetails = false;
+        private Dictionary<string, Models.Commit> _commitMap = new Dictionary<string, Models.Commit>();
+        private Dictionary<string, List<Models.Commit>> _childrenMap = new Dictionary<string, List<Models.Commit>>();
     }
 }

--- a/src/ViewModels/Histories.cs
+++ b/src/ViewModels/Histories.cs
@@ -73,6 +73,28 @@ namespace SourceGit.ViewModels
             set => SetProperty(ref _graph, value);
         }
 
+        public long HoveredCommitIndex
+        {
+            get => _hoveredCommitIndex;
+            set
+            {
+                if (SetProperty(ref _hoveredCommitIndex, value))
+                {
+                    if (value >= 0 && value < _commits.Count)
+                        HoveredLineageCommits = GetCommitLineage(_commits[(int)value],
+                            Models.CommitLineageSearchMethod.FullLineage, 1000);
+                    else
+                        HoveredLineageCommits = null;
+                }
+            }
+        }
+
+        public HashSet<int> HoveredLineageCommits
+        {
+            get => _hoveredLineageCommits;
+            set => SetProperty(ref _hoveredLineageCommits, value);
+        }
+
         public List<Models.Commit> SelectedCommits
         {
             get => _selectedCommits;
@@ -81,6 +103,18 @@ namespace SourceGit.ViewModels
                 if (SetProperty(ref _selectedCommits, value))
                     PostSelectedCommitsChanged();
             }
+        }
+
+        public HashSet<int> SelectedLineagePaths
+        {
+            get => _selectedLineagePaths;
+            set => SetProperty(ref _selectedLineagePaths, value);
+        }
+
+        public HashSet<int> SelectedLineageCommits
+        {
+            get => _selectedLineageCommits;
+            set => SetProperty(ref _selectedLineageCommits, value);
         }
 
         public object DetailContext
@@ -112,6 +146,19 @@ namespace SourceGit.ViewModels
                 if (_repo.UIStates.OnlyHighlightCurrentBranchInHistory != value)
                 {
                     _repo.UIStates.OnlyHighlightCurrentBranchInHistory = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
+        public bool HighlightSelectedLineage
+        {
+            get => _repo.UIStates.HighlightSelectedLineageInHistory;
+            set
+            {
+                if (_repo.UIStates.HighlightSelectedLineageInHistory != value)
+                {
+                    _repo.UIStates.HighlightSelectedLineageInHistory = value;
                     OnPropertyChanged();
                 }
             }
@@ -555,6 +602,8 @@ namespace SourceGit.ViewModels
         private bool _isLoading = true;
         private List<Models.Commit> _commits = new List<Models.Commit>();
         private Models.CommitGraph _graph = null;
+        private long _hoveredCommitIndex = -1;
+        private HashSet<int> _hoveredLineageCommits = null;
         private List<Models.Commit> _selectedCommits = [];
         private Models.Bisect _bisect = null;
         private object _detailContext = new Models.Null();
@@ -565,6 +614,8 @@ namespace SourceGit.ViewModels
         private GridLength _topArea = new GridLength(1, GridUnitType.Star);
         private GridLength _bottomArea = new GridLength(1, GridUnitType.Star);
         private bool _isCollapseDetails = false;
+        private HashSet<int> _selectedLineagePaths = null;
+        private HashSet<int> _selectedLineageCommits = null;
         private Dictionary<string, Models.Commit> _commitMap = new Dictionary<string, Models.Commit>();
         private Dictionary<string, List<Models.Commit>> _childrenMap = new Dictionary<string, List<Models.Commit>>();
     }

--- a/src/ViewModels/Histories.cs
+++ b/src/ViewModels/Histories.cs
@@ -494,6 +494,37 @@ namespace SourceGit.ViewModels
             SelectedCommits = selected;
         }
 
+        private void CalculateTargetLineage(Models.Commit commit)
+        {
+            Task.Run(() =>
+            {
+                if (commit == null)
+                {
+                    Dispatcher.UIThread.Post(() =>
+                    {
+                        SelectedLineageCommits = null;
+                        SelectedLineagePaths = null;
+                    });
+                    return;
+                }
+
+                var paths = new HashSet<int>();
+                var lineage = GetCommitLineage(commit, Models.CommitLineageSearchMethod.FullLineage);
+                foreach (var idx in lineage)
+                {
+                    var c = _commits[idx];
+                    if (c.PathIndex >= 0)
+                        paths.Add(c.PathIndex);
+                }
+
+                Dispatcher.UIThread.Post(() =>
+                {
+                    SelectedLineageCommits = lineage;
+                    SelectedLineagePaths = paths;
+                });
+            });
+        }
+
         private void PostSelectedCommitsChanged()
         {
             if (_ignoreSelectionChange)
@@ -503,6 +534,8 @@ namespace SourceGit.ViewModels
             {
                 _repo.SearchCommitContext.Selected = null;
                 DetailContext = new Models.Null();
+                SelectedLineageCommits = null;
+                SelectedLineagePaths = null;
             }
             else if (_selectedCommits.Count == 1)
             {
@@ -514,6 +547,9 @@ namespace SourceGit.ViewModels
                     detail.Commit = c;
                 else
                     DetailContext = new CommitDetail(_repo, _commitDetailSharedData) { Commit = c };
+
+                if (_repo.UIStates.HighlightSelectedLineageInHistory)
+                    CalculateTargetLineage(c);
             }
             else if (_selectedCommits.Count == 2)
             {
@@ -523,11 +559,16 @@ namespace SourceGit.ViewModels
                     compare.SetTargets(_selectedCommits[1], _selectedCommits[0]);
                 else
                     DetailContext = new RevisionCompare(_repo, _selectedCommits[1], _selectedCommits[0]);
+
+                SelectedLineageCommits = null;
+                SelectedLineagePaths = null;
             }
             else
             {
                 _repo.SearchCommitContext.Selected = null;
                 DetailContext = new Models.Count(_selectedCommits.Count);
+                SelectedLineageCommits = null;
+                SelectedLineagePaths = null;
             }
         }
 

--- a/src/ViewModels/Histories.cs
+++ b/src/ViewModels/Histories.cs
@@ -182,6 +182,26 @@ namespace SourceGit.ViewModels
             }
         }
 
+        public Models.CommitLineageSearchMethod LineageSearchMethod
+        {
+            get => _repo.UIStates.LineageSearchMethod;
+            set
+            {
+                if (_repo.UIStates.LineageSearchMethod != value)
+                {
+                    _repo.UIStates.LineageSearchMethod = value;
+                    OnPropertyChanged();
+
+                    if (_selectedCommits.Count == 1 &&
+                        (CommitGraphHighlighting == Models.CommitGraphHighlighting.SelectedLineageOnly ||
+                         CommitGraphHighlighting == Models.CommitGraphHighlighting.CurrentBranchAndSelectedLineage))
+                    {
+                        CalculateTargetLineage(_selectedCommits[0]);
+                    }
+                }
+            }
+        }
+
         public AvaloniaList<Models.IssueTracker> IssueTrackers
         {
             get => _repo.IssueTrackers;
@@ -552,7 +572,7 @@ namespace SourceGit.ViewModels
                 }
 
                 var paths = new HashSet<int>();
-                var lineage = GetCommitLineage(commit, Models.CommitLineageSearchMethod.FullLineage, 20000);
+                var lineage = GetCommitLineage(commit, LineageSearchMethod, 20000);
                 for (int i = 0; i < lineage.Length; i++)
                 {
                     if (lineage[i])

--- a/src/ViewModels/Histories.cs
+++ b/src/ViewModels/Histories.cs
@@ -110,7 +110,7 @@ namespace SourceGit.ViewModels
             }
         }
 
-        public HashSet<int> HoveredLineageCommits
+        public bool[] HoveredLineageCommits
         {
             get => _hoveredLineageCommits;
             set => SetProperty(ref _hoveredLineageCommits, value);
@@ -132,7 +132,7 @@ namespace SourceGit.ViewModels
             set => SetProperty(ref _selectedLineagePaths, value);
         }
 
-        public HashSet<int> SelectedLineageCommits
+        public bool[] SelectedLineageCommits
         {
             get => _selectedLineageCommits;
             set => SetProperty(ref _selectedLineageCommits, value);
@@ -505,21 +505,11 @@ namespace SourceGit.ViewModels
         private void PostCommitsChanged()
         {
             _commitMap.Clear();
-            _childrenMap.Clear();
             for (int i = 0; i < _commits.Count; i++)
             {
                 var c = _commits[i];
                 c.Index = i;
                 _commitMap[c.SHA] = c;
-                foreach (var p in c.Parents)
-                {
-                    if (!_childrenMap.TryGetValue(p, out var list))
-                    {
-                        list = new List<Models.Commit>();
-                        _childrenMap[p] = list;
-                    }
-                    list.Add(c);
-                }
             }
 
             if (_selectedCommits.Count == 0)
@@ -566,11 +556,14 @@ namespace SourceGit.ViewModels
 
                 var paths = new HashSet<int>();
                 var lineage = GetCommitLineage(commit, Models.CommitLineageSearchMethod.FullLineage);
-                foreach (var idx in lineage)
+                for (int i = 0; i < lineage.Length; i++)
                 {
-                    var c = _commits[idx];
-                    if (c.PathIndex >= 0)
-                        paths.Add(c.PathIndex);
+                    if (lineage[i])
+                    {
+                        var c = _commits[i];
+                        if (c.PathIndex >= 0)
+                            paths.Add(c.PathIndex);
+                    }
                 }
 
                 Dispatcher.UIThread.Post(() =>
@@ -628,18 +621,18 @@ namespace SourceGit.ViewModels
             }
         }
 
-        public HashSet<int> GetCommitLineage(
+        public bool[] GetCommitLineage(
             Models.Commit commit,
             Models.CommitLineageSearchMethod method,
             uint depth = 100,
             int viewportTopIndex = -1,
             int viewportBottomIndex = -1)
         {
-            var active = new HashSet<int>();
+            var active = new bool[_commits.Count];
             if (commit == null || method == Models.CommitLineageSearchMethod.None)
                 return active;
 
-            active.Add(commit.Index);
+            active[commit.Index] = true;
 
             // GUI boundaries: only search within a limited range of commits to improve performance
             int topLimit = Math.Max(0, commit.Index - (int)depth);
@@ -652,51 +645,34 @@ namespace SourceGit.ViewModels
                 bottomLimit = Math.Min(bottomLimit, viewportBottomIndex);
             }
 
-            // UP (Ancestors) - Moving to higher indices
-            if (method == Models.CommitLineageSearchMethod.ParentsOnly || method == Models.CommitLineageSearchMethod.FullLineage)
+            // DOWN (Descendants) - Moving to lower indices
+            if (method == Models.CommitLineageSearchMethod.ChildsOnly || method == Models.CommitLineageSearchMethod.FullLineage)
             {
-                var queueUp = new Queue<Models.Commit>();
-                queueUp.Enqueue(commit);
-                var visitedUp = new HashSet<string>();
-                visitedUp.Add(commit.SHA);
-                while (queueUp.Count > 0)
+                for (int i = commit.Index - 1; i >= topLimit; i--)
                 {
-                    var c = queueUp.Dequeue();
-                    foreach (var pSha in c.Parents)
+                    foreach (var pSha in _commits[i].Parents)
                     {
-                        if (_commitMap.TryGetValue(pSha, out var parent) && visitedUp.Add(pSha))
+                        if (_commitMap.TryGetValue(pSha, out var parent) && parent.Index < _commits.Count && active[parent.Index])
                         {
-                            if (parent.Index <= bottomLimit)
-                            {
-                                active.Add(parent.Index);
-                                queueUp.Enqueue(parent);
-                            }
+                            active[i] = true;
+                            break;
                         }
                     }
                 }
             }
 
-            // DOWN (Descendants) - Moving to lower indices
-            if (method == Models.CommitLineageSearchMethod.ChildsOnly || method == Models.CommitLineageSearchMethod.FullLineage)
+            // UP (Ancestors) - Moving to higher indices
+            if (method == Models.CommitLineageSearchMethod.ParentsOnly || method == Models.CommitLineageSearchMethod.FullLineage)
             {
-                var queueDown = new Queue<Models.Commit>();
-                queueDown.Enqueue(commit);
-                var visitedDown = new HashSet<string>();
-                visitedDown.Add(commit.SHA);
-                while (queueDown.Count > 0)
+                for (int i = commit.Index; i <= bottomLimit; i++)
                 {
-                    var c = queueDown.Dequeue();
-                    if (_childrenMap.TryGetValue(c.SHA, out var children))
+                    if (active[i])
                     {
-                        foreach (var child in children)
+                        foreach (var pSha in _commits[i].Parents)
                         {
-                            if (visitedDown.Add(child.SHA))
+                            if (_commitMap.TryGetValue(pSha, out var parent) && parent.Index <= bottomLimit)
                             {
-                                if (child.Index >= topLimit)
-                                {
-                                    active.Add(child.Index);
-                                    queueDown.Enqueue(child);
-                                }
+                                active[parent.Index] = true;
                             }
                         }
                     }
@@ -712,7 +688,7 @@ namespace SourceGit.ViewModels
         private List<Models.Commit> _commits = new List<Models.Commit>();
         private Models.CommitGraph _graph = null;
         private long _hoveredCommitIndex = -1;
-        private HashSet<int> _hoveredLineageCommits = null;
+        private bool[] _hoveredLineageCommits = null;
         private List<Models.Commit> _selectedCommits = [];
         private Models.Bisect _bisect = null;
         private object _detailContext = new Models.Null();
@@ -724,10 +700,9 @@ namespace SourceGit.ViewModels
         private GridLength _bottomArea = new GridLength(1, GridUnitType.Star);
         private bool _isCollapseDetails = false;
         private HashSet<int> _selectedLineagePaths = null;
-        private HashSet<int> _selectedLineageCommits = null;
+        private bool[] _selectedLineageCommits = null;
         private int _visibleTopIndex = -1;
         private int _visibleBottomIndex = -1;
         private Dictionary<string, Models.Commit> _commitMap = new Dictionary<string, Models.Commit>();
-        private Dictionary<string, List<Models.Commit>> _childrenMap = new Dictionary<string, List<Models.Commit>>();
     }
 }

--- a/src/ViewModels/Histories.cs
+++ b/src/ViewModels/Histories.cs
@@ -159,28 +159,25 @@ namespace SourceGit.ViewModels
             get => _repo.CurrentBranch;
         }
 
-        public bool HighlightCurrentBranchOnly
+        public Models.CommitGraphHighlighting CommitGraphHighlighting
         {
-            get => _repo.UIStates.OnlyHighlightCurrentBranchInHistory;
+            get => _repo.UIStates.CommitGraphHighlighting;
             set
             {
-                if (_repo.UIStates.OnlyHighlightCurrentBranchInHistory != value)
+                if (_repo.UIStates.CommitGraphHighlighting != value)
                 {
-                    _repo.UIStates.OnlyHighlightCurrentBranchInHistory = value;
+                    _repo.UIStates.CommitGraphHighlighting = value;
                     OnPropertyChanged();
-                }
-            }
-        }
 
-        public bool HighlightSelectedLineage
-        {
-            get => _repo.UIStates.HighlightSelectedLineageInHistory;
-            set
-            {
-                if (_repo.UIStates.HighlightSelectedLineageInHistory != value)
-                {
-                    _repo.UIStates.HighlightSelectedLineageInHistory = value;
-                    OnPropertyChanged();
+                    var highlightSelected = value == Models.CommitGraphHighlighting.SelectedLineageOnly ||
+                                             value == Models.CommitGraphHighlighting.CurrentBranchAndSelectedLineage;
+                    if (highlightSelected && _selectedCommits.Count == 1)
+                        CalculateTargetLineage(_selectedCommits[0]);
+                    else if (!highlightSelected)
+                    {
+                        SelectedLineageCommits = null;
+                        SelectedLineagePaths = null;
+                    }
                 }
             }
         }
@@ -555,7 +552,7 @@ namespace SourceGit.ViewModels
                 }
 
                 var paths = new HashSet<int>();
-                var lineage = GetCommitLineage(commit, Models.CommitLineageSearchMethod.FullLineage);
+                var lineage = GetCommitLineage(commit, Models.CommitLineageSearchMethod.FullLineage, 20000);
                 for (int i = 0; i < lineage.Length; i++)
                 {
                     if (lineage[i])
@@ -582,7 +579,7 @@ namespace SourceGit.ViewModels
             if (_selectedCommits.Count == 0)
             {
                 _repo.SearchCommitContext.Selected = null;
-                DetailContext = null;
+                DetailContext = new Models.Null();
                 SelectedLineageCommits = null;
                 SelectedLineagePaths = null;
             }
@@ -597,7 +594,9 @@ namespace SourceGit.ViewModels
                 else
                     DetailContext = new CommitDetail(_repo, _commitDetailSharedData) { Commit = c };
 
-                if (_repo.UIStates.HighlightSelectedLineageInHistory)
+                var highlightSelected = _repo.UIStates.CommitGraphHighlighting == Models.CommitGraphHighlighting.SelectedLineageOnly ||
+                                         _repo.UIStates.CommitGraphHighlighting == Models.CommitGraphHighlighting.CurrentBranchAndSelectedLineage;
+                if (highlightSelected)
                     CalculateTargetLineage(c);
             }
             else if (_selectedCommits.Count == 2)

--- a/src/ViewModels/Preferences.cs
+++ b/src/ViewModels/Preferences.cs
@@ -181,6 +181,12 @@ namespace SourceGit.ViewModels
             set => SetProperty(ref _useAutoHideScrollBars, value);
         }
 
+        public bool EnableHoverViewTracking
+        {
+            get => _enableHoverViewTracking;
+            set => SetProperty(ref _enableHoverViewTracking, value);
+        }
+
         public bool UseGitHubStyleAvatar
         {
             get => _useGitHubStyleAvatar;
@@ -824,6 +830,7 @@ namespace SourceGit.ViewModels
         private int _subjectGuideLength = 50;
         private bool _useFixedTabWidth = true;
         private bool _useAutoHideScrollBars = true;
+        private bool _enableHoverViewTracking = true;
         private bool _useGitHubStyleAvatar = true;
         private bool _showAuthorTimeInGraph = false;
         private bool _showChildren = false;

--- a/src/ViewModels/Repository.cs
+++ b/src/ViewModels/Repository.cs
@@ -126,16 +126,10 @@ namespace SourceGit.ViewModels
             }
         }
 
-        public bool HighlightCurrentBranchOnlyInHistory
+        public Models.CommitGraphHighlighting CommitGraphHighlighting
         {
-            get => _histories.HighlightCurrentBranchOnly;
-            set => _histories.HighlightCurrentBranchOnly = value;
-        }
-
-        public bool HighlightSelectedLineageInHistory
-        {
-            get => _histories.HighlightSelectedLineage;
-            set => _histories.HighlightSelectedLineage = value;
+            get => _histories.CommitGraphHighlighting;
+            set => _histories.CommitGraphHighlighting = value;
         }
 
         public string Filter

--- a/src/ViewModels/Repository.cs
+++ b/src/ViewModels/Repository.cs
@@ -132,6 +132,12 @@ namespace SourceGit.ViewModels
             set => _histories.HighlightCurrentBranchOnly = value;
         }
 
+        public bool HighlightSelectedLineageInHistory
+        {
+            get => _histories.HighlightSelectedLineage;
+            set => _histories.HighlightSelectedLineage = value;
+        }
+
         public string Filter
         {
             get => _filter;

--- a/src/Views/CommitGraph.cs
+++ b/src/Views/CommitGraph.cs
@@ -42,10 +42,10 @@ namespace SourceGit.Views
             set => SetValue(HighlightSelectedLineageProperty, value);
         }
 
-        public static readonly StyledProperty<System.Collections.Generic.HashSet<int>> HoveredLineageCommitsProperty =
-            AvaloniaProperty.Register<CommitGraph, System.Collections.Generic.HashSet<int>>(nameof(HoveredLineageCommits));
+        public static readonly StyledProperty<bool[]> HoveredLineageCommitsProperty =
+            AvaloniaProperty.Register<CommitGraph, bool[]>(nameof(HoveredLineageCommits));
 
-        public System.Collections.Generic.HashSet<int> HoveredLineageCommits
+        public bool[] HoveredLineageCommits
         {
             get => GetValue(HoveredLineageCommitsProperty);
             set => SetValue(HoveredLineageCommitsProperty, value);
@@ -60,10 +60,10 @@ namespace SourceGit.Views
             set => SetValue(HoveredCommitIndexProperty, value);
         }
 
-        public static readonly StyledProperty<System.Collections.Generic.HashSet<int>> SelectedLineageCommitsProperty =
-            AvaloniaProperty.Register<CommitGraph, System.Collections.Generic.HashSet<int>>(nameof(SelectedLineageCommits));
+        public static readonly StyledProperty<bool[]> SelectedLineageCommitsProperty =
+            AvaloniaProperty.Register<CommitGraph, bool[]>(nameof(SelectedLineageCommits));
 
-        public System.Collections.Generic.HashSet<int> SelectedLineageCommits
+        public bool[] SelectedLineageCommits
         {
             get => GetValue(SelectedLineageCommitsProperty);
             set => SetValue(SelectedLineageCommitsProperty, value);
@@ -126,14 +126,15 @@ namespace SourceGit.Views
                 line.IsHoveredRelated = false;
 
             var hoveredLineage = HoveredLineageCommits;
-            if (hoveredLineage != null && hoveredLineage.Count > 0)
+            if (hoveredLineage != null)
             {
                 foreach (var line in graph.Paths)
                 {
-                    if (line.StartCommitIndex >= 0 && line.EndCommitIndex >= 0)
+                    if (line.StartCommitIndex >= 0 && line.EndCommitIndex >= 0 &&
+                        line.StartCommitIndex < hoveredLineage.Length && line.EndCommitIndex < hoveredLineage.Length)
                     {
-                        line.IsHoveredRelated = hoveredLineage.Contains(line.StartCommitIndex) &&
-                                                hoveredLineage.Contains(line.EndCommitIndex);
+                        line.IsHoveredRelated = hoveredLineage[line.StartCommitIndex] &&
+                                                hoveredLineage[line.EndCommitIndex];
                     }
                 }
             }
@@ -181,16 +182,17 @@ namespace SourceGit.Views
 
                 var isLinkInSelectedLineage =
                     highlightSelectedLineage &&
-                    onlyHighlightCurrentBranch &&
                     selectedLineageCommits != null &&
                     link.StartCommitIndex >= 0 && link.EndCommitIndex >= 0 &&
-                    selectedLineageCommits.Contains(link.StartCommitIndex) &&
-                    selectedLineageCommits.Contains(link.EndCommitIndex);
+                    link.StartCommitIndex < selectedLineageCommits.Length && link.EndCommitIndex < selectedLineageCommits.Length &&
+                    selectedLineageCommits[link.StartCommitIndex] &&
+                    selectedLineageCommits[link.EndCommitIndex];
 
                 var isLinkInHoveredLineage = hoveredLineage != null &&
                     link.StartCommitIndex >= 0 && link.EndCommitIndex >= 0 &&
-                    hoveredLineage.Contains(link.StartCommitIndex) &&
-                    hoveredLineage.Contains(link.EndCommitIndex);
+                    link.StartCommitIndex < hoveredLineage.Length && link.EndCommitIndex < hoveredLineage.Length &&
+                    hoveredLineage[link.StartCommitIndex] &&
+                    hoveredLineage[link.EndCommitIndex];
 
                 var pen = link.Color < 0 ? grayedPen : Models.CommitGraph.Pens[link.Color];
                 if (onlyHighlightCurrentBranch && !link.IsMerged && !isLinkInSelectedLineage)
@@ -222,8 +224,9 @@ namespace SourceGit.Views
 
                 var isLineInSelectedLineage = highlightSelectedLineage && selectedLineageCommits != null &&
                     line.StartCommitIndex >= 0 && line.EndCommitIndex >= 0 &&
-                    selectedLineageCommits.Contains(line.StartCommitIndex) &&
-                    selectedLineageCommits.Contains(line.EndCommitIndex);
+                    line.StartCommitIndex < selectedLineageCommits.Length && line.EndCommitIndex < selectedLineageCommits.Length &&
+                    selectedLineageCommits[line.StartCommitIndex] &&
+                    selectedLineageCommits[line.EndCommitIndex];
 
                 var geo = new StreamGeometry();
                 var pen = line.Color < 0 ? grayedPen : Models.CommitGraph.Pens[line.Color];
@@ -311,7 +314,7 @@ namespace SourceGit.Views
                 if (center.Y > bottom)
                     break;
 
-                bool isDotInSelectedLineage = highlightSelectedLineage && selectedLineageCommits != null && selectedLineageCommits.Contains(i);
+                bool isDotInSelectedLineage = highlightSelectedLineage && selectedLineageCommits != null && i >= 0 && i < selectedLineageCommits.Length && selectedLineageCommits[i];
 
                 var pen = Models.CommitGraph.Pens[dot.Color];
                 if (onlyHighlightCurrentBranch && !dot.IsMerged && !isDotInSelectedLineage)

--- a/src/Views/CommitGraph.cs
+++ b/src/Views/CommitGraph.cs
@@ -24,22 +24,13 @@ namespace SourceGit.Views
             set => SetValue(DotBrushProperty, value);
         }
 
-        public static readonly StyledProperty<bool> OnlyHighlightCurrentBranchProperty =
-            AvaloniaProperty.Register<CommitGraph, bool>(nameof(OnlyHighlightCurrentBranch), true);
+        public static readonly StyledProperty<Models.CommitGraphHighlighting> HighlightModeProperty =
+            AvaloniaProperty.Register<CommitGraph, Models.CommitGraphHighlighting>(nameof(HighlightMode), Models.CommitGraphHighlighting.All);
 
-        public bool OnlyHighlightCurrentBranch
+        public Models.CommitGraphHighlighting HighlightMode
         {
-            get => GetValue(OnlyHighlightCurrentBranchProperty);
-            set => SetValue(OnlyHighlightCurrentBranchProperty, value);
-        }
-
-        public static readonly StyledProperty<bool> HighlightSelectedLineageProperty =
-            AvaloniaProperty.Register<CommitGraph, bool>(nameof(HighlightSelectedLineage), false);
-
-        public bool HighlightSelectedLineage
-        {
-            get => GetValue(HighlightSelectedLineageProperty);
-            set => SetValue(HighlightSelectedLineageProperty, value);
+            get => GetValue(HighlightModeProperty);
+            set => SetValue(HighlightModeProperty, value);
         }
 
         public static readonly StyledProperty<bool[]> HoveredLineageCommitsProperty =
@@ -92,8 +83,7 @@ namespace SourceGit.Views
             AffectsRender<CommitGraph>(
                 GraphProperty,
                 DotBrushProperty,
-                OnlyHighlightCurrentBranchProperty,
-                HighlightSelectedLineageProperty,
+                HighlightModeProperty,
                 HoveredLineageCommitsProperty,
                 HoveredCommitIndexProperty,
                 SelectedLineageCommitsProperty,
@@ -110,7 +100,7 @@ namespace SourceGit.Views
                 change.Property == HoveredLineageCommitsProperty ||
                 change.Property == SelectedLineageCommitsProperty ||
                 change.Property == SelectedLineagePathsProperty ||
-                change.Property == HighlightSelectedLineageProperty)
+                change.Property == HighlightModeProperty)
             {
                 UpdateHoveredRelated();
             }
@@ -165,8 +155,11 @@ namespace SourceGit.Views
         {
             var hoverBold = 2.0;
             var grayedPen = new Pen(new SolidColorBrush(Colors.Gray, 0.4), Models.CommitGraph.Pens[0].Thickness);
-            var onlyHighlightCurrentBranch = OnlyHighlightCurrentBranch;
-            var highlightSelectedLineage = HighlightSelectedLineage;
+            var highlightMode = HighlightMode;
+            var onlyHighlightCurrentBranch = highlightMode == Models.CommitGraphHighlighting.CurrentBranchOnly ||
+                                             highlightMode == Models.CommitGraphHighlighting.CurrentBranchAndSelectedLineage;
+            var highlightSelectedLineage = highlightMode == Models.CommitGraphHighlighting.SelectedLineageOnly ||
+                                             highlightMode == Models.CommitGraphHighlighting.CurrentBranchAndSelectedLineage;
             var selectedLineageCommits = SelectedLineageCommits;
             var hoveredLineage = HoveredLineageCommits;
 
@@ -195,7 +188,15 @@ namespace SourceGit.Views
                     hoveredLineage[link.EndCommitIndex];
 
                 var pen = link.Color < 0 ? grayedPen : Models.CommitGraph.Pens[link.Color];
-                if (onlyHighlightCurrentBranch && !link.IsMerged && !isLinkInSelectedLineage)
+                bool shouldDim = false;
+                if (highlightMode == Models.CommitGraphHighlighting.CurrentBranchOnly)
+                    shouldDim = !link.IsMerged;
+                else if (highlightMode == Models.CommitGraphHighlighting.SelectedLineageOnly)
+                    shouldDim = !isLinkInSelectedLineage;
+                else if (highlightMode == Models.CommitGraphHighlighting.CurrentBranchAndSelectedLineage)
+                    shouldDim = !link.IsMerged && !isLinkInSelectedLineage;
+
+                if (shouldDim)
                     pen = grayedPen;
 
                 if (isLinkInHoveredLineage)
@@ -230,7 +231,15 @@ namespace SourceGit.Views
 
                 var geo = new StreamGeometry();
                 var pen = line.Color < 0 ? grayedPen : Models.CommitGraph.Pens[line.Color];
-                if (onlyHighlightCurrentBranch && !line.IsMerged && !isLineInSelectedLineage)
+                bool shouldDim = false;
+                if (highlightMode == Models.CommitGraphHighlighting.CurrentBranchOnly)
+                    shouldDim = !line.IsMerged;
+                else if (highlightMode == Models.CommitGraphHighlighting.SelectedLineageOnly)
+                    shouldDim = !isLineInSelectedLineage;
+                else if (highlightMode == Models.CommitGraphHighlighting.CurrentBranchAndSelectedLineage)
+                    shouldDim = !line.IsMerged && !isLineInSelectedLineage;
+
+                if (shouldDim)
                     pen = grayedPen;
 
                 if (line.IsHoveredRelated)
@@ -297,8 +306,11 @@ namespace SourceGit.Views
             var dotFill = DotBrush;
             var dotFillPen = new Pen(dotFill, 2);
             var grayedPen = new Pen(Brushes.Gray, Models.CommitGraph.Pens[0].Thickness);
-            var onlyHighlightCurrentBranch = OnlyHighlightCurrentBranch;
-            var highlightSelectedLineage = HighlightSelectedLineage;
+            var highlightMode = HighlightMode;
+            var onlyHighlightCurrentBranch = highlightMode == Models.CommitGraphHighlighting.CurrentBranchOnly ||
+                                             highlightMode == Models.CommitGraphHighlighting.CurrentBranchAndSelectedLineage;
+            var highlightSelectedLineage = highlightMode == Models.CommitGraphHighlighting.SelectedLineageOnly ||
+                                             highlightMode == Models.CommitGraphHighlighting.CurrentBranchAndSelectedLineage;
             var selectedLineageCommits = SelectedLineageCommits;
 
             if (DataContext is not ViewModels.Histories vm)
@@ -317,7 +329,15 @@ namespace SourceGit.Views
                 bool isDotInSelectedLineage = highlightSelectedLineage && selectedLineageCommits != null && i >= 0 && i < selectedLineageCommits.Length && selectedLineageCommits[i];
 
                 var pen = Models.CommitGraph.Pens[dot.Color];
-                if (onlyHighlightCurrentBranch && !dot.IsMerged && !isDotInSelectedLineage)
+                bool shouldDim = false;
+                if (highlightMode == Models.CommitGraphHighlighting.CurrentBranchOnly)
+                    shouldDim = !dot.IsMerged;
+                else if (highlightMode == Models.CommitGraphHighlighting.SelectedLineageOnly)
+                    shouldDim = !isDotInSelectedLineage;
+                else if (highlightMode == Models.CommitGraphHighlighting.CurrentBranchAndSelectedLineage)
+                    shouldDim = !dot.IsMerged && !isDotInSelectedLineage;
+
+                if (shouldDim)
                     pen = grayedPen;
 
                 switch (dot.Type)
@@ -339,3 +359,4 @@ namespace SourceGit.Views
         }
     }
 }
+

--- a/src/Views/CommitGraph.cs
+++ b/src/Views/CommitGraph.cs
@@ -162,8 +162,12 @@ namespace SourceGit.Views
 
         private void DrawCurves(DrawingContext context, Models.CommitGraph graph, double top, double bottom, double rowHeight)
         {
+            var hoverBold = 2.0;
             var grayedPen = new Pen(new SolidColorBrush(Colors.Gray, 0.4), Models.CommitGraph.Pens[0].Thickness);
             var onlyHighlightCurrentBranch = OnlyHighlightCurrentBranch;
+            var highlightSelectedLineage = HighlightSelectedLineage;
+            var selectedLineageCommits = SelectedLineageCommits;
+            var hoveredLineage = HoveredLineageCommits;
 
             foreach (var link in graph.Links)
             {
@@ -175,9 +179,25 @@ namespace SourceGit.Views
                 if (startY > bottom)
                     break;
 
-                var pen = Models.CommitGraph.Pens[link.Color];
-                if (onlyHighlightCurrentBranch && !link.IsMerged)
+                var isLinkInSelectedLineage =
+                    highlightSelectedLineage &&
+                    onlyHighlightCurrentBranch &&
+                    selectedLineageCommits != null &&
+                    link.StartCommitIndex >= 0 && link.EndCommitIndex >= 0 &&
+                    selectedLineageCommits.Contains(link.StartCommitIndex) &&
+                    selectedLineageCommits.Contains(link.EndCommitIndex);
+
+                var isLinkInHoveredLineage = hoveredLineage != null &&
+                    link.StartCommitIndex >= 0 && link.EndCommitIndex >= 0 &&
+                    hoveredLineage.Contains(link.StartCommitIndex) &&
+                    hoveredLineage.Contains(link.EndCommitIndex);
+
+                var pen = link.Color < 0 ? grayedPen : Models.CommitGraph.Pens[link.Color];
+                if (onlyHighlightCurrentBranch && !link.IsMerged && !isLinkInSelectedLineage)
                     pen = grayedPen;
+
+                if (isLinkInHoveredLineage)
+                    pen = new Pen(pen.Brush, pen.Thickness + hoverBold);
 
                 var geo = new StreamGeometry();
                 using (var ctx = geo.Open())
@@ -200,8 +220,18 @@ namespace SourceGit.Views
                 if (last.Y > bottom)
                     break;
 
+                var isLineInSelectedLineage = highlightSelectedLineage && selectedLineageCommits != null &&
+                    line.StartCommitIndex >= 0 && line.EndCommitIndex >= 0 &&
+                    selectedLineageCommits.Contains(line.StartCommitIndex) &&
+                    selectedLineageCommits.Contains(line.EndCommitIndex);
+
                 var geo = new StreamGeometry();
-                var pen = Models.CommitGraph.Pens[line.Color];
+                var pen = line.Color < 0 ? grayedPen : Models.CommitGraph.Pens[line.Color];
+                if (onlyHighlightCurrentBranch && !line.IsMerged && !isLineInSelectedLineage)
+                    pen = grayedPen;
+
+                if (line.IsHoveredRelated)
+                    pen = new Pen(pen.Brush, pen.Thickness + hoverBold);
 
                 using (var ctx = geo.Open())
                 {
@@ -255,10 +285,7 @@ namespace SourceGit.Views
                     }
                 }
 
-                if (!line.IsMerged && onlyHighlightCurrentBranch)
-                    context.DrawGeometry(null, grayedPen, geo);
-                else
-                    context.DrawGeometry(null, pen, geo);
+                context.DrawGeometry(null, pen, geo);
             }
         }
 
@@ -268,9 +295,15 @@ namespace SourceGit.Views
             var dotFillPen = new Pen(dotFill, 2);
             var grayedPen = new Pen(Brushes.Gray, Models.CommitGraph.Pens[0].Thickness);
             var onlyHighlightCurrentBranch = OnlyHighlightCurrentBranch;
+            var highlightSelectedLineage = HighlightSelectedLineage;
+            var selectedLineageCommits = SelectedLineageCommits;
 
-            foreach (var dot in graph.Dots)
+            if (DataContext is not ViewModels.Histories vm)
+                return;
+
+            for (int i = 0; i < graph.Dots.Count; i++)
             {
+                var dot = graph.Dots[i];
                 var center = new Point(dot.Center.X, dot.Center.Y * rowHeight);
 
                 if (center.Y < top)
@@ -278,8 +311,10 @@ namespace SourceGit.Views
                 if (center.Y > bottom)
                     break;
 
+                bool isDotInSelectedLineage = highlightSelectedLineage && selectedLineageCommits != null && selectedLineageCommits.Contains(i);
+
                 var pen = Models.CommitGraph.Pens[dot.Color];
-                if (!dot.IsMerged && onlyHighlightCurrentBranch)
+                if (onlyHighlightCurrentBranch && !dot.IsMerged && !isDotInSelectedLineage)
                     pen = grayedPen;
 
                 switch (dot.Type)

--- a/src/Views/CommitGraph.cs
+++ b/src/Views/CommitGraph.cs
@@ -33,6 +33,51 @@ namespace SourceGit.Views
             set => SetValue(OnlyHighlightCurrentBranchProperty, value);
         }
 
+        public static readonly StyledProperty<bool> HighlightSelectedLineageProperty =
+            AvaloniaProperty.Register<CommitGraph, bool>(nameof(HighlightSelectedLineage), false);
+
+        public bool HighlightSelectedLineage
+        {
+            get => GetValue(HighlightSelectedLineageProperty);
+            set => SetValue(HighlightSelectedLineageProperty, value);
+        }
+
+        public static readonly StyledProperty<System.Collections.Generic.HashSet<int>> HoveredLineageCommitsProperty =
+            AvaloniaProperty.Register<CommitGraph, System.Collections.Generic.HashSet<int>>(nameof(HoveredLineageCommits));
+
+        public System.Collections.Generic.HashSet<int> HoveredLineageCommits
+        {
+            get => GetValue(HoveredLineageCommitsProperty);
+            set => SetValue(HoveredLineageCommitsProperty, value);
+        }
+
+        public static readonly StyledProperty<long> HoveredCommitIndexProperty =
+            AvaloniaProperty.Register<CommitGraph, long>(nameof(HoveredCommitIndex), -1);
+
+        public long HoveredCommitIndex
+        {
+            get => GetValue(HoveredCommitIndexProperty);
+            set => SetValue(HoveredCommitIndexProperty, value);
+        }
+
+        public static readonly StyledProperty<System.Collections.Generic.HashSet<int>> SelectedLineageCommitsProperty =
+            AvaloniaProperty.Register<CommitGraph, System.Collections.Generic.HashSet<int>>(nameof(SelectedLineageCommits));
+
+        public System.Collections.Generic.HashSet<int> SelectedLineageCommits
+        {
+            get => GetValue(SelectedLineageCommitsProperty);
+            set => SetValue(SelectedLineageCommitsProperty, value);
+        }
+
+        public static readonly StyledProperty<System.Collections.Generic.HashSet<int>> SelectedLineagePathsProperty =
+            AvaloniaProperty.Register<CommitGraph, System.Collections.Generic.HashSet<int>>(nameof(SelectedLineagePaths));
+
+        public System.Collections.Generic.HashSet<int> SelectedLineagePaths
+        {
+            get => GetValue(SelectedLineagePathsProperty);
+            set => SetValue(SelectedLineagePathsProperty, value);
+        }
+
         public static readonly StyledProperty<Models.CommitGraphLayout> LayoutProperty =
             AvaloniaProperty.Register<CommitGraph, Models.CommitGraphLayout>(nameof(Layout));
 
@@ -48,7 +93,50 @@ namespace SourceGit.Views
                 GraphProperty,
                 DotBrushProperty,
                 OnlyHighlightCurrentBranchProperty,
+                HighlightSelectedLineageProperty,
+                HoveredLineageCommitsProperty,
+                HoveredCommitIndexProperty,
+                SelectedLineageCommitsProperty,
+                SelectedLineagePathsProperty,
                 LayoutProperty);
+        }
+
+        protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
+        {
+            base.OnPropertyChanged(change);
+
+            if (change.Property == GraphProperty ||
+                change.Property == HoveredCommitIndexProperty ||
+                change.Property == HoveredLineageCommitsProperty ||
+                change.Property == SelectedLineageCommitsProperty ||
+                change.Property == SelectedLineagePathsProperty ||
+                change.Property == HighlightSelectedLineageProperty)
+            {
+                UpdateHoveredRelated();
+            }
+        }
+
+        private void UpdateHoveredRelated()
+        {
+            var graph = Graph;
+            if (graph == null)
+                return;
+
+            foreach (var line in graph.Paths)
+                line.IsHoveredRelated = false;
+
+            var hoveredLineage = HoveredLineageCommits;
+            if (hoveredLineage != null && hoveredLineage.Count > 0)
+            {
+                foreach (var line in graph.Paths)
+                {
+                    if (line.StartCommitIndex >= 0 && line.EndCommitIndex >= 0)
+                    {
+                        line.IsHoveredRelated = hoveredLineage.Contains(line.StartCommitIndex) &&
+                                                hoveredLineage.Contains(line.EndCommitIndex);
+                    }
+                }
+            }
         }
 
         public override void Render(DrawingContext context)

--- a/src/Views/Histories.axaml
+++ b/src/Views/Histories.axaml
@@ -100,7 +100,14 @@
         <DataGrid.Columns>
           <DataGridTemplateColumn Width="*" IsReadOnly="True">
             <DataGridTemplateColumn.Header>
-              <TextBlock Classes="table_header" Text="{DynamicResource Text.Histories.Header.GraphAndSubject}" HorizontalAlignment="Center"/>
+              <Grid>
+                <Button Classes="icon_button"
+                        Click="OnHighlightsClicked"
+                        ToolTip.Tip="{DynamicResource Text.Histories.Header.Highlights}">
+                  <Path Width="12" Height="12" Data="{StaticResource Icons.LightOn}"/>
+                </Button>
+                <TextBlock Classes="table_header" Text="{DynamicResource Text.Histories.Header.GraphAndSubject}" HorizontalAlignment="Center"/>
+              </Grid>
             </DataGridTemplateColumn.Header>
 
             <DataGridTemplateColumn.CellTemplate>
@@ -128,7 +135,7 @@
                       <v:CommitRefsPresenter.UseGraphColor>
                         <MultiBinding Converter="{x:Static BoolConverters.Or}">
                           <Binding Path="IsMerged"/>
-                          <Binding Path="$parent[v:Histories].OnlyHighlightCurrentBranch" Converter="{x:Static BoolConverters.Not}"/>
+                          <Binding Path="$parent[v:Histories].CommitGraphHighlighting" Converter="{x:Static c:FilterModeConverters.HighlightModeToIsAllBright}"/>
                         </MultiBinding>
                       </v:CommitRefsPresenter.UseGraphColor>
                     </v:CommitRefsPresenter>
@@ -233,12 +240,11 @@
                      Margin="0,24,0,0"
                      Graph="{Binding Graph}"
                      DotBrush="{DynamicResource Brush.Contents}"
-                     OnlyHighlightCurrentBranch="{Binding $parent[v:Histories].OnlyHighlightCurrentBranch}"
+                     HighlightMode="{Binding $parent[v:Histories].CommitGraphHighlighting}"
                      HoveredCommitIndex="{Binding HoveredCommitIndex}"
                      HoveredLineageCommits="{Binding HoveredLineageCommits}"
                      SelectedLineageCommits="{Binding SelectedLineageCommits}"
                      SelectedLineagePaths="{Binding SelectedLineagePaths}"
-                     HighlightSelectedLineage="{Binding $parent[v:Histories].HighlightSelectedLineage}"
                      HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
                      IsHitTestVisible="False"
                      ClipToBounds="True"/>

--- a/src/Views/Histories.axaml
+++ b/src/Views/Histories.axaml
@@ -268,47 +268,47 @@
                   Focusable="False"
                   IsEnabled="{Binding #ThisControl.IsDetailsPanelExpanded, Mode=OneWay}"/>
 
-    <Grid Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="3" >
+    <Grid Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="3">
       <ContentControl Content="{Binding DetailContext, Mode=OneWay}">
         <ContentControl.DataTemplates>
           <DataTemplate DataType="m:Null">
             <TabControl Padding="0,4">
-                <TabItem>
-                  <TabItem.Header>
-                    <Border Background="Transparent" PointerPressed="OnTabHeaderPointerPressed">
-                      <TextBlock Classes="tab_header" Text="{DynamicResource Text.CommitDetail.Info}"/>
-                    </Border>
-                  </TabItem.Header>
+              <TabItem>
+                <TabItem.Header>
+                  <Border Background="Transparent" PointerPressed="OnTabHeaderPointerPressed">
+                    <TextBlock Classes="tab_header" Text="{DynamicResource Text.CommitDetail.Info}"/>
+                  </Border>
+                </TabItem.Header>
 
-                  <Grid IsVisible="{Binding #ThisControl.IsDetailsPanelExpanded, Mode=OneWay}">
-                    <Path Width="128" Height="128"
-                          Data="{StaticResource Icons.Detail}"
-                          HorizontalAlignment="Center"
-                          Fill="{DynamicResource Brush.FG2}"/>
+                <Grid IsVisible="{Binding #ThisControl.IsDetailsPanelExpanded, Mode=OneWay}">
+                  <Path Width="128" Height="128"
+                        Data="{StaticResource Icons.Detail}"
+                        HorizontalAlignment="Center"
+                        Fill="{DynamicResource Brush.FG2}"/>
 
-                    <StackPanel Margin="0,8" Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Bottom">
-                      <Path Width="12" Height="12" VerticalAlignment="Center" Data="{StaticResource Icons.Info}" Fill="{DynamicResource Brush.FG2}"/>
-                      <TextBlock Margin="4,0" Text="{DynamicResource Text.Histories.Tips.Prefix}" FontWeight="Bold" Foreground="{DynamicResource Brush.FG2}"/>
-                      <TextBlock Text="{DynamicResource Text.Histories.Tips}" Foreground="{DynamicResource Brush.FG2}" IsVisible="{OnPlatform True, macOS=False}"/>
-                      <TextBlock Text="{DynamicResource Text.Histories.Tips.MacOS}" Foreground="{DynamicResource Brush.FG2}" IsVisible="{OnPlatform False, macOS=True}"/>
-                    </StackPanel>
-                  </Grid>
-                </TabItem>
+                  <StackPanel Margin="0,8" Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Bottom">
+                    <Path Width="12" Height="12" VerticalAlignment="Center" Data="{StaticResource Icons.Info}" Fill="{DynamicResource Brush.FG2}"/>
+                    <TextBlock Margin="4,0" Text="{DynamicResource Text.Histories.Tips.Prefix}" FontWeight="Bold" Foreground="{DynamicResource Brush.FG2}"/>
+                    <TextBlock Text="{DynamicResource Text.Histories.Tips}" Foreground="{DynamicResource Brush.FG2}" IsVisible="{OnPlatform True, macOS=False}"/>
+                    <TextBlock Text="{DynamicResource Text.Histories.Tips.MacOS}" Foreground="{DynamicResource Brush.FG2}" IsVisible="{OnPlatform False, macOS=True}"/>
+                  </StackPanel>
+                </Grid>
+              </TabItem>
 
-                <TabItem IsEnabled="False">
-                  <TabItem.Header>
-                    <TextBlock Classes="tab_header" Text="{DynamicResource Text.CommitDetail.Changes}"/>
-                  </TabItem.Header>
-                </TabItem>
+              <TabItem IsEnabled="False">
+                <TabItem.Header>
+                  <TextBlock Classes="tab_header" Text="{DynamicResource Text.CommitDetail.Changes}"/>
+                </TabItem.Header>
+              </TabItem>
 
-                <TabItem IsEnabled="False">
-                  <TabItem.Header>
-                    <TextBlock Classes="tab_header" Text="{DynamicResource Text.CommitDetail.Files}"/>
-                  </TabItem.Header>
-                </TabItem>
-              </TabControl>
+              <TabItem IsEnabled="False">
+                <TabItem.Header>
+                  <TextBlock Classes="tab_header" Text="{DynamicResource Text.CommitDetail.Files}"/>
+                </TabItem.Header>
+              </TabItem>
+            </TabControl>
           </DataTemplate>
-          
+
           <DataTemplate DataType="vm:CommitDetail">
             <v:CommitDetail IsDetailsPanelExpanded="{Binding #ThisControl.IsDetailsPanelExpanded, Mode=OneWay}"/>
           </DataTemplate>

--- a/src/Views/Histories.axaml
+++ b/src/Views/Histories.axaml
@@ -23,7 +23,7 @@
       <ColumnDefinition Width="{Binding RightArea, Mode=TwoWay}" MinWidth="100"/>
     </v:HistoriesLayout.ColumnDefinitions>
 
-    <Grid Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="3">      
+    <Grid Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="3">
       <v:HistoriesCommitList x:Name="CommitListContainer"
                              Classes="static_scrollbar"
                              ScrollViewer.AllowAutoHide="False"
@@ -53,7 +53,7 @@
               <Setter Property="Background" Value="{DynamicResource Brush.Contents}"/>
             </Style>
           </Style>
-          
+
           <Style Selector="DataGridColumnHeader">
             <Setter Property="MinHeight" Value="24"/>
             <Setter Property="Background" Value="Transparent"/>
@@ -234,6 +234,11 @@
                      Graph="{Binding Graph}"
                      DotBrush="{DynamicResource Brush.Contents}"
                      OnlyHighlightCurrentBranch="{Binding $parent[v:Histories].OnlyHighlightCurrentBranch}"
+                     HoveredCommitIndex="{Binding HoveredCommitIndex}"
+                     HoveredLineageCommits="{Binding HoveredLineageCommits}"
+                     SelectedLineageCommits="{Binding SelectedLineageCommits}"
+                     SelectedLineagePaths="{Binding SelectedLineagePaths}"
+                     HighlightSelectedLineage="{Binding $parent[v:Histories].HighlightSelectedLineage}"
                      HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
                      IsHitTestVisible="False"
                      ClipToBounds="True"/>
@@ -346,7 +351,7 @@
                 <StackPanel Orientation="Vertical"
                             HorizontalAlignment="Center" VerticalAlignment="Center"
                             IsVisible="{Binding #ThisControl.IsDetailsPanelExpanded, Mode=OneWay}">
-                  
+
                   <Path Width="128" Height="128"
                         Data="{StaticResource Icons.Detail}"
                         HorizontalAlignment="Center"
@@ -387,7 +392,7 @@
                 ToolTip.Tip="{DynamicResource Text.HistoriesDetailsStandalone}">
           <Path Width="15" Height="15" Margin="0,1,0,0" Data="{StaticResource Icons.OpenAsStandalone}"/>
         </Button>
-        
+
         <ToggleButton Classes="line_path"
                       Width="28" Height="28"
                       Padding="0"

--- a/src/Views/Histories.axaml.cs
+++ b/src/Views/Histories.axaml.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Text;
@@ -344,6 +344,15 @@ namespace SourceGit.Views
         {
             get => GetValue(OnlyHighlightCurrentBranchProperty);
             set => SetValue(OnlyHighlightCurrentBranchProperty, value);
+        }
+
+        public static readonly StyledProperty<bool> HighlightSelectedLineageProperty =
+            AvaloniaProperty.Register<Histories, bool>(nameof(HighlightSelectedLineage), false);
+
+        public bool HighlightSelectedLineage
+        {
+            get => GetValue(HighlightSelectedLineageProperty);
+            set => SetValue(HighlightSelectedLineageProperty, value);
         }
 
         public static readonly StyledProperty<bool> IsScrollToTopVisibleProperty =

--- a/src/Views/Histories.axaml.cs
+++ b/src/Views/Histories.axaml.cs
@@ -241,6 +241,12 @@ namespace SourceGit.Views
             if (DataContext is not ViewModels.Histories vm)
                 return;
 
+            if (!ViewModels.Preferences.Instance.EnableHoverViewTracking)
+            {
+                vm.HoveredCommitIndex = -1;
+                return;
+            }
+
             var point = e.GetPosition(this);
             var row = (this.InputHitTest(point) as Visual)?.FindAncestorOfType<DataGridRow>();
             if (row != null)

--- a/src/Views/Histories.axaml.cs
+++ b/src/Views/Histories.axaml.cs
@@ -234,6 +234,33 @@ namespace SourceGit.Views
                 base.OnKeyDown(e);
         }
 
+        protected override void OnPointerMoved(PointerEventArgs e)
+        {
+            base.OnPointerMoved(e);
+
+            if (DataContext is not ViewModels.Histories vm)
+                return;
+
+            var point = e.GetPosition(this);
+            var row = (this.InputHitTest(point) as Visual)?.FindAncestorOfType<DataGridRow>();
+            if (row != null)
+            {
+                var index = (long)row.Index;
+                vm.HoveredCommitIndex = index;
+            }
+            else
+            {
+                vm.HoveredCommitIndex = -1;
+            }
+        }
+
+        protected override void OnPointerExited(PointerEventArgs e)
+        {
+            base.OnPointerExited(e);
+            if (DataContext is ViewModels.Histories vm)
+                vm.HoveredCommitIndex = -1;
+        }
+
         private void ApplySelection()
         {
             _ignoreSelectionChanged = true;

--- a/src/Views/Histories.axaml.cs
+++ b/src/Views/Histories.axaml.cs
@@ -498,6 +498,31 @@ namespace SourceGit.Views
             menu.Items.Add(currentBranchOnly);
             menu.Items.Add(selectedCommitsOnly);
             menu.Items.Add(currentBranchAndSelectedCommits);
+            menu.Items.Add(new MenuItem() { Header = "-" });
+
+            var methodHeader = new MenuItem();
+            methodHeader.Header = new TextBlock() { Text = App.Text("Histories.Header.Highlights.LineageMethod"), FontWeight = FontWeight.Bold };
+            methodHeader.IsEnabled = false;
+            menu.Items.Add(methodHeader);
+
+            var parentsOnly = new MenuItem();
+            parentsOnly.Header = App.Text("Histories.Header.Highlights.LineageMethod.ParentsOnly");
+            parentsOnly.Icon = vm.LineageSearchMethod == Models.CommitLineageSearchMethod.ParentsOnly ? this.CreateMenuIcon("Icons.Check") : null;
+            parentsOnly.Click += (_, _) => vm.LineageSearchMethod = Models.CommitLineageSearchMethod.ParentsOnly;
+            menu.Items.Add(parentsOnly);
+
+            var childsOnly = new MenuItem();
+            childsOnly.Header = App.Text("Histories.Header.Highlights.LineageMethod.ChildsOnly");
+            childsOnly.Icon = vm.LineageSearchMethod == Models.CommitLineageSearchMethod.ChildsOnly ? this.CreateMenuIcon("Icons.Check") : null;
+            childsOnly.Click += (_, _) => vm.LineageSearchMethod = Models.CommitLineageSearchMethod.ChildsOnly;
+            menu.Items.Add(childsOnly);
+
+            var fullLineage = new MenuItem();
+            fullLineage.Header = App.Text("Histories.Header.Highlights.LineageMethod.FullLineage");
+            fullLineage.Icon = vm.LineageSearchMethod == Models.CommitLineageSearchMethod.FullLineage ? this.CreateMenuIcon("Icons.Check") : null;
+            fullLineage.Click += (_, _) => vm.LineageSearchMethod = Models.CommitLineageSearchMethod.FullLineage;
+            menu.Items.Add(fullLineage);
+
             menu.Open(button);
 
             e.Handled = true;

--- a/src/Views/Histories.axaml.cs
+++ b/src/Views/Histories.axaml.cs
@@ -469,6 +469,9 @@ namespace SourceGit.Views
             if (!IsLoaded)
                 return;
 
+            if (DataContext is not ViewModels.Histories vm)
+                return;
+
             var dataGrid = CommitListContainer;
             var rowsPresenter = dataGrid.FindDescendantOfType<DataGridRowsPresenter>();
             if (rowsPresenter == null)
@@ -476,11 +479,18 @@ namespace SourceGit.Views
 
             double rowHeight = dataGrid.RowHeight;
             double startY = 0;
+            var visibleTopIndex = int.MaxValue;
+            var visibleBottomIndex = -1;
             foreach (var child in rowsPresenter.Children)
             {
                 if (child is DataGridRow { IsVisible: true } row)
                 {
                     rowHeight = row.Bounds.Height;
+                    if (row.Index < visibleTopIndex)
+                        visibleTopIndex = row.Index;
+
+                    if (row.Index > visibleBottomIndex)
+                        visibleBottomIndex = row.Index;
 
                     if (row.Bounds.Top <= 0 && row.Bounds.Top > -rowHeight)
                     {
@@ -490,6 +500,11 @@ namespace SourceGit.Views
                     }
                 }
             }
+
+            if (visibleBottomIndex >= visibleTopIndex)
+                vm.SetVisibleCommitRange(visibleTopIndex, visibleBottomIndex);
+            else
+                vm.SetVisibleCommitRange(-1, -1);
 
             SetCurrentValue(IsScrollToTopVisibleProperty, startY >= rowHeight);
 

--- a/src/Views/Histories.axaml.cs
+++ b/src/Views/Histories.axaml.cs
@@ -343,22 +343,13 @@ namespace SourceGit.Views
             set => SetValue(IssueTrackersProperty, value);
         }
 
-        public static readonly StyledProperty<bool> OnlyHighlightCurrentBranchProperty =
-            AvaloniaProperty.Register<Histories, bool>(nameof(OnlyHighlightCurrentBranch), true);
+        public static readonly StyledProperty<Models.CommitGraphHighlighting> CommitGraphHighlightingProperty =
+            AvaloniaProperty.Register<Histories, Models.CommitGraphHighlighting>(nameof(CommitGraphHighlighting), Models.CommitGraphHighlighting.All);
 
-        public bool OnlyHighlightCurrentBranch
+        public Models.CommitGraphHighlighting CommitGraphHighlighting
         {
-            get => GetValue(OnlyHighlightCurrentBranchProperty);
-            set => SetValue(OnlyHighlightCurrentBranchProperty, value);
-        }
-
-        public static readonly StyledProperty<bool> HighlightSelectedLineageProperty =
-            AvaloniaProperty.Register<Histories, bool>(nameof(HighlightSelectedLineage), false);
-
-        public bool HighlightSelectedLineage
-        {
-            get => GetValue(HighlightSelectedLineageProperty);
-            set => SetValue(HighlightSelectedLineageProperty, value);
+            get => GetValue(CommitGraphHighlightingProperty);
+            set => SetValue(CommitGraphHighlightingProperty, value);
         }
 
         public static readonly StyledProperty<bool> IsScrollToTopVisibleProperty =
@@ -468,6 +459,48 @@ namespace SourceGit.Views
                 if (c != null)
                     vm.NavigateTo(c.SHA);
             }
+        }
+
+        private void OnHighlightsClicked(object sender, RoutedEventArgs e)
+        {
+            if (DataContext is not ViewModels.Histories vm || sender is not Control button)
+                return;
+
+            var all = new MenuItem();
+            all.Header = App.Text("Histories.Header.Highlights.All");
+            all.Icon = vm.CommitGraphHighlighting == Models.CommitGraphHighlighting.All ? this.CreateMenuIcon("Icons.Check") : null;
+            all.Click += (_, _) => vm.CommitGraphHighlighting = Models.CommitGraphHighlighting.All;
+
+            var currentBranchOnly = new MenuItem();
+            currentBranchOnly.Header = App.Text("Histories.Header.Highlights.CurrentBranchOnly");
+            currentBranchOnly.Icon = vm.CommitGraphHighlighting == Models.CommitGraphHighlighting.CurrentBranchOnly ? this.CreateMenuIcon("Icons.Check") : null;
+            currentBranchOnly.Click += (_, _) => vm.CommitGraphHighlighting = Models.CommitGraphHighlighting.CurrentBranchOnly;
+
+            var selectedCommitsOnly = new MenuItem();
+            selectedCommitsOnly.Header = App.Text("Histories.Header.Highlights.SelectedLineageOnly");
+            selectedCommitsOnly.Icon = vm.CommitGraphHighlighting == Models.CommitGraphHighlighting.SelectedLineageOnly ? this.CreateMenuIcon("Icons.Check") : null;
+            selectedCommitsOnly.Click += (_, _) => vm.CommitGraphHighlighting = Models.CommitGraphHighlighting.SelectedLineageOnly;
+
+            var currentBranchAndSelectedCommits = new MenuItem();
+            currentBranchAndSelectedCommits.Header = App.Text("Histories.Header.Highlights.CurrentBranchAndSelectedLineage");
+            currentBranchAndSelectedCommits.Icon = vm.CommitGraphHighlighting == Models.CommitGraphHighlighting.CurrentBranchAndSelectedLineage ? this.CreateMenuIcon("Icons.Check") : null;
+            currentBranchAndSelectedCommits.Click += (_, _) => vm.CommitGraphHighlighting = Models.CommitGraphHighlighting.CurrentBranchAndSelectedLineage;
+
+            var menu = new ContextMenu();
+            menu.Placement = PlacementMode.BottomEdgeAlignedLeft;
+
+            var modeHeader = new MenuItem();
+            modeHeader.Header = new TextBlock() { Text = App.Text("Histories.Header.Highlights"), FontWeight = FontWeight.Bold };
+            modeHeader.IsEnabled = false;
+            menu.Items.Add(modeHeader);
+
+            menu.Items.Add(all);
+            menu.Items.Add(currentBranchOnly);
+            menu.Items.Add(selectedCommitsOnly);
+            menu.Items.Add(currentBranchAndSelectedCommits);
+            menu.Open(button);
+
+            e.Handled = true;
         }
 
         private void OnCommitListLayoutUpdated(object _1, EventArgs _2)

--- a/src/Views/Preferences.axaml
+++ b/src/Views/Preferences.axaml
@@ -145,7 +145,7 @@
                       Height="32"
                       Content="{DynamicResource Text.Preferences.General.ShowChangesPageByDefault}"
                       IsChecked="{Binding ShowLocalChangesByDefault, Mode=TwoWay}"/>
-            
+
             <CheckBox Grid.Row="6" Grid.Column="1"
                       Height="32"
                       Content="{DynamicResource Text.Preferences.General.ShowChangesTabInCommitDetailByDefault}"
@@ -188,7 +188,7 @@
           <TabItem.Header>
             <TextBlock Classes="tab_header" Text="{DynamicResource Text.Preferences.Appearance}"/>
           </TabItem.Header>
-          <Grid Margin="8" RowDefinitions="32,32,32,32,32,32,32,32,Auto" ColumnDefinitions="Auto,*">
+          <Grid Margin="8" RowDefinitions="32,32,32,32,32,32,32,32,32,Auto" ColumnDefinitions="Auto,*">
             <TextBlock Grid.Row="0" Grid.Column="0"
                        Text="{DynamicResource Text.Preferences.Appearance.Theme}"
                        HorizontalAlignment="Right"
@@ -296,6 +296,11 @@
                       IsChecked="{Binding UseAutoHideScrollBars, Mode=TwoWay}"/>
 
             <CheckBox Grid.Row="8" Grid.Column="1"
+                      Height="32"
+                      Content="{DynamicResource Text.Preferences.Appearance.EnableHoverViewTracking}"
+                      IsChecked="{Binding EnableHoverViewTracking, Mode=TwoWay}"/>
+
+            <CheckBox Grid.Row="9" Grid.Column="1"
                       Height="32"
                       Content="{DynamicResource Text.Preferences.Appearance.UseNativeWindowFrame}"
                       IsChecked="{Binding UseSystemWindowFrame, Mode=OneTime}"

--- a/src/Views/Repository.axaml
+++ b/src/Views/Repository.axaml
@@ -109,11 +109,19 @@
                                 Classes="line_path"
                                 Width="26" Height="26"
                                 Background="Transparent"
+                                IsChecked="{Binding HighlightSelectedLineageInHistory, Mode=TwoWay}"
+                                ToolTip.Tip="{DynamicResource Text.Repository.HighlightSelectedLineageInGraph}">
+                    <Path Width="12" Height="12" Data="{StaticResource Icons.Connect}"/>
+                  </ToggleButton>
+                  <ToggleButton Grid.Column="4"
+                                Classes="line_path"
+                                Width="26" Height="26"
+                                Background="Transparent"
                                 IsChecked="{Binding Source={x:Static vm:Preferences.Instance}, Path=DisplayTimeAsPeriodInHistories, Mode=TwoWay}"
                                 ToolTip.Tip="{DynamicResource Text.Repository.UseRelativeTimeInGraph}">
                     <Path Width="12" Height="12" Data="{StaticResource Icons.Stopwatch}"/>
                   </ToggleButton>
-                  <Button Grid.Column="4"
+                  <Button Grid.Column="5"
                           Classes="icon_button"
                           Width="26" Height="26"
                           Click="OnOpenAdvancedHistoriesOption"
@@ -424,7 +432,7 @@
                 <Setter Property="CornerRadius" Value="4"/>
               </Style>
             </ListBox.Styles>
-            <ListBox.ItemTemplate>              
+            <ListBox.ItemTemplate>
               <DataTemplate DataType="vm:Worktree">
                 <Border Height="24"
                         Background="Transparent"
@@ -450,7 +458,7 @@
                         <TextBlock Grid.Row="0" Grid.Column="3"
                                    Margin="6,0,0,0"
                                    Text="{Binding Branch, Mode=OneWay}"/>
-                        
+
                         <TextBlock Grid.Row="1" Grid.Column="0"
                                    Classes="info_label"
                                    HorizontalAlignment="Left" VerticalAlignment="Center"

--- a/src/Views/Repository.axaml
+++ b/src/Views/Repository.axaml
@@ -93,7 +93,7 @@
               </ListBox.ItemsPanel>
 
               <ListBoxItem BorderThickness="0">
-                <Grid Classes="view_mode" ColumnDefinitions="Auto,*,Auto,Auto,Auto">
+                <Grid Classes="view_mode" ColumnDefinitions="Auto,*,Auto,Auto">
                   <Path Grid.Column="0" Classes="icon" Data="{StaticResource Icons.Histories}"/>
                   <TextBlock Grid.Column="1" Classes="header" Text="{DynamicResource Text.Histories}"/>
 
@@ -101,27 +101,11 @@
                                 Classes="line_path"
                                 Width="26" Height="26"
                                 Background="Transparent"
-                                IsChecked="{Binding HighlightCurrentBranchOnlyInHistory, Mode=TwoWay}"
-                                ToolTip.Tip="{DynamicResource Text.Repository.OnlyHighlightCurrentBranchInGraph}">
-                    <Path Width="12" Height="12" Data="{StaticResource Icons.LightOn}"/>
-                  </ToggleButton>
-                  <ToggleButton Grid.Column="3"
-                                Classes="line_path"
-                                Width="26" Height="26"
-                                Background="Transparent"
-                                IsChecked="{Binding HighlightSelectedLineageInHistory, Mode=TwoWay}"
-                                ToolTip.Tip="{DynamicResource Text.Repository.HighlightSelectedLineageInGraph}">
-                    <Path Width="12" Height="12" Data="{StaticResource Icons.Connect}"/>
-                  </ToggleButton>
-                  <ToggleButton Grid.Column="4"
-                                Classes="line_path"
-                                Width="26" Height="26"
-                                Background="Transparent"
                                 IsChecked="{Binding Source={x:Static vm:Preferences.Instance}, Path=DisplayTimeAsPeriodInHistories, Mode=TwoWay}"
                                 ToolTip.Tip="{DynamicResource Text.Repository.UseRelativeTimeInGraph}">
                     <Path Width="12" Height="12" Data="{StaticResource Icons.Stopwatch}"/>
                   </ToggleButton>
-                  <Button Grid.Column="5"
+                  <Button Grid.Column="3"
                           Classes="icon_button"
                           Width="26" Height="26"
                           Click="OnOpenAdvancedHistoriesOption"
@@ -934,7 +918,7 @@
               <v:Histories CurrentBranch="{Binding CurrentBranch, Mode=OneWay}"
                            Bisect="{Binding Bisect, Mode=OneWay}"
                            IssueTrackers="{Binding IssueTrackers, Mode=OneWay}"
-                           OnlyHighlightCurrentBranch="{Binding HighlightCurrentBranchOnly, Mode=OneWay}">
+                           CommitGraphHighlighting="{Binding CommitGraphHighlighting, Mode=OneWay}">
                 <v:Histories.IsDetailsPanelExpanded>
                   <MultiBinding Converter="{x:Static BoolConverters.Or}">
                     <Binding Source="{x:Static vm:Preferences.Instance}" Path="UseTwoColumnsLayoutInHistories" Mode="OneWay"/>
@@ -979,3 +963,4 @@
     </Border>
   </Grid>
 </UserControl>
+


### PR DESCRIPTION
## 背景
在提交历史视图中，用户很难快速判断一个提交与其祖先/后代的关系，尤其在 merge 较多时。这个 PR 引入“提交血缘高亮”能力，支持：
- 选中提交后高亮其血缘路径
- 鼠标悬停提交时即时预览其血缘路径
- 在仓库页提供可开关的配置项

## 设计思路
核心目标是把“血缘关系”从数据层、状态层、渲染层、交互层分离，保证功能可扩展且编译/行为稳定。

1. 索引层（Index Mapping）
- 建立 `SHA -> Commit` 映射与 `ParentSHA -> Children` 反向映射，避免每次查询线性扫描。
- 为 `Commit` 与图形元素记录稳定的索引（`Commit.Index` / `PathIndex` / `StartCommitIndex` / `EndCommitIndex`），把“图上元素”与“历史列表项”连接起来。

2. 查询层（Lineage Query）
- 使用 BFS 分别向上（祖先）和向下（后代）搜索。
- 通过 `visited` 集合去重，避免在复杂图中重复遍历。
- 增加深度上限，控制最坏情况开销，避免大仓库下 UI 卡顿。

3. 状态层（ViewModel State）
- 新增悬停与选中两套 lineage 状态集合，分别驱动临时预览与稳定高亮。
- 在选中项变化时异步计算目标 lineage，计算完成后回到 UI 线程更新，避免阻塞界面。

4. 渲染层（Graph Rendering）
- 在 `CommitGraph` 中根据 lineage 状态提升路径/连线可视权重（线宽与显著度）。
- 与“仅高亮当前分支”策略兼容：非目标路径按灰化处理，目标 lineage 保留强调。

5. 交互层（Hover + Toggle）
- 悬停时把 DataGrid 行索引映射为提交索引，触发 lineage 预览。
- 通过仓库级 UI 配置项开启/关闭选中 lineage 高亮，默认行为可控。

## 方法与关键实现
- 数据结构：`Dictionary<string, Commit>`、`Dictionary<string, List<Commit>>`、`HashSet<int>`
- 遍历算法：双向 BFS（parents/children）
- 并发策略：`Task.Run` 计算 + `Dispatcher.UIThread.Post` 回写
- 复杂度（单次查询）：
  - 时间：约 `O(V + E)`（受 depth 限制）
  - 空间：约 `O(V)`（队列 + visited + 结果集合）

## 提交拆分
本 PR 按“可独立编译 + 渐进集成”拆分为 6 个提交：
1. `feat(CommitGraph): add index tracking for paths and links`
2. `feat(Histories): add commit lineage query engine`
3. `feat(Histories,CommitGraph): add lineage state management`
4. `feat(CommitGraph): implement lineage highlight rendering`
5. `feat(Histories): add hover-based lineage highlighting interaction`
6. `feat(Histories,Repository): add UI configuration for lineage highlighting`

## 验证方式
- 构建验证：`dotnet build SourceGit.slnx` 通过
- 功能验证：
  - 单选提交后，图中血缘路径被正确高亮
  - 鼠标悬停不同提交时，预览路径实时切换
  - 切换配置项后，高亮开关行为符合预期

## 影响范围
- 主要影响 History/CommitGraph 相关模块与 Repository 配置入口。
- 对现有 Git 命令执行链无侵入，仅新增图查询与可视化增强逻辑。

## 风险与后续优化建议
- 大型仓库下 hover 高频触发仍可能带来额外计算成本。
- 后续可考虑：
  - lineage 结果缓存（LRU）
  - hover 防抖 + 任务取消
  - 使用边集合直接驱动高亮以提升精确性