### PR TITLE
ux: Add config option to show containing refs directly in the commit detail view

### DIFF
--- a/src/Converters/DoubleConverters.cs
+++ b/src/Converters/DoubleConverters.cs
@@ -19,5 +19,8 @@ namespace SourceGit.Converters
 
         public static readonly FuncValueConverter<double, Thickness> ToLeftMargin =
             new FuncValueConverter<double, Thickness>(v => new Thickness(v, 0, 0, 0));
+
+        public static readonly FuncValueConverter<bool, double> ToContainingRefsMaxHeight =
+            new FuncValueConverter<bool, double>(v => v ? double.PositiveInfinity : 24.0);
     }
 }

--- a/src/Models/RepositorySettings.cs
+++ b/src/Models/RepositorySettings.cs
@@ -36,6 +36,18 @@ namespace SourceGit.Models
             set;
         } = false;
 
+        public int ShowContainingRefsInCommitDetail
+        {
+            get;
+            set;
+        } = 0;
+
+        public int ContainingRefsDefaultExpansion
+        {
+            get;
+            set;
+        } = 0;
+
         public string PreferredOpenAIService
         {
             get;

--- a/src/Resources/Locales/de_DE.axaml
+++ b/src/Resources/Locales/de_DE.axaml
@@ -173,6 +173,7 @@
   <x:String x:Key="Text.CommitDetail.Info.Committer" xml:space="preserve">COMMITTER</x:String>
   <x:String x:Key="Text.CommitDetail.Info.ContainsIn" xml:space="preserve">Prüfe Refs, die diesen Commit enthalten</x:String>
   <x:String x:Key="Text.CommitDetail.Info.ContainsIn.Title" xml:space="preserve">COMMIT ENTHALTEN IN</x:String>
+  <x:String x:Key="Text.CommitDetail.Info.ContainsIn.TableTitle" xml:space="preserve">ENTHALTEN IN</x:String>
   <x:String x:Key="Text.CommitDetail.Info.CopyEmail" xml:space="preserve">E-Mail-Adresse kopieren</x:String>
   <x:String x:Key="Text.CommitDetail.Info.CopyName" xml:space="preserve">Namen kopieren</x:String>
   <x:String x:Key="Text.CommitDetail.Info.CopyNameAndEmail" xml:space="preserve">Namen &amp; E-Mail-Adresse kopieren</x:String>
@@ -620,6 +621,7 @@ $1, $2, … Werte der Eingabe-Steuerelemente</x:String>
   <x:String x:Key="Text.Preferences.General.ShowChangesPageByDefault" xml:space="preserve">Standardmäßig ‚ÄNDERUNGEN‘-Ansicht anzeigen</x:String>
   <x:String x:Key="Text.Preferences.General.ShowChangesTabInCommitDetailByDefault" xml:space="preserve">Standardmäßig Registerkarte ‚ÄNDERUNGEN‘ in Commit-Details anzeigen</x:String>
   <x:String x:Key="Text.Preferences.General.ShowChildren" xml:space="preserve">Zeige Nachfolger in den Commit-Details</x:String>
+  <x:String x:Key="Text.Preferences.General.ShowContainingRefsInCommitDetail" xml:space="preserve">Referenzen mit ausgewähltem Commit in den Commit-Details anzeigen</x:String>
   <x:String x:Key="Text.Preferences.General.ShowTagsInGraph" xml:space="preserve">Zeige Tags im Commit-Verlauf</x:String>
   <x:String x:Key="Text.Preferences.General.SubjectGuideLength" xml:space="preserve">Längenvorgabe für Commit-Nachrichten</x:String>
   <x:String x:Key="Text.Preferences.General.UseGitHubStyleAvatar" xml:space="preserve">Standard-Avatar im GitHub-Stil generieren</x:String>

--- a/src/Resources/Locales/de_DE.axaml
+++ b/src/Resources/Locales/de_DE.axaml
@@ -226,6 +226,14 @@ $1, $2, … Werte der Eingabe-Steuerelemente</x:String>
   <x:String x:Key="Text.Configure.CustomAction.WaitForExit" xml:space="preserve">Auf Beenden der Aktion warten</x:String>
   <x:String x:Key="Text.Configure.Email" xml:space="preserve">E-Mail-Adresse</x:String>
   <x:String x:Key="Text.Configure.Email.Placeholder" xml:space="preserve">E-Mail-Adresse</x:String>
+  <x:String x:Key="Text.Configure.General" xml:space="preserve">ALLGEMEIN</x:String>
+  <x:String x:Key="Text.Configure.General.ContainingRefs.Collapsed" xml:space="preserve">Eingeklappt</x:String>
+  <x:String x:Key="Text.Configure.General.ContainingRefs.Disabled" xml:space="preserve">Deaktiviert</x:String>
+  <x:String x:Key="Text.Configure.General.ContainingRefs.Enabled" xml:space="preserve">Aktiviert</x:String>
+  <x:String x:Key="Text.Configure.General.ContainingRefs.Expanded" xml:space="preserve">Ausgeklappt</x:String>
+  <x:String x:Key="Text.Configure.General.ContainingRefs.Inherit" xml:space="preserve">Globale Einstellung übernehmen</x:String>
+  <x:String x:Key="Text.Configure.General.ContainingRefsDefaultExpansion" xml:space="preserve">Standardzustand der enthaltenen Referenzen</x:String>
+  <x:String x:Key="Text.Configure.General.ShowContainingRefsInCommitDetail" xml:space="preserve">Referenzen anzeigen, die den ausgewählten Commit enthalten</x:String>
   <x:String x:Key="Text.Configure.Git" xml:space="preserve">GIT</x:String>
   <x:String x:Key="Text.Configure.Git.AskBeforeAutoUpdatingSubmodules" xml:space="preserve">Vor dem Auto-Aktualisieren von Submodulen fragen</x:String>
   <x:String x:Key="Text.Configure.Git.AutoFetch" xml:space="preserve">Remotes automatisch fetchen</x:String>
@@ -621,6 +629,7 @@ $1, $2, … Werte der Eingabe-Steuerelemente</x:String>
   <x:String x:Key="Text.Preferences.General.ShowChangesPageByDefault" xml:space="preserve">Standardmäßig ‚ÄNDERUNGEN‘-Ansicht anzeigen</x:String>
   <x:String x:Key="Text.Preferences.General.ShowChangesTabInCommitDetailByDefault" xml:space="preserve">Standardmäßig Registerkarte ‚ÄNDERUNGEN‘ in Commit-Details anzeigen</x:String>
   <x:String x:Key="Text.Preferences.General.ShowChildren" xml:space="preserve">Zeige Nachfolger in den Commit-Details</x:String>
+  <x:String x:Key="Text.Preferences.General.ShowContainingRefsExpandedByDefault" xml:space="preserve">Referenzen mit ausgewähltem Commit standardmäßig ausklappen</x:String>
   <x:String x:Key="Text.Preferences.General.ShowContainingRefsInCommitDetail" xml:space="preserve">Referenzen mit ausgewähltem Commit in den Commit-Details anzeigen</x:String>
   <x:String x:Key="Text.Preferences.General.ShowTagsInGraph" xml:space="preserve">Zeige Tags im Commit-Verlauf</x:String>
   <x:String x:Key="Text.Preferences.General.SubjectGuideLength" xml:space="preserve">Längenvorgabe für Commit-Nachrichten</x:String>

--- a/src/Resources/Locales/en_US.axaml
+++ b/src/Resources/Locales/en_US.axaml
@@ -243,6 +243,14 @@
   <x:String x:Key="Text.Configure.CustomAction.WaitForExit" xml:space="preserve">Wait for action exit</x:String>
   <x:String x:Key="Text.Configure.Email" xml:space="preserve">Email Address</x:String>
   <x:String x:Key="Text.Configure.Email.Placeholder" xml:space="preserve">Email address</x:String>
+  <x:String x:Key="Text.Configure.General" xml:space="preserve">GENERAL</x:String>
+  <x:String x:Key="Text.Configure.General.ContainingRefs.Collapsed" xml:space="preserve">Collapsed</x:String>
+  <x:String x:Key="Text.Configure.General.ContainingRefs.Disabled" xml:space="preserve">Disabled</x:String>
+  <x:String x:Key="Text.Configure.General.ContainingRefs.Enabled" xml:space="preserve">Enabled</x:String>
+  <x:String x:Key="Text.Configure.General.ContainingRefs.Expanded" xml:space="preserve">Expanded</x:String>
+  <x:String x:Key="Text.Configure.General.ContainingRefs.Inherit" xml:space="preserve">Inherit global preference</x:String>
+  <x:String x:Key="Text.Configure.General.ContainingRefsDefaultExpansion" xml:space="preserve">Contained-by refs default state</x:String>
+  <x:String x:Key="Text.Configure.General.ShowContainingRefsInCommitDetail" xml:space="preserve">Show refs containing selected commit</x:String>
   <x:String x:Key="Text.Configure.Git" xml:space="preserve">GIT</x:String>
   <x:String x:Key="Text.Configure.Git.AskBeforeAutoUpdatingSubmodules" xml:space="preserve">Ask before auto-updating submodules</x:String>
   <x:String x:Key="Text.Configure.Git.AutoFetch" xml:space="preserve">Fetch remotes automatically</x:String>
@@ -667,6 +675,7 @@
   <x:String x:Key="Text.Preferences.General.ShowChangesPageByDefault" xml:space="preserve">Show `LOCAL CHANGES` page by default</x:String>
   <x:String x:Key="Text.Preferences.General.ShowChangesTabInCommitDetailByDefault" xml:space="preserve">Show `CHANGES` tab in commit detail by default</x:String>
   <x:String x:Key="Text.Preferences.General.ShowChildren" xml:space="preserve">Show children in the commit details</x:String>
+  <x:String x:Key="Text.Preferences.General.ShowContainingRefsExpandedByDefault" xml:space="preserve">Expand refs containing selected commit by default</x:String>
   <x:String x:Key="Text.Preferences.General.ShowContainingRefsInCommitDetail" xml:space="preserve">Show refs containing selected commit in commit detail</x:String>
   <x:String x:Key="Text.Preferences.General.ShowRelativeTimeInGraph" xml:space="preserve">Show relative time in commit graph</x:String>
   <x:String x:Key="Text.Preferences.General.ShowTagsInGraph" xml:space="preserve">Show tags in commit graph</x:String>

--- a/src/Resources/Locales/en_US.axaml
+++ b/src/Resources/Locales/en_US.axaml
@@ -184,6 +184,7 @@
   <x:String x:Key="Text.CommitDetail.Info.Committer" xml:space="preserve">COMMITTER</x:String>
   <x:String x:Key="Text.CommitDetail.Info.ContainsIn" xml:space="preserve">Check refs that contains this commit</x:String>
   <x:String x:Key="Text.CommitDetail.Info.ContainsIn.Title" xml:space="preserve">COMMIT IS CONTAINED BY</x:String>
+  <x:String x:Key="Text.CommitDetail.Info.ContainsIn.TableTitle" xml:space="preserve">CONTAINED BY</x:String>
   <x:String x:Key="Text.CommitDetail.Info.CopyEmail" xml:space="preserve">Copy Email</x:String>
   <x:String x:Key="Text.CommitDetail.Info.CopyName" xml:space="preserve">Copy Name</x:String>
   <x:String x:Key="Text.CommitDetail.Info.CopyNameAndEmail" xml:space="preserve">Copy Name &amp; Email</x:String>
@@ -666,6 +667,7 @@
   <x:String x:Key="Text.Preferences.General.ShowChangesPageByDefault" xml:space="preserve">Show `LOCAL CHANGES` page by default</x:String>
   <x:String x:Key="Text.Preferences.General.ShowChangesTabInCommitDetailByDefault" xml:space="preserve">Show `CHANGES` tab in commit detail by default</x:String>
   <x:String x:Key="Text.Preferences.General.ShowChildren" xml:space="preserve">Show children in the commit details</x:String>
+  <x:String x:Key="Text.Preferences.General.ShowContainingRefsInCommitDetail" xml:space="preserve">Show refs containing selected commit in commit detail</x:String>
   <x:String x:Key="Text.Preferences.General.ShowRelativeTimeInGraph" xml:space="preserve">Show relative time in commit graph</x:String>
   <x:String x:Key="Text.Preferences.General.ShowTagsInGraph" xml:space="preserve">Show tags in commit graph</x:String>
   <x:String x:Key="Text.Preferences.General.SubjectGuideLength" xml:space="preserve">Subject Guide Length</x:String>

--- a/src/Resources/Locales/es_ES.axaml
+++ b/src/Resources/Locales/es_ES.axaml
@@ -187,6 +187,7 @@
   <x:String x:Key="Text.CommitDetail.Info.Committer" xml:space="preserve">COMMITTER</x:String>
   <x:String x:Key="Text.CommitDetail.Info.ContainsIn" xml:space="preserve">Ver refs que contienen este commit</x:String>
   <x:String x:Key="Text.CommitDetail.Info.ContainsIn.Title" xml:space="preserve">COMMIT ESTÁ CONTENIDO EN</x:String>
+  <x:String x:Key="Text.CommitDetail.Info.ContainsIn.TableTitle" xml:space="preserve">CONTENIDO EN</x:String>
   <x:String x:Key="Text.CommitDetail.Info.CopyEmail" xml:space="preserve">Copiar Email</x:String>
   <x:String x:Key="Text.CommitDetail.Info.CopyName" xml:space="preserve">Copiar Nombre</x:String>
   <x:String x:Key="Text.CommitDetail.Info.CopyNameAndEmail" xml:space="preserve">Copiar Nombre y Email</x:String>

--- a/src/Resources/Locales/es_ES.axaml
+++ b/src/Resources/Locales/es_ES.axaml
@@ -241,6 +241,14 @@
   <x:String x:Key="Text.Configure.CustomAction.WaitForExit" xml:space="preserve">Esperar la acción de salida</x:String>
   <x:String x:Key="Text.Configure.Email" xml:space="preserve">Dirección de Email</x:String>
   <x:String x:Key="Text.Configure.Email.Placeholder" xml:space="preserve">Dirección de email</x:String>
+  <x:String x:Key="Text.Configure.General" xml:space="preserve">GENERAL</x:String>
+  <x:String x:Key="Text.Configure.General.ContainingRefs.Collapsed" xml:space="preserve">Contraído</x:String>
+  <x:String x:Key="Text.Configure.General.ContainingRefs.Disabled" xml:space="preserve">Deshabilitado</x:String>
+  <x:String x:Key="Text.Configure.General.ContainingRefs.Enabled" xml:space="preserve">Habilitado</x:String>
+  <x:String x:Key="Text.Configure.General.ContainingRefs.Expanded" xml:space="preserve">Expandido</x:String>
+  <x:String x:Key="Text.Configure.General.ContainingRefs.Inherit" xml:space="preserve">Heredar preferencia global</x:String>
+  <x:String x:Key="Text.Configure.General.ContainingRefsDefaultExpansion" xml:space="preserve">Estado predeterminado de refs contenedoras</x:String>
+  <x:String x:Key="Text.Configure.General.ShowContainingRefsInCommitDetail" xml:space="preserve">Mostrar refs que contienen el commit seleccionado</x:String>
   <x:String x:Key="Text.Configure.Git" xml:space="preserve">GIT</x:String>
   <x:String x:Key="Text.Configure.Git.AskBeforeAutoUpdatingSubmodules" xml:space="preserve">Preguntar antes de actualizar automáticamente los submódulos</x:String>
   <x:String x:Key="Text.Configure.Git.AutoFetch" xml:space="preserve">Fetch remotos automáticamente</x:String>
@@ -653,6 +661,8 @@
   <x:String x:Key="Text.Preferences.General.ShowChangesPageByDefault" xml:space="preserve">Mostrar la página `CAMBIOS LOCALES` por defecto</x:String>
   <x:String x:Key="Text.Preferences.General.ShowChangesTabInCommitDetailByDefault" xml:space="preserve">Mostrar pestaña de `CAMBIOS` en los detalles del commit por defecto</x:String>
   <x:String x:Key="Text.Preferences.General.ShowChildren" xml:space="preserve">Mostrar hijos en los detalles de commit</x:String>
+  <x:String x:Key="Text.Preferences.General.ShowContainingRefsExpandedByDefault" xml:space="preserve">Expandir refs que contienen el commit seleccionado por defecto</x:String>
+  <x:String x:Key="Text.Preferences.General.ShowContainingRefsInCommitDetail" xml:space="preserve">Mostrar refs que contienen el commit seleccionado en los detalles del commit</x:String>
   <x:String x:Key="Text.Preferences.General.ShowTagsInGraph" xml:space="preserve">Mostrar etiquetas en el gráfico de commit</x:String>
   <x:String x:Key="Text.Preferences.General.SubjectGuideLength" xml:space="preserve">Longitud de la guía del asunto</x:String>
   <x:String x:Key="Text.Preferences.General.Use24Hours" xml:space="preserve">24-Horas</x:String>

--- a/src/Resources/Locales/fr_FR.axaml
+++ b/src/Resources/Locales/fr_FR.axaml
@@ -163,6 +163,7 @@
   <x:String x:Key="Text.CommitDetail.Info.Committer" xml:space="preserve">COMMITTER</x:String>
   <x:String x:Key="Text.CommitDetail.Info.ContainsIn" xml:space="preserve">Vérifier les références contenant ce commit</x:String>
   <x:String x:Key="Text.CommitDetail.Info.ContainsIn.Title" xml:space="preserve">LE COMMIT EST CONTENU PAR</x:String>
+  <x:String x:Key="Text.CommitDetail.Info.ContainsIn.TableTitle" xml:space="preserve">CONTENU PAR</x:String>
   <x:String x:Key="Text.CommitDetail.Info.CopyEmail" xml:space="preserve">Copier l'E-mail</x:String>
   <x:String x:Key="Text.CommitDetail.Info.CopyName" xml:space="preserve">Copier le Nom</x:String>
   <x:String x:Key="Text.CommitDetail.Info.CopyNameAndEmail" xml:space="preserve">Copier le Nom &amp; l'E-mail</x:String>
@@ -576,6 +577,7 @@
   <x:String x:Key="Text.Preferences.General.ShowChangesPageByDefault" xml:space="preserve">Afficher la page 'CHANGEMENTS LOCAUX' par défaut</x:String>
   <x:String x:Key="Text.Preferences.General.ShowChangesTabInCommitDetailByDefault" xml:space="preserve">Afficher l'onglet 'CHANGEMENTS' dans les détails du commit par défaut</x:String>
   <x:String x:Key="Text.Preferences.General.ShowChildren" xml:space="preserve">Afficher les enfants dans les détails du commit</x:String>
+  <x:String x:Key="Text.Preferences.General.ShowContainingRefsInCommitDetail" xml:space="preserve">Afficher les références contenant le commit sélectionné dans les détails du commit</x:String>
   <x:String x:Key="Text.Preferences.General.ShowTagsInGraph" xml:space="preserve">Afficher les tags dans le graphique des commits</x:String>
   <x:String x:Key="Text.Preferences.General.SubjectGuideLength" xml:space="preserve">Guide de longueur du sujet</x:String>
   <x:String x:Key="Text.Preferences.General.UseGitHubStyleAvatar" xml:space="preserve">Générer un avatar par défaut de style GitHub</x:String>

--- a/src/Resources/Locales/fr_FR.axaml
+++ b/src/Resources/Locales/fr_FR.axaml
@@ -215,6 +215,14 @@
   <x:String x:Key="Text.Configure.CustomAction.WaitForExit" xml:space="preserve">Attendre la fin de l'action</x:String>
   <x:String x:Key="Text.Configure.Email" xml:space="preserve">Adresse e-mail</x:String>
   <x:String x:Key="Text.Configure.Email.Placeholder" xml:space="preserve">Adresse e-mail</x:String>
+  <x:String x:Key="Text.Configure.General" xml:space="preserve">GÉNÉRAL</x:String>
+  <x:String x:Key="Text.Configure.General.ContainingRefs.Collapsed" xml:space="preserve">Réduit</x:String>
+  <x:String x:Key="Text.Configure.General.ContainingRefs.Disabled" xml:space="preserve">Désactivé</x:String>
+  <x:String x:Key="Text.Configure.General.ContainingRefs.Enabled" xml:space="preserve">Activé</x:String>
+  <x:String x:Key="Text.Configure.General.ContainingRefs.Expanded" xml:space="preserve">Développé</x:String>
+  <x:String x:Key="Text.Configure.General.ContainingRefs.Inherit" xml:space="preserve">Hériter de la préférence globale</x:String>
+  <x:String x:Key="Text.Configure.General.ContainingRefsDefaultExpansion" xml:space="preserve">État par défaut des références contenant le commit</x:String>
+  <x:String x:Key="Text.Configure.General.ShowContainingRefsInCommitDetail" xml:space="preserve">Afficher les références contenant le commit sélectionné</x:String>
   <x:String x:Key="Text.Configure.Git" xml:space="preserve">GIT</x:String>
   <x:String x:Key="Text.Configure.Git.AutoFetch" xml:space="preserve">Fetch les dépôts distants automatiquement</x:String>
   <x:String x:Key="Text.Configure.Git.AutoFetchIntervalSuffix" xml:space="preserve">minute(s)</x:String>
@@ -577,6 +585,7 @@
   <x:String x:Key="Text.Preferences.General.ShowChangesPageByDefault" xml:space="preserve">Afficher la page 'CHANGEMENTS LOCAUX' par défaut</x:String>
   <x:String x:Key="Text.Preferences.General.ShowChangesTabInCommitDetailByDefault" xml:space="preserve">Afficher l'onglet 'CHANGEMENTS' dans les détails du commit par défaut</x:String>
   <x:String x:Key="Text.Preferences.General.ShowChildren" xml:space="preserve">Afficher les enfants dans les détails du commit</x:String>
+  <x:String x:Key="Text.Preferences.General.ShowContainingRefsExpandedByDefault" xml:space="preserve">Développer par défaut les références contenant le commit sélectionné</x:String>
   <x:String x:Key="Text.Preferences.General.ShowContainingRefsInCommitDetail" xml:space="preserve">Afficher les références contenant le commit sélectionné dans les détails du commit</x:String>
   <x:String x:Key="Text.Preferences.General.ShowTagsInGraph" xml:space="preserve">Afficher les tags dans le graphique des commits</x:String>
   <x:String x:Key="Text.Preferences.General.SubjectGuideLength" xml:space="preserve">Guide de longueur du sujet</x:String>

--- a/src/Resources/Locales/id_ID.axaml
+++ b/src/Resources/Locales/id_ID.axaml
@@ -203,6 +203,14 @@
   <x:String x:Key="Text.Configure.CustomAction.WaitForExit" xml:space="preserve">Tunggu aksi selesai</x:String>
   <x:String x:Key="Text.Configure.Email" xml:space="preserve">Alamat Email</x:String>
   <x:String x:Key="Text.Configure.Email.Placeholder" xml:space="preserve">Alamat email</x:String>
+  <x:String x:Key="Text.Configure.General" xml:space="preserve">UMUM</x:String>
+  <x:String x:Key="Text.Configure.General.ContainingRefs.Collapsed" xml:space="preserve">Diciutkan</x:String>
+  <x:String x:Key="Text.Configure.General.ContainingRefs.Disabled" xml:space="preserve">Dinonaktifkan</x:String>
+  <x:String x:Key="Text.Configure.General.ContainingRefs.Enabled" xml:space="preserve">Diaktifkan</x:String>
+  <x:String x:Key="Text.Configure.General.ContainingRefs.Expanded" xml:space="preserve">Diperluas</x:String>
+  <x:String x:Key="Text.Configure.General.ContainingRefs.Inherit" xml:space="preserve">Ikuti preferensi global</x:String>
+  <x:String x:Key="Text.Configure.General.ContainingRefsDefaultExpansion" xml:space="preserve">Status default ref yang memuat commit</x:String>
+  <x:String x:Key="Text.Configure.General.ShowContainingRefsInCommitDetail" xml:space="preserve">Tampilkan ref yang memuat commit terpilih</x:String>
   <x:String x:Key="Text.Configure.Git" xml:space="preserve">GIT</x:String>
   <x:String x:Key="Text.Configure.Git.AutoFetch" xml:space="preserve">Fetch remote secara otomatis</x:String>
   <x:String x:Key="Text.Configure.Git.AutoFetchIntervalSuffix" xml:space="preserve">Menit</x:String>
@@ -555,6 +563,8 @@
   <x:String x:Key="Text.Preferences.General.ShowChangesPageByDefault" xml:space="preserve">Tampilkan halaman `LOCAL CHANGES` secara default</x:String>
   <x:String x:Key="Text.Preferences.General.ShowChangesTabInCommitDetailByDefault" xml:space="preserve">Tampilkan tab `CHANGES` di detail commit secara default</x:String>
   <x:String x:Key="Text.Preferences.General.ShowChildren" xml:space="preserve">Tampilkan children di detail commit</x:String>
+  <x:String x:Key="Text.Preferences.General.ShowContainingRefsExpandedByDefault" xml:space="preserve">Perluas ref yang memuat commit terpilih secara default</x:String>
+  <x:String x:Key="Text.Preferences.General.ShowContainingRefsInCommitDetail" xml:space="preserve">Tampilkan ref yang memuat commit terpilih di detail commit</x:String>
   <x:String x:Key="Text.Preferences.General.ShowTagsInGraph" xml:space="preserve">Tampilkan tag di grafik commit</x:String>
   <x:String x:Key="Text.Preferences.General.SubjectGuideLength" xml:space="preserve">Panjang Panduan Subjek</x:String>
   <x:String x:Key="Text.Preferences.General.UseGitHubStyleAvatar" xml:space="preserve">Generate avatar default bergaya GitHub</x:String>

--- a/src/Resources/Locales/id_ID.axaml
+++ b/src/Resources/Locales/id_ID.axaml
@@ -159,6 +159,7 @@
   <x:String x:Key="Text.CommitDetail.Info.Committer" xml:space="preserve">COMMITTER</x:String>
   <x:String x:Key="Text.CommitDetail.Info.ContainsIn" xml:space="preserve">Periksa ref yang mengandung commit ini</x:String>
   <x:String x:Key="Text.CommitDetail.Info.ContainsIn.Title" xml:space="preserve">COMMIT TERKANDUNG DALAM</x:String>
+  <x:String x:Key="Text.CommitDetail.Info.ContainsIn.TableTitle" xml:space="preserve">TERKANDUNG DALAM</x:String>
   <x:String x:Key="Text.CommitDetail.Info.CopyEmail" xml:space="preserve">Salin Email</x:String>
   <x:String x:Key="Text.CommitDetail.Info.CopyName" xml:space="preserve">Salin Nama</x:String>
   <x:String x:Key="Text.CommitDetail.Info.CopyNameAndEmail" xml:space="preserve">Salin Nama &amp; Email</x:String>

--- a/src/Resources/Locales/it_IT.axaml
+++ b/src/Resources/Locales/it_IT.axaml
@@ -225,6 +225,14 @@ ${pure_files:N} Come ${files:N}, ma senza cartelle</x:String>
   <x:String x:Key="Text.Configure.CustomAction.WaitForExit" xml:space="preserve">Attendi la fine dell'azione</x:String>
   <x:String x:Key="Text.Configure.Email" xml:space="preserve">Indirizzo Email</x:String>
   <x:String x:Key="Text.Configure.Email.Placeholder" xml:space="preserve">Indirizzo email</x:String>
+  <x:String x:Key="Text.Configure.General" xml:space="preserve">GENERALE</x:String>
+  <x:String x:Key="Text.Configure.General.ContainingRefs.Collapsed" xml:space="preserve">Compresso</x:String>
+  <x:String x:Key="Text.Configure.General.ContainingRefs.Disabled" xml:space="preserve">Disabilitato</x:String>
+  <x:String x:Key="Text.Configure.General.ContainingRefs.Enabled" xml:space="preserve">Abilitato</x:String>
+  <x:String x:Key="Text.Configure.General.ContainingRefs.Expanded" xml:space="preserve">Espanso</x:String>
+  <x:String x:Key="Text.Configure.General.ContainingRefs.Inherit" xml:space="preserve">Eredita preferenza globale</x:String>
+  <x:String x:Key="Text.Configure.General.ContainingRefsDefaultExpansion" xml:space="preserve">Stato predefinito dei ref contenenti il commit</x:String>
+  <x:String x:Key="Text.Configure.General.ShowContainingRefsInCommitDetail" xml:space="preserve">Mostra i ref che contengono il commit selezionato</x:String>
   <x:String x:Key="Text.Configure.Git" xml:space="preserve">GIT</x:String>
   <x:String x:Key="Text.Configure.Git.AskBeforeAutoUpdatingSubmodules" xml:space="preserve">Chiedi prima di aggiornare automaticamente i sottomoduli</x:String>
   <x:String x:Key="Text.Configure.Git.AutoFetch" xml:space="preserve">Recupera automaticamente i remoti</x:String>
@@ -617,6 +625,8 @@ ${pure_files:N} Come ${files:N}, ma senza cartelle</x:String>
   <x:String x:Key="Text.Preferences.General.ShowChangesPageByDefault" xml:space="preserve">Mostra pagina `MODIFICHE LOCALI` per impostazione predefinita</x:String>
   <x:String x:Key="Text.Preferences.General.ShowChangesTabInCommitDetailByDefault" xml:space="preserve">Mostra scheda `MODIFICHE` nei dettagli del commit per impostazione predefinita</x:String>
   <x:String x:Key="Text.Preferences.General.ShowChildren" xml:space="preserve">Mostra i figli nei dettagli del commit</x:String>
+  <x:String x:Key="Text.Preferences.General.ShowContainingRefsExpandedByDefault" xml:space="preserve">Espandi di default i ref che contengono il commit selezionato</x:String>
+  <x:String x:Key="Text.Preferences.General.ShowContainingRefsInCommitDetail" xml:space="preserve">Mostra i ref che contengono il commit selezionato nei dettagli del commit</x:String>
   <x:String x:Key="Text.Preferences.General.ShowTagsInGraph" xml:space="preserve">Mostra i tag nel grafico dei commit</x:String>
   <x:String x:Key="Text.Preferences.General.SubjectGuideLength" xml:space="preserve">Lunghezza Guida Oggetto</x:String>
   <x:String x:Key="Text.Preferences.General.UseGitHubStyleAvatar" xml:space="preserve">Genera avatar predefinito stile GitHub</x:String>

--- a/src/Resources/Locales/it_IT.axaml
+++ b/src/Resources/Locales/it_IT.axaml
@@ -172,6 +172,7 @@
   <x:String x:Key="Text.CommitDetail.Info.Committer" xml:space="preserve">CHI HA COMMITTATO</x:String>
   <x:String x:Key="Text.CommitDetail.Info.ContainsIn" xml:space="preserve">Controlla i riferimenti che contengono questo commit</x:String>
   <x:String x:Key="Text.CommitDetail.Info.ContainsIn.Title" xml:space="preserve">IL COMMIT È CONTENUTO DA</x:String>
+  <x:String x:Key="Text.CommitDetail.Info.ContainsIn.TableTitle" xml:space="preserve">CONTENUTO IN</x:String>
   <x:String x:Key="Text.CommitDetail.Info.CopyEmail" xml:space="preserve">Copia Email</x:String>
   <x:String x:Key="Text.CommitDetail.Info.CopyName" xml:space="preserve">Copia Nome</x:String>
   <x:String x:Key="Text.CommitDetail.Info.CopyNameAndEmail" xml:space="preserve">Copia Nome ed Email</x:String>

--- a/src/Resources/Locales/ja_JP.axaml
+++ b/src/Resources/Locales/ja_JP.axaml
@@ -227,6 +227,14 @@
   <x:String x:Key="Text.Configure.CustomAction.WaitForExit" xml:space="preserve">アクションの終了を待機</x:String>
   <x:String x:Key="Text.Configure.Email" xml:space="preserve">メールアドレス</x:String>
   <x:String x:Key="Text.Configure.Email.Placeholder" xml:space="preserve">E メールアドレス</x:String>
+  <x:String x:Key="Text.Configure.General" xml:space="preserve">一般</x:String>
+  <x:String x:Key="Text.Configure.General.ContainingRefs.Collapsed" xml:space="preserve">折りたたみ</x:String>
+  <x:String x:Key="Text.Configure.General.ContainingRefs.Disabled" xml:space="preserve">無効</x:String>
+  <x:String x:Key="Text.Configure.General.ContainingRefs.Enabled" xml:space="preserve">有効</x:String>
+  <x:String x:Key="Text.Configure.General.ContainingRefs.Expanded" xml:space="preserve">展開</x:String>
+  <x:String x:Key="Text.Configure.General.ContainingRefs.Inherit" xml:space="preserve">グローバル設定を継承</x:String>
+  <x:String x:Key="Text.Configure.General.ContainingRefsDefaultExpansion" xml:space="preserve">含まれる参照の既定状態</x:String>
+  <x:String x:Key="Text.Configure.General.ShowContainingRefsInCommitDetail" xml:space="preserve">選択したコミットを含む参照を表示</x:String>
   <x:String x:Key="Text.Configure.Git" xml:space="preserve">Git</x:String>
   <x:String x:Key="Text.Configure.Git.AskBeforeAutoUpdatingSubmodules" xml:space="preserve">サブモジュールを自動更新する前に尋ねる</x:String>
   <x:String x:Key="Text.Configure.Git.AutoFetch" xml:space="preserve">リモートから</x:String>
@@ -623,6 +631,8 @@
   <x:String x:Key="Text.Preferences.General.ShowChangesPageByDefault" xml:space="preserve">初めから `ローカルの変更` ページを表示</x:String>
   <x:String x:Key="Text.Preferences.General.ShowChangesTabInCommitDetailByDefault" xml:space="preserve">初めからコミットの詳細の `変更` タブを表示</x:String>
   <x:String x:Key="Text.Preferences.General.ShowChildren" xml:space="preserve">コミットの詳細に子コミットを表示</x:String>
+  <x:String x:Key="Text.Preferences.General.ShowContainingRefsExpandedByDefault" xml:space="preserve">選択したコミットを含む参照を既定で展開</x:String>
+  <x:String x:Key="Text.Preferences.General.ShowContainingRefsInCommitDetail" xml:space="preserve">コミットの詳細に選択したコミットを含む参照を表示</x:String>
   <x:String x:Key="Text.Preferences.General.ShowTagsInGraph" xml:space="preserve">コミットグラフにタグを表示</x:String>
   <x:String x:Key="Text.Preferences.General.SubjectGuideLength" xml:space="preserve">適切とするコミットタイトルの長さ</x:String>
   <x:String x:Key="Text.Preferences.General.UseGitHubStyleAvatar" xml:space="preserve">GitHub のような既定のアバターを生成</x:String>

--- a/src/Resources/Locales/ja_JP.axaml
+++ b/src/Resources/Locales/ja_JP.axaml
@@ -173,6 +173,7 @@
   <x:String x:Key="Text.CommitDetail.Info.Committer" xml:space="preserve">コミッター</x:String>
   <x:String x:Key="Text.CommitDetail.Info.ContainsIn" xml:space="preserve">このコミットが含まれる参照を確認</x:String>
   <x:String x:Key="Text.CommitDetail.Info.ContainsIn.Title" xml:space="preserve">これらの参照にコミットが含まれています</x:String>
+  <x:String x:Key="Text.CommitDetail.Info.ContainsIn.TableTitle" xml:space="preserve">含まれる参照</x:String>
   <x:String x:Key="Text.CommitDetail.Info.CopyEmail" xml:space="preserve">メールアドレスをコピー</x:String>
   <x:String x:Key="Text.CommitDetail.Info.CopyName" xml:space="preserve">名前をコピー</x:String>
   <x:String x:Key="Text.CommitDetail.Info.CopyNameAndEmail" xml:space="preserve">名前 &amp; メールアドレスをコピー</x:String>

--- a/src/Resources/Locales/ko_KR.axaml
+++ b/src/Resources/Locales/ko_KR.axaml
@@ -156,6 +156,7 @@
   <x:String x:Key="Text.CommitDetail.Info.Committer" xml:space="preserve">커밋터</x:String>
   <x:String x:Key="Text.CommitDetail.Info.ContainsIn" xml:space="preserve">이 커밋을 포함하는 ref 확인</x:String>
   <x:String x:Key="Text.CommitDetail.Info.ContainsIn.Title" xml:space="preserve">커밋 포함 REF</x:String>
+  <x:String x:Key="Text.CommitDetail.Info.ContainsIn.TableTitle" xml:space="preserve">포함된 REF</x:String>
   <x:String x:Key="Text.CommitDetail.Info.CopyEmail" xml:space="preserve">이메일 복사</x:String>
   <x:String x:Key="Text.CommitDetail.Info.CopyName" xml:space="preserve">이름 복사</x:String>
   <x:String x:Key="Text.CommitDetail.Info.CopyNameAndEmail" xml:space="preserve">이름 &amp; 이메일 복사</x:String>

--- a/src/Resources/Locales/ko_KR.axaml
+++ b/src/Resources/Locales/ko_KR.axaml
@@ -201,6 +201,14 @@
   <x:String x:Key="Text.Configure.CustomAction.WaitForExit" xml:space="preserve">작업이 끝날 때까지 대기</x:String>
   <x:String x:Key="Text.Configure.Email" xml:space="preserve">이메일 주소</x:String>
   <x:String x:Key="Text.Configure.Email.Placeholder" xml:space="preserve">이메일 주소</x:String>
+  <x:String x:Key="Text.Configure.General" xml:space="preserve">일반</x:String>
+  <x:String x:Key="Text.Configure.General.ContainingRefs.Collapsed" xml:space="preserve">접힘</x:String>
+  <x:String x:Key="Text.Configure.General.ContainingRefs.Disabled" xml:space="preserve">비활성화</x:String>
+  <x:String x:Key="Text.Configure.General.ContainingRefs.Enabled" xml:space="preserve">활성화</x:String>
+  <x:String x:Key="Text.Configure.General.ContainingRefs.Expanded" xml:space="preserve">펼침</x:String>
+  <x:String x:Key="Text.Configure.General.ContainingRefs.Inherit" xml:space="preserve">전역 설정 상속</x:String>
+  <x:String x:Key="Text.Configure.General.ContainingRefsDefaultExpansion" xml:space="preserve">포함하는 ref의 기본 상태</x:String>
+  <x:String x:Key="Text.Configure.General.ShowContainingRefsInCommitDetail" xml:space="preserve">선택한 커밋을 포함하는 ref 표시</x:String>
   <x:String x:Key="Text.Configure.Git" xml:space="preserve">GIT</x:String>
   <x:String x:Key="Text.Configure.Git.AutoFetch" xml:space="preserve">원격 자동 Fetch</x:String>
   <x:String x:Key="Text.Configure.Git.AutoFetchIntervalSuffix" xml:space="preserve">분</x:String>
@@ -552,6 +560,8 @@
   <x:String x:Key="Text.Preferences.General.ShowChangesPageByDefault" xml:space="preserve">기본으로 `로컬 변경 사항` 페이지 표시</x:String>
   <x:String x:Key="Text.Preferences.General.ShowChangesTabInCommitDetailByDefault" xml:space="preserve">커밋 세부 정보에서 기본으로 `변경 사항` 탭 표시</x:String>
   <x:String x:Key="Text.Preferences.General.ShowChildren" xml:space="preserve">커밋 세부 정보에 자식 커밋 표시</x:String>
+  <x:String x:Key="Text.Preferences.General.ShowContainingRefsExpandedByDefault" xml:space="preserve">선택한 커밋을 포함하는 ref를 기본으로 펼침</x:String>
+  <x:String x:Key="Text.Preferences.General.ShowContainingRefsInCommitDetail" xml:space="preserve">커밋 세부 정보에 선택한 커밋을 포함하는 ref 표시</x:String>
   <x:String x:Key="Text.Preferences.General.ShowTagsInGraph" xml:space="preserve">커밋 그래프에 태그 표시</x:String>
   <x:String x:Key="Text.Preferences.General.SubjectGuideLength" xml:space="preserve">제목 가이드 길이</x:String>
   <x:String x:Key="Text.Preferences.General.UseGitHubStyleAvatar" xml:space="preserve">GitHub 스타일 기본 아바타 생성</x:String>

--- a/src/Resources/Locales/pt_BR.axaml
+++ b/src/Resources/Locales/pt_BR.axaml
@@ -136,6 +136,7 @@
   <x:String x:Key="Text.CommitDetail.Info.Committer" xml:space="preserve">COMMITTER</x:String>
   <x:String x:Key="Text.CommitDetail.Info.ContainsIn" xml:space="preserve">Verificar referências que contenham este commit</x:String>
   <x:String x:Key="Text.CommitDetail.Info.ContainsIn.Title" xml:space="preserve">COMMIT EXISTE EM</x:String>
+  <x:String x:Key="Text.CommitDetail.Info.ContainsIn.TableTitle" xml:space="preserve">CONTIDO EM</x:String>
   <x:String x:Key="Text.CommitDetail.Info.GotoChangesPage" xml:space="preserve">Mostra apenas as primeiras 100 alterações. Veja todas as alterações na aba ALTERAÇÕES.</x:String>
   <x:String x:Key="Text.CommitDetail.Info.Message" xml:space="preserve">MENSAGEM</x:String>
   <x:String x:Key="Text.CommitDetail.Info.Parents" xml:space="preserve">PAIS</x:String>

--- a/src/Resources/Locales/pt_BR.axaml
+++ b/src/Resources/Locales/pt_BR.axaml
@@ -157,6 +157,14 @@
   <x:String x:Key="Text.Configure.CustomAction.Scope.Repository" xml:space="preserve">Repositório</x:String>
   <x:String x:Key="Text.Configure.Email" xml:space="preserve">Endereço de email</x:String>
   <x:String x:Key="Text.Configure.Email.Placeholder" xml:space="preserve">Endereço de email</x:String>
+  <x:String x:Key="Text.Configure.General" xml:space="preserve">GERAL</x:String>
+  <x:String x:Key="Text.Configure.General.ContainingRefs.Collapsed" xml:space="preserve">Recolhido</x:String>
+  <x:String x:Key="Text.Configure.General.ContainingRefs.Disabled" xml:space="preserve">Desativado</x:String>
+  <x:String x:Key="Text.Configure.General.ContainingRefs.Enabled" xml:space="preserve">Ativado</x:String>
+  <x:String x:Key="Text.Configure.General.ContainingRefs.Expanded" xml:space="preserve">Expandido</x:String>
+  <x:String x:Key="Text.Configure.General.ContainingRefs.Inherit" xml:space="preserve">Herdar preferência global</x:String>
+  <x:String x:Key="Text.Configure.General.ContainingRefsDefaultExpansion" xml:space="preserve">Estado padrão das refs que contêm o commit</x:String>
+  <x:String x:Key="Text.Configure.General.ShowContainingRefsInCommitDetail" xml:space="preserve">Mostrar refs que contêm o commit selecionado</x:String>
   <x:String x:Key="Text.Configure.Git" xml:space="preserve">GIT</x:String>
   <x:String x:Key="Text.Configure.Git.AutoFetch" xml:space="preserve">Buscar remotos automaticamente</x:String>
   <x:String x:Key="Text.Configure.Git.AutoFetchIntervalSuffix" xml:space="preserve">Minuto(s)</x:String>
@@ -433,6 +441,8 @@
   <x:String x:Key="Text.Preferences.General.Locale" xml:space="preserve">Idioma</x:String>
   <x:String x:Key="Text.Preferences.General.MaxHistoryCommits" xml:space="preserve">Commits do Histórico</x:String>
   <x:String x:Key="Text.Preferences.General.ShowAuthorTime" xml:space="preserve">Exibir data do autor em vez da data do commit no gráfico</x:String>
+  <x:String x:Key="Text.Preferences.General.ShowContainingRefsExpandedByDefault" xml:space="preserve">Expandir refs que contêm o commit selecionado por padrão</x:String>
+  <x:String x:Key="Text.Preferences.General.ShowContainingRefsInCommitDetail" xml:space="preserve">Mostrar refs que contêm o commit selecionado nos detalhes do commit</x:String>
   <x:String x:Key="Text.Preferences.General.SubjectGuideLength" xml:space="preserve">Comprimento do Guia de Assunto</x:String>
   <x:String x:Key="Text.Preferences.Git" xml:space="preserve">GIT</x:String>
   <x:String x:Key="Text.Preferences.Git.CRLF" xml:space="preserve">Habilitar Auto CRLF</x:String>

--- a/src/Resources/Locales/ru_RU.axaml
+++ b/src/Resources/Locales/ru_RU.axaml
@@ -242,6 +242,14 @@
   <x:String x:Key="Text.Configure.CustomAction.WaitForExit" xml:space="preserve">Ждать для выполения выхода</x:String>
   <x:String x:Key="Text.Configure.Email" xml:space="preserve">Адрес электронной почты</x:String>
   <x:String x:Key="Text.Configure.Email.Placeholder" xml:space="preserve">Адрес электронной почты</x:String>
+  <x:String x:Key="Text.Configure.General" xml:space="preserve">ОБЩИЕ</x:String>
+  <x:String x:Key="Text.Configure.General.ContainingRefs.Collapsed" xml:space="preserve">Свернуто</x:String>
+  <x:String x:Key="Text.Configure.General.ContainingRefs.Disabled" xml:space="preserve">Отключено</x:String>
+  <x:String x:Key="Text.Configure.General.ContainingRefs.Enabled" xml:space="preserve">Включено</x:String>
+  <x:String x:Key="Text.Configure.General.ContainingRefs.Expanded" xml:space="preserve">Развернуто</x:String>
+  <x:String x:Key="Text.Configure.General.ContainingRefs.Inherit" xml:space="preserve">Наследовать глобальную настройку</x:String>
+  <x:String x:Key="Text.Configure.General.ContainingRefsDefaultExpansion" xml:space="preserve">Состояние по умолчанию для содержащих ссылок</x:String>
+  <x:String x:Key="Text.Configure.General.ShowContainingRefsInCommitDetail" xml:space="preserve">Показывать ссылки, содержащие выбранный коммит</x:String>
   <x:String x:Key="Text.Configure.Git" xml:space="preserve">GIT</x:String>
   <x:String x:Key="Text.Configure.Git.AskBeforeAutoUpdatingSubmodules" xml:space="preserve">Спрашивать перед автоматическим обновлением подмодулей.</x:String>
   <x:String x:Key="Text.Configure.Git.AutoFetch" xml:space="preserve">Автозагрузка изменений</x:String>
@@ -654,6 +662,8 @@
   <x:String x:Key="Text.Preferences.General.ShowChangesPageByDefault" xml:space="preserve">Показывать вкладку «ЛОКАЛЬНЫЕ ИЗМЕНЕНИЯ» по умолчанию</x:String>
   <x:String x:Key="Text.Preferences.General.ShowChangesTabInCommitDetailByDefault" xml:space="preserve">Показывать вкладку «Изменения» в сведении ревизии по умолчанию</x:String>
   <x:String x:Key="Text.Preferences.General.ShowChildren" xml:space="preserve">Показать наследника в деталях комментария</x:String>
+  <x:String x:Key="Text.Preferences.General.ShowContainingRefsExpandedByDefault" xml:space="preserve">Разворачивать ссылки, содержащие выбранный коммит, по умолчанию</x:String>
+  <x:String x:Key="Text.Preferences.General.ShowContainingRefsInCommitDetail" xml:space="preserve">Показывать ссылки, содержащие выбранный коммит, в деталях коммита</x:String>
   <x:String x:Key="Text.Preferences.General.ShowTagsInGraph" xml:space="preserve">Показывать метки на графике</x:String>
   <x:String x:Key="Text.Preferences.General.SubjectGuideLength" xml:space="preserve">Длина темы ревизии</x:String>
   <x:String x:Key="Text.Preferences.General.Use24Hours" xml:space="preserve">24-часовой</x:String>

--- a/src/Resources/Locales/ru_RU.axaml
+++ b/src/Resources/Locales/ru_RU.axaml
@@ -188,6 +188,7 @@
   <x:String x:Key="Text.CommitDetail.Info.Committer" xml:space="preserve">РЕВИЗОР (ИСПОЛНИТЕЛЬ)</x:String>
   <x:String x:Key="Text.CommitDetail.Info.ContainsIn" xml:space="preserve">Найти все ветки с этой ревизией</x:String>
   <x:String x:Key="Text.CommitDetail.Info.ContainsIn.Title" xml:space="preserve">ВЕТКИ С ЭТОЙ РЕВИЗИЕЙ</x:String>
+  <x:String x:Key="Text.CommitDetail.Info.ContainsIn.TableTitle" xml:space="preserve">СОДЕРЖИТСЯ В</x:String>
   <x:String x:Key="Text.CommitDetail.Info.CopyEmail" xml:space="preserve">Копировать адрес почты</x:String>
   <x:String x:Key="Text.CommitDetail.Info.CopyName" xml:space="preserve">Копировать имя</x:String>
   <x:String x:Key="Text.CommitDetail.Info.CopyNameAndEmail" xml:space="preserve">Копировать имя и адрес почты</x:String>

--- a/src/Resources/Locales/ta_IN.axaml
+++ b/src/Resources/Locales/ta_IN.axaml
@@ -135,6 +135,14 @@
   <x:String x:Key="Text.Configure.CustomAction.WaitForExit" xml:space="preserve">செயல்பாட்டிலிருந்து வெளியேற காத்திரு</x:String>
   <x:String x:Key="Text.Configure.Email" xml:space="preserve">மின்னஞ்சல் முகவரி</x:String>
   <x:String x:Key="Text.Configure.Email.Placeholder" xml:space="preserve">மின்னஞ்சல் முகவரி</x:String>
+  <x:String x:Key="Text.Configure.General" xml:space="preserve">பொது</x:String>
+  <x:String x:Key="Text.Configure.General.ContainingRefs.Collapsed" xml:space="preserve">சுருக்கப்பட்டது</x:String>
+  <x:String x:Key="Text.Configure.General.ContainingRefs.Disabled" xml:space="preserve">முடக்கப்பட்டது</x:String>
+  <x:String x:Key="Text.Configure.General.ContainingRefs.Enabled" xml:space="preserve">இயக்கப்பட்டது</x:String>
+  <x:String x:Key="Text.Configure.General.ContainingRefs.Expanded" xml:space="preserve">விரிவாக்கப்பட்டது</x:String>
+  <x:String x:Key="Text.Configure.General.ContainingRefs.Inherit" xml:space="preserve">உலகளாவிய விருப்பத்தைப் பெறு</x:String>
+  <x:String x:Key="Text.Configure.General.ContainingRefsDefaultExpansion" xml:space="preserve">உறுதிமொழியை கொண்டுள்ள refs-இன் இயல்புநிலை நிலை</x:String>
+  <x:String x:Key="Text.Configure.General.ShowContainingRefsInCommitDetail" xml:space="preserve">தேர்ந்தெடுத்த உறுதிமொழியை கொண்டுள்ள refs-ஐ காட்டு</x:String>
   <x:String x:Key="Text.Configure.Git" xml:space="preserve">அறிவிலி</x:String>
   <x:String x:Key="Text.Configure.Git.AutoFetch" xml:space="preserve">தொலைகளை தானாக எடு</x:String>
   <x:String x:Key="Text.Configure.Git.AutoFetchIntervalSuffix" xml:space="preserve">நிமையங்கள்</x:String>
@@ -433,6 +441,8 @@
   <x:String x:Key="Text.Preferences.General.MaxHistoryCommits" xml:space="preserve">வரலாற்று உறுதிமொழிகள்</x:String>
   <x:String x:Key="Text.Preferences.General.ShowAuthorTime" xml:space="preserve">வரைபடத்தில் உறுதிமொழி நேரத்திற்குப் பதிலாக ஆசிரியர் நேரத்தைக் காட்டு</x:String>
   <x:String x:Key="Text.Preferences.General.ShowChildren" xml:space="preserve">உறுதிமொழி விவரங்களில் குழந்தைகளைக் காட்டு</x:String>
+  <x:String x:Key="Text.Preferences.General.ShowContainingRefsExpandedByDefault" xml:space="preserve">தேர்ந்தெடுத்த உறுதிமொழியை கொண்டுள்ள refs-ஐ இயல்பாக விரிவாக்கு</x:String>
+  <x:String x:Key="Text.Preferences.General.ShowContainingRefsInCommitDetail" xml:space="preserve">உறுதிமொழி விவரங்களில் தேர்ந்தெடுத்த உறுதிமொழியை கொண்டுள்ள refs-ஐ காட்டு</x:String>
   <x:String x:Key="Text.Preferences.General.ShowTagsInGraph" xml:space="preserve">உறுதிமொழி வரைபடத்தில் குறிச்சொற்களைக் காட்டு</x:String>
   <x:String x:Key="Text.Preferences.General.SubjectGuideLength" xml:space="preserve">பொருள் வழிகாட்டி நீளம்</x:String>
   <x:String x:Key="Text.Preferences.Git" xml:space="preserve">அறிவிலி</x:String>

--- a/src/Resources/Locales/ta_IN.axaml
+++ b/src/Resources/Locales/ta_IN.axaml
@@ -112,6 +112,7 @@
   <x:String x:Key="Text.CommitDetail.Info.Committer" xml:space="preserve">உறுதிமொழியாளர்</x:String>
   <x:String x:Key="Text.CommitDetail.Info.ContainsIn" xml:space="preserve">இந்த உறுதிமொழிடைக் கொண்ட குறிப்புகளைச் சரிபார்</x:String>
   <x:String x:Key="Text.CommitDetail.Info.ContainsIn.Title" xml:space="preserve">உறுதிமொழி இதில் உள்ளது</x:String>
+  <x:String x:Key="Text.CommitDetail.Info.ContainsIn.TableTitle" xml:space="preserve">இதில் உள்ளது</x:String>
   <x:String x:Key="Text.CommitDetail.Info.GotoChangesPage" xml:space="preserve">முதல் 100 மாற்றங்களை மட்டும் காட்டுகிறது மாற்றங்கள் தாவலில் அனைத்து மாற்றங்களையும் காண்க.</x:String>
   <x:String x:Key="Text.CommitDetail.Info.Message" xml:space="preserve">செய்தி</x:String>
   <x:String x:Key="Text.CommitDetail.Info.Parents" xml:space="preserve">பெற்றோர்கள்</x:String>

--- a/src/Resources/Locales/uk_UA.axaml
+++ b/src/Resources/Locales/uk_UA.axaml
@@ -112,6 +112,7 @@
   <x:String x:Key="Text.CommitDetail.Info.Committer" xml:space="preserve">КОМІТЕР</x:String>
   <x:String x:Key="Text.CommitDetail.Info.ContainsIn" xml:space="preserve">Перевірити посилання, що містять цей коміт</x:String>
   <x:String x:Key="Text.CommitDetail.Info.ContainsIn.Title" xml:space="preserve">КОМІТ МІСТИТЬСЯ В</x:String>
+  <x:String x:Key="Text.CommitDetail.Info.ContainsIn.TableTitle" xml:space="preserve">МІСТИТЬСЯ В</x:String>
   <x:String x:Key="Text.CommitDetail.Info.GotoChangesPage" xml:space="preserve">Показано лише перші 100 змін. Дивіться всі зміни на вкладці ЗМІНИ.</x:String>
   <x:String x:Key="Text.CommitDetail.Info.Message" xml:space="preserve">ПОВІДОМЛЕННЯ</x:String>
   <x:String x:Key="Text.CommitDetail.Info.Parents" xml:space="preserve">БАТЬКІВСЬКІ</x:String>

--- a/src/Resources/Locales/uk_UA.axaml
+++ b/src/Resources/Locales/uk_UA.axaml
@@ -135,6 +135,14 @@
   <x:String x:Key="Text.Configure.CustomAction.WaitForExit" xml:space="preserve">Чекати завершення дії</x:String>
   <x:String x:Key="Text.Configure.Email" xml:space="preserve">Адреса Email</x:String>
   <x:String x:Key="Text.Configure.Email.Placeholder" xml:space="preserve">Адреса електронної пошти</x:String>
+  <x:String x:Key="Text.Configure.General" xml:space="preserve">ЗАГАЛЬНІ</x:String>
+  <x:String x:Key="Text.Configure.General.ContainingRefs.Collapsed" xml:space="preserve">Згорнуто</x:String>
+  <x:String x:Key="Text.Configure.General.ContainingRefs.Disabled" xml:space="preserve">Вимкнено</x:String>
+  <x:String x:Key="Text.Configure.General.ContainingRefs.Enabled" xml:space="preserve">Увімкнено</x:String>
+  <x:String x:Key="Text.Configure.General.ContainingRefs.Expanded" xml:space="preserve">Розгорнуто</x:String>
+  <x:String x:Key="Text.Configure.General.ContainingRefs.Inherit" xml:space="preserve">Успадкувати глобальне налаштування</x:String>
+  <x:String x:Key="Text.Configure.General.ContainingRefsDefaultExpansion" xml:space="preserve">Типовий стан посилань, що містять коміт</x:String>
+  <x:String x:Key="Text.Configure.General.ShowContainingRefsInCommitDetail" xml:space="preserve">Показувати посилання, що містять вибраний коміт</x:String>
   <x:String x:Key="Text.Configure.Git" xml:space="preserve">GIT</x:String>
   <x:String x:Key="Text.Configure.Git.AutoFetch" xml:space="preserve">Автоматично отримувати зміни з віддалених сховищ</x:String>
   <x:String x:Key="Text.Configure.Git.AutoFetchIntervalSuffix" xml:space="preserve">хвилин(и)</x:String>
@@ -437,6 +445,8 @@
   <x:String x:Key="Text.Preferences.General.MaxHistoryCommits" xml:space="preserve">Кількість комітів в історії</x:String>
   <x:String x:Key="Text.Preferences.General.ShowAuthorTime" xml:space="preserve">Показувати час автора замість часу коміту в графі</x:String>
   <x:String x:Key="Text.Preferences.General.ShowChildren" xml:space="preserve">Показувати дочірні коміти в деталях</x:String>
+  <x:String x:Key="Text.Preferences.General.ShowContainingRefsExpandedByDefault" xml:space="preserve">Типово розгортати посилання, що містять вибраний коміт</x:String>
+  <x:String x:Key="Text.Preferences.General.ShowContainingRefsInCommitDetail" xml:space="preserve">Показувати посилання, що містять вибраний коміт, у деталях коміту</x:String>
   <x:String x:Key="Text.Preferences.General.ShowTagsInGraph" xml:space="preserve">Показувати теги в графі комітів</x:String>
   <x:String x:Key="Text.Preferences.General.SubjectGuideLength" xml:space="preserve">Довжина лінії-орієнтира для теми</x:String>
   <x:String x:Key="Text.Preferences.Git" xml:space="preserve">GIT</x:String>

--- a/src/Resources/Locales/zh_CN.axaml
+++ b/src/Resources/Locales/zh_CN.axaml
@@ -247,6 +247,14 @@
   <x:String x:Key="Text.Configure.CustomAction.WaitForExit" xml:space="preserve">等待操作执行完成</x:String>
   <x:String x:Key="Text.Configure.Email" xml:space="preserve">电子邮箱</x:String>
   <x:String x:Key="Text.Configure.Email.Placeholder" xml:space="preserve">邮箱地址</x:String>
+  <x:String x:Key="Text.Configure.General" xml:space="preserve">通用</x:String>
+  <x:String x:Key="Text.Configure.General.ContainingRefs.Collapsed" xml:space="preserve">折叠</x:String>
+  <x:String x:Key="Text.Configure.General.ContainingRefs.Disabled" xml:space="preserve">禁用</x:String>
+  <x:String x:Key="Text.Configure.General.ContainingRefs.Enabled" xml:space="preserve">启用</x:String>
+  <x:String x:Key="Text.Configure.General.ContainingRefs.Expanded" xml:space="preserve">展开</x:String>
+  <x:String x:Key="Text.Configure.General.ContainingRefs.Inherit" xml:space="preserve">继承全局偏好设置</x:String>
+  <x:String x:Key="Text.Configure.General.ContainingRefsDefaultExpansion" xml:space="preserve">包含引用的默认状态</x:String>
+  <x:String x:Key="Text.Configure.General.ShowContainingRefsInCommitDetail" xml:space="preserve">显示包含选中提交的引用</x:String>
   <x:String x:Key="Text.Configure.Git" xml:space="preserve">GIT配置</x:String>
   <x:String x:Key="Text.Configure.Git.AskBeforeAutoUpdatingSubmodules" xml:space="preserve">在自动更新子模块前询问用户</x:String>
   <x:String x:Key="Text.Configure.Git.AutoFetch" xml:space="preserve">启用定时自动拉取远程更新</x:String>
@@ -671,6 +679,7 @@
   <x:String x:Key="Text.Preferences.General.ShowChangesPageByDefault" xml:space="preserve">默认显示【本地更改】页</x:String>
   <x:String x:Key="Text.Preferences.General.ShowChangesTabInCommitDetailByDefault" xml:space="preserve">在提交详情页默认打开【变更对比】标签页</x:String>
   <x:String x:Key="Text.Preferences.General.ShowChildren" xml:space="preserve">在提交详情页中显示子提交列表</x:String>
+  <x:String x:Key="Text.Preferences.General.ShowContainingRefsExpandedByDefault" xml:space="preserve">默认展开包含选中提交的引用</x:String>
   <x:String x:Key="Text.Preferences.General.ShowContainingRefsInCommitDetail" xml:space="preserve">在提交详情页中显示包含当前提交的分支/标签</x:String>
   <x:String x:Key="Text.Preferences.General.ShowRelativeTimeInGraph" xml:space="preserve">在提交路线图中显示相对时间</x:String>
   <x:String x:Key="Text.Preferences.General.ShowTagsInGraph" xml:space="preserve">在提交路线图中显示标签</x:String>

--- a/src/Resources/Locales/zh_CN.axaml
+++ b/src/Resources/Locales/zh_CN.axaml
@@ -188,6 +188,7 @@
   <x:String x:Key="Text.CommitDetail.Info.Committer" xml:space="preserve">提交者</x:String>
   <x:String x:Key="Text.CommitDetail.Info.ContainsIn" xml:space="preserve">查看包含此提交的分支/标签</x:String>
   <x:String x:Key="Text.CommitDetail.Info.ContainsIn.Title" xml:space="preserve">本提交已被以下分支/标签包含</x:String>
+  <x:String x:Key="Text.CommitDetail.Info.ContainsIn.TableTitle" xml:space="preserve">包含于</x:String>
   <x:String x:Key="Text.CommitDetail.Info.CopyEmail" xml:space="preserve">复制电子邮箱</x:String>
   <x:String x:Key="Text.CommitDetail.Info.CopyName" xml:space="preserve">复制用户名</x:String>
   <x:String x:Key="Text.CommitDetail.Info.CopyNameAndEmail" xml:space="preserve">复制用户名及邮箱</x:String>
@@ -670,6 +671,7 @@
   <x:String x:Key="Text.Preferences.General.ShowChangesPageByDefault" xml:space="preserve">默认显示【本地更改】页</x:String>
   <x:String x:Key="Text.Preferences.General.ShowChangesTabInCommitDetailByDefault" xml:space="preserve">在提交详情页默认打开【变更对比】标签页</x:String>
   <x:String x:Key="Text.Preferences.General.ShowChildren" xml:space="preserve">在提交详情页中显示子提交列表</x:String>
+  <x:String x:Key="Text.Preferences.General.ShowContainingRefsInCommitDetail" xml:space="preserve">在提交详情页中显示包含当前提交的分支/标签</x:String>
   <x:String x:Key="Text.Preferences.General.ShowRelativeTimeInGraph" xml:space="preserve">在提交路线图中显示相对时间</x:String>
   <x:String x:Key="Text.Preferences.General.ShowTagsInGraph" xml:space="preserve">在提交路线图中显示标签</x:String>
   <x:String x:Key="Text.Preferences.General.SubjectGuideLength" xml:space="preserve">SUBJECT字数检测</x:String>

--- a/src/Resources/Locales/zh_TW.axaml
+++ b/src/Resources/Locales/zh_TW.axaml
@@ -247,6 +247,14 @@
   <x:String x:Key="Text.Configure.CustomAction.WaitForExit" xml:space="preserve">等待自訂動作執行結束</x:String>
   <x:String x:Key="Text.Configure.Email" xml:space="preserve">電子郵件</x:String>
   <x:String x:Key="Text.Configure.Email.Placeholder" xml:space="preserve">電子郵件地址</x:String>
+  <x:String x:Key="Text.Configure.General" xml:space="preserve">一般</x:String>
+  <x:String x:Key="Text.Configure.General.ContainingRefs.Collapsed" xml:space="preserve">摺疊</x:String>
+  <x:String x:Key="Text.Configure.General.ContainingRefs.Disabled" xml:space="preserve">停用</x:String>
+  <x:String x:Key="Text.Configure.General.ContainingRefs.Enabled" xml:space="preserve">啟用</x:String>
+  <x:String x:Key="Text.Configure.General.ContainingRefs.Expanded" xml:space="preserve">展開</x:String>
+  <x:String x:Key="Text.Configure.General.ContainingRefs.Inherit" xml:space="preserve">繼承全域偏好設定</x:String>
+  <x:String x:Key="Text.Configure.General.ContainingRefsDefaultExpansion" xml:space="preserve">包含參照的預設狀態</x:String>
+  <x:String x:Key="Text.Configure.General.ShowContainingRefsInCommitDetail" xml:space="preserve">顯示包含所選提交的參照</x:String>
   <x:String x:Key="Text.Configure.Git" xml:space="preserve">Git 設定</x:String>
   <x:String x:Key="Text.Configure.Git.AskBeforeAutoUpdatingSubmodules" xml:space="preserve">在自動更新子模組之前先詢問</x:String>
   <x:String x:Key="Text.Configure.Git.AutoFetch" xml:space="preserve">啟用定時自動提取 (fetch) 遠端更新</x:String>
@@ -671,6 +679,8 @@
   <x:String x:Key="Text.Preferences.General.ShowChangesPageByDefault" xml:space="preserve">預設顯示 [本機變更] 頁面</x:String>
   <x:String x:Key="Text.Preferences.General.ShowChangesTabInCommitDetailByDefault" xml:space="preserve">在提交詳細資訊頁面預設顯示 [變更對比]</x:String>
   <x:String x:Key="Text.Preferences.General.ShowChildren" xml:space="preserve">在提交詳細資訊中顯示後續提交</x:String>
+  <x:String x:Key="Text.Preferences.General.ShowContainingRefsExpandedByDefault" xml:space="preserve">預設展開包含所選提交的參照</x:String>
+  <x:String x:Key="Text.Preferences.General.ShowContainingRefsInCommitDetail" xml:space="preserve">在提交詳細資訊中顯示包含所選提交的參照</x:String>
   <x:String x:Key="Text.Preferences.General.ShowRelativeTimeInGraph" xml:space="preserve">在提交路線圖中顯示相對時間</x:String>
   <x:String x:Key="Text.Preferences.General.ShowTagsInGraph" xml:space="preserve">在路線圖中顯示標籤</x:String>
   <x:String x:Key="Text.Preferences.General.SubjectGuideLength" xml:space="preserve">提交標題字數偵測</x:String>

--- a/src/Resources/Locales/zh_TW.axaml
+++ b/src/Resources/Locales/zh_TW.axaml
@@ -188,6 +188,7 @@
   <x:String x:Key="Text.CommitDetail.Info.Committer" xml:space="preserve">提交者</x:String>
   <x:String x:Key="Text.CommitDetail.Info.ContainsIn" xml:space="preserve">檢視包含此提交的分支或標籤</x:String>
   <x:String x:Key="Text.CommitDetail.Info.ContainsIn.Title" xml:space="preserve">本提交包含於以下分支或標籤</x:String>
+  <x:String x:Key="Text.CommitDetail.Info.ContainsIn.TableTitle" xml:space="preserve">包含於</x:String>
   <x:String x:Key="Text.CommitDetail.Info.CopyEmail" xml:space="preserve">複製電子郵件</x:String>
   <x:String x:Key="Text.CommitDetail.Info.CopyName" xml:space="preserve">複製名稱</x:String>
   <x:String x:Key="Text.CommitDetail.Info.CopyNameAndEmail" xml:space="preserve">複製名稱及電子郵件</x:String>

--- a/src/ViewModels/CommitDetail.cs
+++ b/src/ViewModels/CommitDetail.cs
@@ -84,6 +84,18 @@ namespace SourceGit.ViewModels
             private set => SetProperty(ref _children, value);
         }
 
