### PR TITLE
feature: allow search branches when adding a worktree

### DIFF
--- a/src/ViewModels/AddWorktree.cs
+++ b/src/ViewModels/AddWorktree.cs
@@ -24,23 +24,29 @@ namespace SourceGit.ViewModels
                 if (SetProperty(ref _createNewBranch, value, true))
                 {
                     if (value)
-                        SelectedBranch = string.Empty;
+                        SelectedBranch = null;
                     else
-                        SelectedBranch = LocalBranches.Count > 0 ? LocalBranches[0] : string.Empty;
+                        SelectedBranch = LocalBranches.Count > 0 ? LocalBranches[0] : null;
                 }
             }
         }
 
-        public List<string> LocalBranches
+        public List<Models.Branch> LocalBranches
         {
             get;
             private set;
         }
 
-        public string SelectedBranch
+        public Models.Branch SelectedBranch
         {
             get => _selectedBranch;
             set => SetProperty(ref _selectedBranch, value);
+        }
+
+        public string NewBranchName
+        {
+            get => _newBranchName;
+            set => SetProperty(ref _newBranchName, value);
         }
 
         public bool SetTrackingBranch
@@ -69,12 +75,12 @@ namespace SourceGit.ViewModels
         {
             _repo = repo;
 
-            LocalBranches = new List<string>();
+            LocalBranches = new List<Models.Branch>();
             RemoteBranches = new List<Models.Branch>();
             foreach (var branch in repo.Branches)
             {
                 if (branch.IsLocal)
-                    LocalBranches.Add(branch.Name);
+                    LocalBranches.Add(branch);
                 else
                     RemoteBranches.Add(branch);
             }
@@ -109,7 +115,7 @@ namespace SourceGit.ViewModels
             using var lockWatcher = _repo.LockWatcher();
             ProgressDescription = "Adding worktree ...";
 
-            var branchName = _selectedBranch;
+            var branchName = _createNewBranch ? _newBranchName : (_selectedBranch?.FriendlyName ?? string.Empty);
             var tracking = (_setTrackingBranch && _selectedTrackingBranch != null) ? _selectedTrackingBranch.FriendlyName : string.Empty;
             var log = _repo.CreateLog("Add Worktree");
 
@@ -128,7 +134,7 @@ namespace SourceGit.ViewModels
             if (!_setTrackingBranch || RemoteBranches.Count == 0)
                 return;
 
-            var name = string.IsNullOrEmpty(_selectedBranch) ? System.IO.Path.GetFileName(_path.TrimEnd('/', '\\')) : _selectedBranch;
+            var name = string.IsNullOrEmpty(_selectedBranch?.FriendlyName) ? System.IO.Path.GetFileName(_path.TrimEnd('/', '\\')) : _selectedBranch.FriendlyName;
             var remoteBranch = RemoteBranches.Find(b => b.Name.EndsWith(name, StringComparison.Ordinal));
             if (remoteBranch == null)
                 remoteBranch = RemoteBranches[0];
@@ -139,7 +145,8 @@ namespace SourceGit.ViewModels
         private Repository _repo = null;
         private string _path = string.Empty;
         private bool _createNewBranch = true;
-        private string _selectedBranch = string.Empty;
+        private Models.Branch _selectedBranch = null;
+        private string _newBranchName = string.Empty;
         private bool _setTrackingBranch = false;
         private Models.Branch _selectedTrackingBranch = null;
     }

--- a/src/Views/AddWorktree.axaml
+++ b/src/Views/AddWorktree.axaml
@@ -57,26 +57,17 @@
       <TextBox Grid.Row="2" Grid.Column="1"
                Height="28"
                CornerRadius="3"
-               Text="{Binding SelectedBranch, Mode=TwoWay}"
+               Text="{Binding NewBranchName, Mode=TwoWay}"
                Watermark="{DynamicResource Text.AddWorktree.Name.Placeholder}"
                IsEnabled="{Binding CreateNewBranch, Mode=OneWay}"
                IsVisible="{Binding CreateNewBranch, Mode=OneWay}"/>
-      <ComboBox Grid.Row="2" Grid.Column="1"
-                Height="28" Padding="8,0"
-                VerticalAlignment="Center" HorizontalAlignment="Stretch"
-                ItemsSource="{Binding LocalBranches}"
-                SelectedItem="{Binding SelectedBranch, Mode=TwoWay}"
-                IsEnabled="{Binding !CreateNewBranch, Mode=OneWay}"
-                IsVisible="{Binding !CreateNewBranch, Mode=OneWay}">
-        <ComboBox.ItemTemplate>
-          <DataTemplate>
-            <StackPanel Orientation="Horizontal" Height="20" VerticalAlignment="Center">
-              <Path Margin="0,0,8,0" Width="14" Height="14" Fill="{DynamicResource Brush.FG1}" Data="{StaticResource Icons.Branch}"/>
-              <TextBlock Text="{Binding}"/>
-            </StackPanel>
-          </DataTemplate>
-        </ComboBox.ItemTemplate>
-      </ComboBox>
+      <v:BranchSelector Grid.Row="2" Grid.Column="1"
+                        Height="28"
+                        VerticalAlignment="Center" HorizontalAlignment="Stretch"
+                        Branches="{Binding LocalBranches}"
+                        SelectedBranch="{Binding SelectedBranch, Mode=TwoWay}"
+                        IsEnabled="{Binding !CreateNewBranch, Mode=OneWay}"
+                        IsVisible="{Binding !CreateNewBranch, Mode=OneWay}"/>
 
       <Border Grid.Row="3" Grid.Column="0"
               Height="32"


### PR DESCRIPTION
Fixes #2393. Please note this is "vibe coded" as I do not have any knowledge on C#/.NET/AvaloniaUI, so feel free to make any extra change if necessary. For now this works and looks very well.

## Screenshots
`Existing Branch`:
<img width="550" height="268" alt="image" src="https://github.com/user-attachments/assets/5100b011-8ac1-4507-b29c-207286778fa8" />

`Existing Branch` + `Tracking remote branch`:
<img width="558" height="324" alt="image" src="https://github.com/user-attachments/assets/55d3b327-1385-4269-b763-5b8402f9b96e" />

With search query:
<img width="552" height="275" alt="image" src="https://github.com/user-attachments/assets/b70c49db-41a4-44ce-80d8-830c40800193" />
