### PR TITLE
fix: remove extra '\n' when resolving conflicts using internal merge tool

### DIFF
--- a/src/ViewModels/MergeConflictEditor.cs
+++ b/src/ViewModels/MergeConflictEditor.cs
@@ -190,6 +190,9 @@ namespace SourceGit.ViewModels
             for (var j = lastLineIdx; j < lines.Length; j++)
                 builder.Append(lines[j]).Append('\n');
 
+            if (builder.Length > 1)
+                builder.Length--; // Remove extra '\n'
+
             try
             {
                 // Write merged content to file


### PR DESCRIPTION
When using the internal merge conflict editor, an extra '\n' is added at the end of each resolved file