+        public List<Models.Decorator> ContainingRefs
+        {
+            get => _containingRefs;
+            private set => SetProperty(ref _containingRefs, value);
+        }
+
+        public bool IsContainingRefsLoading
+        {
+            get => _isContainingRefsLoading;
+            private set => SetProperty(ref _isContainingRefsLoading, value);
+        }
+
         public List<Models.Change> Changes
         {
             get => _changes;
@@ -471,6 +483,8 @@ namespace SourceGit.ViewModels
             ViewRevisionFilePath = string.Empty;
             CanOpenRevisionFileWithDefaultEditor = false;
             Children = null;
+            ContainingRefs = null;
+            IsContainingRefsLoading = false;
             RevisionFileSearchFilter = string.Empty;
             RevisionFileSearchSuggestion = null;
             ScrollOffset = Vector.Zero;
@@ -526,6 +540,25 @@ namespace SourceGit.ViewModels
                     var children = await cmd.GetResultAsync().ConfigureAwait(false);
                     if (!token.IsCancellationRequested)
                         Dispatcher.UIThread.Post(() => Children = children);
+                }, token);
+            }
+
+            if (Preferences.Instance.ShowContainingRefsInCommitDetail)
+            {
+                IsContainingRefsLoading = true;
+
+                Task.Run(async () =>
+                {
+                    var refs = await new Commands.QueryRefsContainsCommit(_repo.FullPath, _commit.SHA)
+                        .GetResultAsync()
+                        .ConfigureAwait(false);
+
+                    if (!token.IsCancellationRequested)
+                        Dispatcher.UIThread.Post(() =>
+                        {
+                            ContainingRefs = refs;
+                            IsContainingRefsLoading = false;
+                        });
                 }, token);
             }
 
@@ -764,6 +797,8 @@ namespace SourceGit.ViewModels
         private Models.CommitFullMessage _fullMessage = null;
         private Models.CommitSignInfo _signInfo = null;
         private List<string> _children = null;
+        private List<Models.Decorator> _containingRefs = null;
+        private bool _isContainingRefsLoading = false;
         private List<Models.Change> _changes = [];
         private List<Models.Change> _visibleChanges = [];
         private List<Models.Change> _selectedChanges = null;

--- a/src/ViewModels/CommitDetail.cs
+++ b/src/ViewModels/CommitDetail.cs
@@ -96,6 +96,32 @@ namespace SourceGit.ViewModels
             private set => SetProperty(ref _isContainingRefsLoading, value);
         }
 
+        public bool ShowContainingRefsInCommitDetail
+        {
+            get
+            {
+                return _repo.Settings.ShowContainingRefsInCommitDetail switch
+                {
+                    1 => false,
+                    2 => true,
+                    _ => Preferences.Instance.ShowContainingRefsInCommitDetail,
+                };
+            }
+        }
+
+        public bool ContainingRefsExpandedByDefault
+        {
+            get
+            {
+                return _repo.Settings.ContainingRefsDefaultExpansion switch
+                {
+                    1 => false,
+                    2 => true,
+                    _ => Preferences.Instance.ShowContainingRefsExpandedByDefault,
+                };
+            }
+        }
+
         public List<Models.Change> Changes
         {
             get => _changes;
@@ -184,6 +210,18 @@ namespace SourceGit.ViewModels
             _repo = repo;
             _sharedData = sharedData ?? new CommitDetailSharedData();
             WebLinks = Models.CommitLink.Get(repo.Remotes);
+            Preferences.Instance.PropertyChanged += (_, e) =>
+            {
+                if (e.PropertyName == nameof(Preferences.ShowContainingRefsInCommitDetail))
+                {
+                    OnPropertyChanged(nameof(ShowContainingRefsInCommitDetail));
+                    Refresh();
+                }
+                else if (e.PropertyName == nameof(Preferences.ShowContainingRefsExpandedByDefault))
+                {
+                    OnPropertyChanged(nameof(ContainingRefsExpandedByDefault));
+                }
+            };
         }
 
         public CommitDetail Clone()
@@ -543,7 +581,7 @@ namespace SourceGit.ViewModels
                 }, token);
             }
 
-            if (Preferences.Instance.ShowContainingRefsInCommitDetail)
+            if (ShowContainingRefsInCommitDetail)
             {
                 IsContainingRefsLoading = true;
 

--- a/src/ViewModels/CommitDetail.cs
+++ b/src/ViewModels/CommitDetail.cs
@@ -222,6 +222,15 @@ namespace SourceGit.ViewModels
                     OnPropertyChanged(nameof(ContainingRefsExpandedByDefault));
                 }
             };
+
+            _repo.ContainingRefsSettingsChanged += OnContainingRefsSettingsChanged;
+        }
+
+        private void OnContainingRefsSettingsChanged()
+        {
+            OnPropertyChanged(nameof(ShowContainingRefsInCommitDetail));
+            OnPropertyChanged(nameof(ContainingRefsExpandedByDefault));
+            Refresh();
         }
 
         public CommitDetail Clone()

--- a/src/ViewModels/Preferences.cs
+++ b/src/ViewModels/Preferences.cs
@@ -211,6 +211,12 @@ namespace SourceGit.ViewModels
             set => SetProperty(ref _showContainingRefsInCommitDetail, value);
         }
 
+        public bool ShowContainingRefsExpandedByDefault
+        {
+            get => _showContainingRefsExpandedByDefault;
+            set => SetProperty(ref _showContainingRefsExpandedByDefault, value);
+        }
+
         public string IgnoreUpdateTag
         {
             get => _ignoreUpdateTag;
@@ -834,6 +840,7 @@ namespace SourceGit.ViewModels
         private bool _showAuthorTimeInGraph = false;
         private bool _showChildren = false;
         private bool _showContainingRefsInCommitDetail = false;
+        private bool _showContainingRefsExpandedByDefault = false;
 
         private bool _check4UpdatesOnStartup = true;
         private double _lastCheckUpdateTime = 0;

--- a/src/ViewModels/Preferences.cs
+++ b/src/ViewModels/Preferences.cs
@@ -205,6 +205,12 @@ namespace SourceGit.ViewModels
             set => SetProperty(ref _showChildren, value);
         }
 
+        public bool ShowContainingRefsInCommitDetail
+        {
+            get => _showContainingRefsInCommitDetail;
+            set => SetProperty(ref _showContainingRefsInCommitDetail, value);
+        }
+
         public string IgnoreUpdateTag
         {
             get => _ignoreUpdateTag;
@@ -827,6 +833,7 @@ namespace SourceGit.ViewModels
         private bool _useGitHubStyleAvatar = true;
         private bool _showAuthorTimeInGraph = false;
         private bool _showChildren = false;
+        private bool _showContainingRefsInCommitDetail = false;
 
         private bool _check4UpdatesOnStartup = true;
         private double _lastCheckUpdateTime = 0;

--- a/src/ViewModels/Repository.cs
+++ b/src/ViewModels/Repository.cs
@@ -34,6 +34,8 @@ namespace SourceGit.ViewModels
             get => _settings;
         }
 
+        public event Action ContainingRefsSettingsChanged;
+
         public Models.RepositoryUIStates UIStates
         {
             get => _uiStates;
@@ -455,6 +457,11 @@ namespace SourceGit.ViewModels
 
             _settings = Models.RepositorySettings.Get(_gitCommonDir);
             _uiStates = Models.RepositoryUIStates.Load(GitDir);
+        }
+
+        public void NotifyContainingRefsSettingsChanged()
+        {
+            ContainingRefsSettingsChanged?.Invoke();
         }
 
         public void Open()

--- a/src/ViewModels/RepositoryConfigure.cs
+++ b/src/ViewModels/RepositoryConfigure.cs
@@ -110,6 +110,7 @@ namespace SourceGit.ViewModels
                 {
                     _repo.Settings.ShowContainingRefsInCommitDetail = value;
                     OnPropertyChanged();
+                    _repo.NotifyContainingRefsSettingsChanged();
                 }
             }
         }
@@ -123,6 +124,7 @@ namespace SourceGit.ViewModels
                 {
                     _repo.Settings.ContainingRefsDefaultExpansion = value;
                     OnPropertyChanged();
+                    _repo.NotifyContainingRefsSettingsChanged();
                 }
             }
         }

--- a/src/ViewModels/RepositoryConfigure.cs
+++ b/src/ViewModels/RepositoryConfigure.cs
@@ -101,6 +101,32 @@ namespace SourceGit.ViewModels
             set => _repo.Settings.AskBeforeAutoUpdatingSubmodules = value;
         }
 
+        public int ShowContainingRefsInCommitDetail
+        {
+            get => _repo.Settings.ShowContainingRefsInCommitDetail;
+            set
+            {
+                if (_repo.Settings.ShowContainingRefsInCommitDetail != value)
+                {
+                    _repo.Settings.ShowContainingRefsInCommitDetail = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
+        public int ContainingRefsDefaultExpansion
+        {
+            get => _repo.Settings.ContainingRefsDefaultExpansion;
+            set
+            {
+                if (_repo.Settings.ContainingRefsDefaultExpansion != value)
+                {
+                    _repo.Settings.ContainingRefsDefaultExpansion = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
         public AvaloniaList<Models.CommitTemplate> CommitTemplates
         {
             get => _repo.Settings.CommitTemplates;

--- a/src/Views/CommitBaseInfo.axaml
+++ b/src/Views/CommitBaseInfo.axaml
@@ -151,39 +151,6 @@
             </ItemsControl.ItemTemplate>
           </ItemsControl>
 
-          <!-- CONTAINS IN -->
-          <TextBlock Grid.Row="3" Grid.Column="0" Classes="info_label" VerticalAlignment="Top" Margin="0,4,0,0" Text="{DynamicResource Text.CommitDetail.Info.ContainsIn.TableTitle}" IsVisible="{Binding #ThisControl.ShowContainingRefsInCommitDetail}"/>
-          <Grid Grid.Row="3" Grid.Column="1" Margin="12,0,0,0" IsVisible="{Binding #ThisControl.ShowContainingRefsInCommitDetail}">
-            <v:LoadingIcon Width="14" Height="14" Margin="0,4,0,0" IsVisible="{Binding #ThisControl.IsContainingRefsLoading}"/>
-            <Grid ColumnDefinitions="*,Auto" IsVisible="{Binding #ThisControl.ContainingRefs, Converter={x:Static c:ListConverters.IsNotNullOrEmpty}}">
-              <Border Grid.Column="0"
-                      ClipToBounds="True"
-                      MaxHeight="{Binding #ThisControl.IsContainingRefsExpanded, Converter={x:Static c:DoubleConverters.ToContainingRefsMaxHeight}}">
-                <v:CommitRefsPresenter x:Name="ContainingRefsPresenter"
-                                       Margin="0,4,0,0"
-                                       Foreground="{DynamicResource Brush.FG1}"
-                                       FontSize="12"
-                                       AllowWrap="True"
-                                       UseGraphColor="False"
-                                       Refs="{Binding #ThisControl.ContainingRefs}"/>
-              </Border>
-
-              <Button Grid.Column="1"
-                      Classes="icon_button"
-                      Width="24"
-                      Height="24"
-                      Margin="4,0,0,0"
-                      VerticalAlignment="Top"
-                      Click="OnToggleContainingRefsExpanded"
-                      IsVisible="{Binding #ContainingRefsPresenter.HasOverflow}">
-                <Grid>
-                  <Path Width="10" Height="10" Data="{StaticResource Icons.Down}" IsVisible="{Binding #ThisControl.IsContainingRefsExpanded, Converter={x:Static BoolConverters.Not}}"/>
-                  <Path Width="10" Height="10" Data="{StaticResource Icons.Up}" IsVisible="{Binding #ThisControl.IsContainingRefsExpanded}"/>
-                </Grid>
-              </Button>
-            </Grid>
-          </Grid>
-
           <!-- CHILDREN -->
           <TextBlock Grid.Row="2" Grid.Column="0" Classes="info_label" VerticalAlignment="Top" Margin="0,4,0,0" Text="{DynamicResource Text.CommitDetail.Info.Children}" IsVisible="{Binding #ThisControl.Children, Converter={x:Static c:ListConverters.IsNotNullOrEmpty}}"/>
           <ItemsControl Grid.Row="2" Grid.Column="1" Margin="12,0,0,0" ItemsSource="{Binding #ThisControl.Children}" IsVisible="{Binding #ThisControl.Children, Converter={x:Static c:ListConverters.IsNotNullOrEmpty}}">
@@ -232,8 +199,8 @@
           </ItemsControl>
 
           <!-- REFS -->
-          <TextBlock Grid.Row="4" Grid.Column="0" Classes="info_label" VerticalAlignment="Top" Margin="0,4,0,0" Text="{DynamicResource Text.CommitDetail.Info.Refs}" IsVisible="{Binding HasDecorators}"/>
-          <Border Grid.Row="4" Grid.Column="1" Margin="12,0,0,0" MinHeight="24" IsVisible="{Binding HasDecorators}">
+          <TextBlock Grid.Row="3" Grid.Column="0" Classes="info_label" VerticalAlignment="Top" Margin="0,4,0,0" Text="{DynamicResource Text.CommitDetail.Info.Refs}" IsVisible="{Binding HasDecorators}"/>
+          <Border Grid.Row="3" Grid.Column="1" Margin="12,0,0,0" MinHeight="24" IsVisible="{Binding HasDecorators}">
             <v:CommitRefsPresenter Foreground="{DynamicResource Brush.FG1}"
                                    FontSize="12"
                                    AllowWrap="True"
@@ -241,6 +208,39 @@
                                    UseGraphColor="False"
                                    PointerReleased="OnCommitRefsPresenterPointerReleased"/>
           </Border>
+
+          <!-- CONTAINS IN -->
+          <TextBlock Grid.Row="4" Grid.Column="0" Classes="info_label" VerticalAlignment="Top" Margin="0,4,0,0" Text="{DynamicResource Text.CommitDetail.Info.ContainsIn.TableTitle}" IsVisible="{Binding #ThisControl.ShowContainingRefsInCommitDetail}"/>
+          <Grid Grid.Row="4" Grid.Column="1" Margin="12,0,0,0" IsVisible="{Binding #ThisControl.ShowContainingRefsInCommitDetail}">
+            <v:LoadingIcon Width="14" Height="14" Margin="0,4,0,0" IsVisible="{Binding #ThisControl.IsContainingRefsLoading}"/>
+            <Grid ColumnDefinitions="*,Auto" IsVisible="{Binding #ThisControl.ContainingRefs, Converter={x:Static c:ListConverters.IsNotNullOrEmpty}}">
+              <Border Grid.Column="0"
+                      ClipToBounds="True"
+                      MaxHeight="{Binding #ThisControl.IsContainingRefsExpanded, Converter={x:Static c:DoubleConverters.ToContainingRefsMaxHeight}}">
+                <v:CommitRefsPresenter x:Name="ContainingRefsPresenter"
+                                       Margin="0,4,0,0"
+                                       Foreground="{DynamicResource Brush.FG1}"
+                                       FontSize="12"
+                                       AllowWrap="True"
+                                       UseGraphColor="False"
+                                       Refs="{Binding #ThisControl.ContainingRefs}"/>
+              </Border>
+
+              <Button Grid.Column="1"
+                      Classes="icon_button"
+                      Width="24"
+                      Height="24"
+                      Margin="4,0,0,0"
+                      VerticalAlignment="Top"
+                      Click="OnToggleContainingRefsExpanded"
+                      IsVisible="{Binding #ContainingRefsPresenter.HasOverflow}">
+                <Grid>
+                  <Path Width="10" Height="10" Data="{StaticResource Icons.Down}" IsVisible="{Binding #ThisControl.IsContainingRefsExpanded, Converter={x:Static BoolConverters.Not}}"/>
+                  <Path Width="10" Height="10" Data="{StaticResource Icons.Up}" IsVisible="{Binding #ThisControl.IsContainingRefsExpanded}"/>
+                </Grid>
+              </Button>
+            </Grid>
+          </Grid>
 
           <!-- Messages -->
           <TextBlock Grid.Row="5" Grid.Column="0" Classes="info_label" VerticalAlignment="Top" Margin="0,4,0,0" Text="{DynamicResource Text.CommitDetail.Info.Message}" />

--- a/src/Views/CommitBaseInfo.axaml
+++ b/src/Views/CommitBaseInfo.axaml
@@ -55,7 +55,7 @@
         <Rectangle Height=".65" Margin="8,8,0,8" Fill="{DynamicResource Brush.Border2}" VerticalAlignment="Center"/>
 
         <!-- Base Information -->
-        <Grid RowDefinitions="24,Auto,Auto,Auto,Auto" ColumnDefinitions="96,*">
+        <Grid RowDefinitions="24,Auto,Auto,Auto,Auto,Auto" ColumnDefinitions="112,*">
           <!-- SHA -->
           <TextBlock Grid.Row="0" Grid.Column="0" Classes="info_label" VerticalAlignment="Top" Margin="0,4,0,0" Text="{DynamicResource Text.CommitDetail.Info.SHA}" />
           <StackPanel Grid.Row="0" Grid.Column="1" Orientation="Horizontal" Height="24">
@@ -68,7 +68,13 @@
               </Grid>
             </Button>
 
-            <Button Classes="icon_button" Width="24" Cursor="Hand" Click="OnOpenContainsIn" IsVisible="{Binding #ThisControl.SupportsContainsIn}" ToolTip.Tip="{DynamicResource Text.CommitDetail.Info.ContainsIn}">
+            <Button Classes="icon_button" Width="24" Cursor="Hand" Click="OnOpenContainsIn" ToolTip.Tip="{DynamicResource Text.CommitDetail.Info.ContainsIn}">
+              <Button.IsVisible>
+                <MultiBinding Converter="{x:Static BoolConverters.And}">
+                  <Binding Path="#ThisControl.SupportsContainsIn"/>
+                  <Binding Path="#ThisControl.ShowContainingRefsInCommitDetail" Converter="{x:Static BoolConverters.Not}"/>
+                </MultiBinding>
+              </Button.IsVisible>
               <Path Width="14" Height="14" Margin="0,1,0,0" Data="{StaticResource Icons.Relation}"/>
             </Button>
 
@@ -145,6 +151,31 @@
             </ItemsControl.ItemTemplate>
           </ItemsControl>
 
+          <!-- CONTAINS IN -->
+          <TextBlock Grid.Row="3" Grid.Column="0" Classes="info_label" VerticalAlignment="Top" Margin="0,4,0,0" Text="{DynamicResource Text.CommitDetail.Info.ContainsIn.TableTitle}" IsVisible="{Binding #ThisControl.ShowContainingRefsInCommitDetail}"/>
+          <Grid Grid.Row="3" Grid.Column="1" Margin="12,0,0,0" IsVisible="{Binding #ThisControl.ShowContainingRefsInCommitDetail}">
+            <v:LoadingIcon Width="14" Height="14" Margin="0,4,0,0" IsVisible="{Binding #ThisControl.IsContainingRefsLoading}"/>
+            <ItemsControl ItemsSource="{Binding #ThisControl.ContainingRefs}" IsVisible="{Binding #ThisControl.ContainingRefs, Converter={x:Static c:ListConverters.IsNotNullOrEmpty}}">
+              <ItemsControl.ItemsPanel>
+                <ItemsPanelTemplate>
+                  <WrapPanel Orientation="Horizontal" VerticalAlignment="Center" ItemHeight="24"/>
+                </ItemsPanelTemplate>
+              </ItemsControl.ItemsPanel>
+
+              <ItemsControl.ItemTemplate>
+                <DataTemplate DataType="m:Decorator">
+                  <Border Height="20" Margin="0,4,6,0" BorderThickness="1" BorderBrush="{DynamicResource Brush.Border2}" CornerRadius="12">
+                    <StackPanel Orientation="Horizontal" Margin="8,0" VerticalAlignment="Center">
+                      <Path Width="10" Height="10" Data="{StaticResource Icons.Branch}" IsVisible="{Binding !IsTag}"/>
+                      <Path Width="10" Height="10" Data="{StaticResource Icons.Tag}" IsVisible="{Binding IsTag}"/>
+                      <TextBlock Text="{Binding Name}" Margin="2,0,0,0"/>
+                    </StackPanel>
+                  </Border>
+                </DataTemplate>
+              </ItemsControl.ItemTemplate>
+            </ItemsControl>
+          </Grid>
+
           <!-- CHILDREN -->
           <TextBlock Grid.Row="2" Grid.Column="0" Classes="info_label" VerticalAlignment="Top" Margin="0,4,0,0" Text="{DynamicResource Text.CommitDetail.Info.Children}" IsVisible="{Binding #ThisControl.Children, Converter={x:Static c:ListConverters.IsNotNullOrEmpty}}"/>
           <ItemsControl Grid.Row="2" Grid.Column="1" Margin="12,0,0,0" ItemsSource="{Binding #ThisControl.Children}" IsVisible="{Binding #ThisControl.Children, Converter={x:Static c:ListConverters.IsNotNullOrEmpty}}">
@@ -193,8 +224,8 @@
           </ItemsControl>
 
           <!-- REFS -->
-          <TextBlock Grid.Row="3" Grid.Column="0" Classes="info_label" VerticalAlignment="Top" Margin="0,4,0,0" Text="{DynamicResource Text.CommitDetail.Info.Refs}" IsVisible="{Binding HasDecorators}"/>
-          <Border Grid.Row="3" Grid.Column="1" Margin="12,0,0,0" MinHeight="24" IsVisible="{Binding HasDecorators}">
+          <TextBlock Grid.Row="4" Grid.Column="0" Classes="info_label" VerticalAlignment="Top" Margin="0,4,0,0" Text="{DynamicResource Text.CommitDetail.Info.Refs}" IsVisible="{Binding HasDecorators}"/>
+          <Border Grid.Row="4" Grid.Column="1" Margin="12,0,0,0" MinHeight="24" IsVisible="{Binding HasDecorators}">
             <v:CommitRefsPresenter Foreground="{DynamicResource Brush.FG1}"
                                    FontSize="12"
                                    AllowWrap="True"
@@ -204,8 +235,8 @@
           </Border>
 
           <!-- Messages -->
-          <TextBlock Grid.Row="4" Grid.Column="0" Classes="info_label" VerticalAlignment="Top" Margin="0,4,0,0" Text="{DynamicResource Text.CommitDetail.Info.Message}" />
-          <v:CommitMessagePresenter Grid.Row="4" Grid.Column="1"
+          <TextBlock Grid.Row="5" Grid.Column="0" Classes="info_label" VerticalAlignment="Top" Margin="0,4,0,0" Text="{DynamicResource Text.CommitDetail.Info.Message}" />
+          <v:CommitMessagePresenter Grid.Row="5" Grid.Column="1"
                                     Margin="12,4,0,0"
                                     Foreground="{DynamicResource Brush.FG1}"
                                     FullMessage="{Binding #ThisControl.FullMessage}"

--- a/src/Views/CommitBaseInfo.axaml
+++ b/src/Views/CommitBaseInfo.axaml
@@ -155,25 +155,33 @@
           <TextBlock Grid.Row="3" Grid.Column="0" Classes="info_label" VerticalAlignment="Top" Margin="0,4,0,0" Text="{DynamicResource Text.CommitDetail.Info.ContainsIn.TableTitle}" IsVisible="{Binding #ThisControl.ShowContainingRefsInCommitDetail}"/>
           <Grid Grid.Row="3" Grid.Column="1" Margin="12,0,0,0" IsVisible="{Binding #ThisControl.ShowContainingRefsInCommitDetail}">
             <v:LoadingIcon Width="14" Height="14" Margin="0,4,0,0" IsVisible="{Binding #ThisControl.IsContainingRefsLoading}"/>
-            <ItemsControl ItemsSource="{Binding #ThisControl.ContainingRefs}" IsVisible="{Binding #ThisControl.ContainingRefs, Converter={x:Static c:ListConverters.IsNotNullOrEmpty}}">
-              <ItemsControl.ItemsPanel>
-                <ItemsPanelTemplate>
-                  <WrapPanel Orientation="Horizontal" VerticalAlignment="Center" ItemHeight="24"/>
-                </ItemsPanelTemplate>
-              </ItemsControl.ItemsPanel>
+            <Grid ColumnDefinitions="*,Auto" IsVisible="{Binding #ThisControl.ContainingRefs, Converter={x:Static c:ListConverters.IsNotNullOrEmpty}}">
+              <Border Grid.Column="0"
+                      ClipToBounds="True"
+                      MaxHeight="{Binding #ThisControl.IsContainingRefsExpanded, Converter={x:Static c:DoubleConverters.ToContainingRefsMaxHeight}}">
+                <v:CommitRefsPresenter x:Name="ContainingRefsPresenter"
+                                       Margin="0,4,0,0"
+                                       Foreground="{DynamicResource Brush.FG1}"
+                                       FontSize="12"
+                                       AllowWrap="True"
+                                       UseGraphColor="False"
+                                       Refs="{Binding #ThisControl.ContainingRefs}"/>
+              </Border>
 
-              <ItemsControl.ItemTemplate>
-                <DataTemplate DataType="m:Decorator">
-                  <Border Height="20" Margin="0,4,6,0" BorderThickness="1" BorderBrush="{DynamicResource Brush.Border2}" CornerRadius="12">
-                    <StackPanel Orientation="Horizontal" Margin="8,0" VerticalAlignment="Center">
-                      <Path Width="10" Height="10" Data="{StaticResource Icons.Branch}" IsVisible="{Binding !IsTag}"/>
-                      <Path Width="10" Height="10" Data="{StaticResource Icons.Tag}" IsVisible="{Binding IsTag}"/>
-                      <TextBlock Text="{Binding Name}" Margin="2,0,0,0"/>
-                    </StackPanel>
-                  </Border>
-                </DataTemplate>
-              </ItemsControl.ItemTemplate>
-            </ItemsControl>
+              <Button Grid.Column="1"
+                      Classes="icon_button"
+                      Width="24"
+                      Height="24"
+                      Margin="4,0,0,0"
+                      VerticalAlignment="Top"
+                      Click="OnToggleContainingRefsExpanded"
+                      IsVisible="{Binding #ContainingRefsPresenter.HasOverflow}">
+                <Grid>
+                  <Path Width="10" Height="10" Data="{StaticResource Icons.Down}" IsVisible="{Binding #ThisControl.IsContainingRefsExpanded, Converter={x:Static BoolConverters.Not}}"/>
+                  <Path Width="10" Height="10" Data="{StaticResource Icons.Up}" IsVisible="{Binding #ThisControl.IsContainingRefsExpanded}"/>
+                </Grid>
+              </Button>
+            </Grid>
           </Grid>
 
           <!-- CHILDREN -->

--- a/src/Views/CommitBaseInfo.axaml.cs
+++ b/src/Views/CommitBaseInfo.axaml.cs
@@ -90,6 +90,15 @@ namespace SourceGit.Views
             set => SetValue(IsContainingRefsExpandedProperty, value);
         }
 
+        public static readonly StyledProperty<bool> ContainingRefsExpandedByDefaultProperty =
+            AvaloniaProperty.Register<CommitBaseInfo, bool>(nameof(ContainingRefsExpandedByDefault));
+
+        public bool ContainingRefsExpandedByDefault
+        {
+            get => GetValue(ContainingRefsExpandedByDefaultProperty);
+            set => SetValue(ContainingRefsExpandedByDefaultProperty, value);
+        }
+
         public static readonly StyledProperty<bool> IsSHACopiedProperty =
             AvaloniaProperty.Register<CommitBaseInfo, bool>(nameof(IsSHACopied));
 
@@ -112,11 +121,11 @@ namespace SourceGit.Views
             {
                 _iconResetTimer?.Dispose();
                 SetCurrentValue(IsSHACopiedProperty, false);
-                SetCurrentValue(IsContainingRefsExpandedProperty, false);
+                SetCurrentValue(IsContainingRefsExpandedProperty, ContainingRefsExpandedByDefault);
             }
             else if (change.Property == ContainingRefsProperty)
             {
-                SetCurrentValue(IsContainingRefsExpandedProperty, false);
+                SetCurrentValue(IsContainingRefsExpandedProperty, ContainingRefsExpandedByDefault);
             }
         }
 

--- a/src/Views/CommitBaseInfo.axaml.cs
+++ b/src/Views/CommitBaseInfo.axaml.cs
@@ -127,6 +127,10 @@ namespace SourceGit.Views
             {
                 SetCurrentValue(IsContainingRefsExpandedProperty, ContainingRefsExpandedByDefault);
             }
+            else if (change.Property == ContainingRefsExpandedByDefaultProperty)
+            {
+                SetCurrentValue(IsContainingRefsExpandedProperty, ContainingRefsExpandedByDefault);
+            }
         }
 
         protected override void OnUnloaded(RoutedEventArgs e)

--- a/src/Views/CommitBaseInfo.axaml.cs
+++ b/src/Views/CommitBaseInfo.axaml.cs
@@ -81,6 +81,15 @@ namespace SourceGit.Views
             set => SetValue(IsContainingRefsLoadingProperty, value);
         }
 
+        public static readonly StyledProperty<bool> IsContainingRefsExpandedProperty =
+            AvaloniaProperty.Register<CommitBaseInfo, bool>(nameof(IsContainingRefsExpanded));
+
+        public bool IsContainingRefsExpanded
+        {
+            get => GetValue(IsContainingRefsExpandedProperty);
+            set => SetValue(IsContainingRefsExpandedProperty, value);
+        }
+
         public static readonly StyledProperty<bool> IsSHACopiedProperty =
             AvaloniaProperty.Register<CommitBaseInfo, bool>(nameof(IsSHACopied));
 
@@ -103,6 +112,11 @@ namespace SourceGit.Views
             {
                 _iconResetTimer?.Dispose();
                 SetCurrentValue(IsSHACopiedProperty, false);
+                SetCurrentValue(IsContainingRefsExpandedProperty, false);
+            }
+            else if (change.Property == ContainingRefsProperty)
+            {
+                SetCurrentValue(IsContainingRefsExpandedProperty, false);
             }
         }
 
@@ -175,6 +189,12 @@ namespace SourceGit.Views
                 await tracking.SetDataAsync(detail);
             }
 
+            e.Handled = true;
+        }
+
+        private void OnToggleContainingRefsExpanded(object sender, RoutedEventArgs e)
+        {
+            IsContainingRefsExpanded = !IsContainingRefsExpanded;
             e.Handled = true;
         }
 

--- a/src/Views/CommitBaseInfo.axaml.cs
+++ b/src/Views/CommitBaseInfo.axaml.cs
@@ -50,10 +50,35 @@ namespace SourceGit.Views
         public static readonly StyledProperty<List<string>> ChildrenProperty =
             AvaloniaProperty.Register<CommitBaseInfo, List<string>>(nameof(Children));
 
+        public static readonly StyledProperty<List<Models.Decorator>> ContainingRefsProperty =
+            AvaloniaProperty.Register<CommitBaseInfo, List<Models.Decorator>>(nameof(ContainingRefs));
+        public static readonly StyledProperty<bool> ShowContainingRefsInCommitDetailProperty =
+            AvaloniaProperty.Register<CommitBaseInfo, bool>(nameof(ShowContainingRefsInCommitDetail));
+        public static readonly StyledProperty<bool> IsContainingRefsLoadingProperty =
+            AvaloniaProperty.Register<CommitBaseInfo, bool>(nameof(IsContainingRefsLoading));
+
         public List<string> Children
         {
             get => GetValue(ChildrenProperty);
             set => SetValue(ChildrenProperty, value);
+        }
+
+        public List<Models.Decorator> ContainingRefs
+        {
+            get => GetValue(ContainingRefsProperty);
+            set => SetValue(ContainingRefsProperty, value);
+        }
+
+        public bool ShowContainingRefsInCommitDetail
+        {
+            get => GetValue(ShowContainingRefsInCommitDetailProperty);
+            set => SetValue(ShowContainingRefsInCommitDetailProperty, value);
+        }
+
+        public bool IsContainingRefsLoading
+        {
+            get => GetValue(IsContainingRefsLoadingProperty);
+            set => SetValue(IsContainingRefsLoadingProperty, value);
         }
 
         public static readonly StyledProperty<bool> IsSHACopiedProperty =

--- a/src/Views/CommitDetail.axaml
+++ b/src/Views/CommitDetail.axaml
@@ -32,7 +32,8 @@
                             WebLinks="{Binding WebLinks}"
                             Children="{Binding Children}"
                             ContainingRefs="{Binding ContainingRefs}"
-                            ShowContainingRefsInCommitDetail="{Binding Source={x:Static vm:Preferences.Instance}, Path=ShowContainingRefsInCommitDetail}"
+                            ShowContainingRefsInCommitDetail="{Binding ShowContainingRefsInCommitDetail}"
+                            ContainingRefsExpandedByDefault="{Binding ContainingRefsExpandedByDefault}"
                             IsContainingRefsLoading="{Binding IsContainingRefsLoading}"
                             Margin="0,0,12,0"/>
 

--- a/src/Views/CommitDetail.axaml
+++ b/src/Views/CommitDetail.axaml
@@ -31,6 +31,9 @@
                             SupportsContainsIn="True"
                             WebLinks="{Binding WebLinks}"
                             Children="{Binding Children}"
+                            ContainingRefs="{Binding ContainingRefs}"
+                            ShowContainingRefsInCommitDetail="{Binding Source={x:Static vm:Preferences.Instance}, Path=ShowContainingRefsInCommitDetail}"
+                            IsContainingRefsLoading="{Binding IsContainingRefsLoading}"
                             Margin="0,0,12,0"/>
 
           <!-- Line -->

--- a/src/Views/CommitRefsPresenter.cs
+++ b/src/Views/CommitRefsPresenter.cs
@@ -83,6 +83,24 @@ namespace SourceGit.Views
             set => SetValue(ShowTagsProperty, value);
         }
 
+        public static readonly StyledProperty<List<Models.Decorator>> RefsProperty =
+            AvaloniaProperty.Register<CommitRefsPresenter, List<Models.Decorator>>(nameof(Refs));
+
+        public List<Models.Decorator> Refs
+        {
+            get => GetValue(RefsProperty);
+            set => SetValue(RefsProperty, value);
+        }
+
+        public static readonly DirectProperty<CommitRefsPresenter, bool> HasOverflowProperty =
+            AvaloniaProperty.RegisterDirect<CommitRefsPresenter, bool>(nameof(HasOverflow), o => o.HasOverflow);
+
+        public bool HasOverflow
+        {
+            get => _hasOverflow;
+            private set => SetAndRaise(HasOverflowProperty, ref _hasOverflow, value);
+        }
+
         static CommitRefsPresenter()
         {
             AffectsMeasure<CommitRefsPresenter>(
@@ -91,7 +109,9 @@ namespace SourceGit.Views
                 ForegroundProperty,
                 UseGraphColorProperty,
                 BackgroundProperty,
-                ShowTagsProperty);
+                AllowWrapProperty,
+                ShowTagsProperty,
+                RefsProperty);
         }
 
         public Models.Decorator DecoratorAt(Point point)
@@ -176,18 +196,18 @@ namespace SourceGit.Views
         {
             _items.Clear();
 
-            if (DataContext is not Models.Commit commit)
-                return new Size(0, 0);
+            var explicitRefs = Refs;
+            var commit = DataContext as Models.Commit;
+            var refs = explicitRefs ?? commit?.Decorators;
 
-            var refs = commit.Decorators;
             if (refs is { Count: > 0 })
             {
                 var typeface = new Typeface(FontFamily);
                 var typefaceBold = new Typeface(FontFamily, FontStyle.Normal, FontWeight.Bold);
                 var fg = Foreground;
-                var normalBG = UseGraphColor ? Models.CommitGraph.Pens[commit.Color].Brush : Brushes.Gray;
+                var normalBG = UseGraphColor && commit != null ? Models.CommitGraph.Pens[commit.Color].Brush : Brushes.Gray;
                 var labelSize = FontSize;
-                var requiredHeight = 16.0;
+                var requiredHeight = 17.0;
                 var x = 0.0;
                 var allowWrap = AllowWrap;
                 var showTags = ShowTags;
@@ -259,17 +279,21 @@ namespace SourceGit.Views
                     }
                 }
 
-                var requiredWidth = allowWrap && requiredHeight > 16.0
+                HasOverflow = allowWrap && requiredHeight > 17.0;
+
+                var requiredWidth = allowWrap && requiredHeight > 17.0
                     ? (double.IsInfinity(availableSize.Width) ? x + 2 : availableSize.Width)
                     : x + 2;
                 InvalidateVisual();
                 return new Size(requiredWidth, requiredHeight);
             }
 
+            HasOverflow = false;
             InvalidateVisual();
             return new Size(0, 0);
         }
 
         private List<RenderItem> _items = new List<RenderItem>();
+        private bool _hasOverflow = false;
     }
 }

--- a/src/Views/Preferences.axaml
+++ b/src/Views/Preferences.axaml
@@ -47,7 +47,7 @@
           <TabItem.Header>
             <TextBlock Classes="tab_header" Text="{DynamicResource Text.Preferences.General}"/>
           </TabItem.Header>
-          <Grid Margin="8" RowDefinitions="32,32,32,32,32,32,32,32,32,32,32,32,32,32,Auto" ColumnDefinitions="Auto,*">
+          <Grid Margin="8" RowDefinitions="32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,Auto" ColumnDefinitions="Auto,*">
             <TextBlock Grid.Row="0" Grid.Column="0"
                        Text="{DynamicResource Text.Preferences.General.Locale}"
                        HorizontalAlignment="Right"
@@ -178,15 +178,21 @@
 
             <CheckBox Grid.Row="12" Grid.Column="1"
                       Height="32"
+                      Content="{DynamicResource Text.Preferences.General.ShowContainingRefsExpandedByDefault}"
+                      IsEnabled="{Binding ShowContainingRefsInCommitDetail}"
+                      IsChecked="{Binding ShowContainingRefsExpandedByDefault, Mode=TwoWay}"/>
+
+            <CheckBox Grid.Row="13" Grid.Column="1"
+                      Height="32"
                       Content="{DynamicResource Text.Preferences.General.EnableCompactFolders}"
                       IsChecked="{Binding EnableCompactFoldersInChangesTree, Mode=TwoWay}"/>
 
-            <CheckBox Grid.Row="13" Grid.Column="1"
+            <CheckBox Grid.Row="14" Grid.Column="1"
                       Height="32"
                       Content="{DynamicResource Text.Preferences.General.UseGitHubStyleAvatar}"
                       IsChecked="{Binding UseGitHubStyleAvatar, Mode=TwoWay}"/>
 
-            <CheckBox Grid.Row="14" Grid.Column="1"
+            <CheckBox Grid.Row="15" Grid.Column="1"
                       Height="32"
                       Content="{DynamicResource Text.Preferences.General.Check4UpdatesOnStartup}"
                       IsVisible="{x:Static s:App.IsCheckForUpdateCommandVisible}"

--- a/src/Views/Preferences.axaml
+++ b/src/Views/Preferences.axaml
@@ -47,7 +47,7 @@
           <TabItem.Header>
             <TextBlock Classes="tab_header" Text="{DynamicResource Text.Preferences.General}"/>
           </TabItem.Header>
-          <Grid Margin="8" RowDefinitions="32,32,32,32,32,32,32,32,32,32,32,32,32,Auto" ColumnDefinitions="Auto,*">
+          <Grid Margin="8" RowDefinitions="32,32,32,32,32,32,32,32,32,32,32,32,32,32,Auto" ColumnDefinitions="Auto,*">
             <TextBlock Grid.Row="0" Grid.Column="0"
                        Text="{DynamicResource Text.Preferences.General.Locale}"
                        HorizontalAlignment="Right"
@@ -173,15 +173,20 @@
 
             <CheckBox Grid.Row="11" Grid.Column="1"
                       Height="32"
+                      Content="{DynamicResource Text.Preferences.General.ShowContainingRefsInCommitDetail}"
+                      IsChecked="{Binding ShowContainingRefsInCommitDetail, Mode=TwoWay}"/>
+
+            <CheckBox Grid.Row="12" Grid.Column="1"
+                      Height="32"
                       Content="{DynamicResource Text.Preferences.General.EnableCompactFolders}"
                       IsChecked="{Binding EnableCompactFoldersInChangesTree, Mode=TwoWay}"/>
 
-            <CheckBox Grid.Row="12" Grid.Column="1"
+            <CheckBox Grid.Row="13" Grid.Column="1"
                       Height="32"
                       Content="{DynamicResource Text.Preferences.General.UseGitHubStyleAvatar}"
                       IsChecked="{Binding UseGitHubStyleAvatar, Mode=TwoWay}"/>
 
-            <CheckBox Grid.Row="13" Grid.Column="1"
+            <CheckBox Grid.Row="14" Grid.Column="1"
                       Height="32"
                       Content="{DynamicResource Text.Preferences.General.Check4UpdatesOnStartup}"
                       IsVisible="{x:Static s:App.IsCheckForUpdateCommandVisible}"

--- a/src/Views/RepositoryConfigure.axaml
+++ b/src/Views/RepositoryConfigure.axaml
@@ -41,6 +41,40 @@
     <TabControl Grid.Row="1">
       <TabItem>
         <TabItem.Header>
+          <TextBlock Classes="tab_header" Text="{DynamicResource Text.Configure.General}"/>
+        </TabItem.Header>
+
+        <Grid Margin="16,4,16,8" RowDefinitions="32,32" ColumnDefinitions="Auto,*">
+          <TextBlock Grid.Row="0" Grid.Column="0"
+                     HorizontalAlignment="Right" VerticalAlignment="Center"
+                     Margin="0,0,8,0"
+                     Text="{DynamicResource Text.Configure.General.ShowContainingRefsInCommitDetail}"/>
+          <ComboBox Grid.Row="0" Grid.Column="1"
+                    Height="28" Padding="8,0"
+                    VerticalAlignment="Center" HorizontalAlignment="Stretch"
+                    SelectedIndex="{Binding ShowContainingRefsInCommitDetail, Mode=TwoWay}">
+            <ComboBoxItem Content="{DynamicResource Text.Configure.General.ContainingRefs.Inherit}"/>
+            <ComboBoxItem Content="{DynamicResource Text.Configure.General.ContainingRefs.Disabled}"/>
+            <ComboBoxItem Content="{DynamicResource Text.Configure.General.ContainingRefs.Enabled}"/>
+          </ComboBox>
+
+          <TextBlock Grid.Row="1" Grid.Column="0"
+                     HorizontalAlignment="Right" VerticalAlignment="Center"
+                     Margin="0,0,8,0"
+                     Text="{DynamicResource Text.Configure.General.ContainingRefsDefaultExpansion}"/>
+          <ComboBox Grid.Row="1" Grid.Column="1"
+                    Height="28" Padding="8,0"
+                    VerticalAlignment="Center" HorizontalAlignment="Stretch"
+                    SelectedIndex="{Binding ContainingRefsDefaultExpansion, Mode=TwoWay}">
+            <ComboBoxItem Content="{DynamicResource Text.Configure.General.ContainingRefs.Inherit}"/>
+            <ComboBoxItem Content="{DynamicResource Text.Configure.General.ContainingRefs.Collapsed}"/>
+            <ComboBoxItem Content="{DynamicResource Text.Configure.General.ContainingRefs.Expanded}"/>
+          </ComboBox>
+        </Grid>
+      </TabItem>
+
+      <TabItem>
+        <TabItem.Header>
           <TextBlock Classes="tab_header" Text="{DynamicResource Text.Configure.Git}"/>
         </TabItem.Header>
 


### PR DESCRIPTION
Adds a new config option to show the containing refs directly in the commit detail view. The default is `false` so that the current behavior of the app stays the default.

When enabled, the tooltip "commit is contained by" is hidden and instead a new row "CONTAINED BY" is shown above the "REFS" in the commit detail view. 

The containing refs are loaded asynchronously to not block the app.

New option in the app settings (red border is only to highlight what changed, not part of the app):
<img width="656" height="546" alt="grafik" src="https://github.com/user-attachments/assets/1133a6a0-133b-44d5-8361-a0f2064fa154" />

Updated commit details view:
<img width="918" height="300" alt="grafik" src="https://github.com/user-attachments/assets/8653197a-b1a7-4774-b8f9-df008f121fa5" />
