### PR TITLE
Fix issue where ignore-whitespace can't be toggled (#2435)

### DIFF
--- a/src/ViewModels/DiffContext.cs
+++ b/src/ViewModels/DiffContext.cs
@@ -85,12 +85,12 @@ namespace SourceGit.ViewModels
 
         public void CheckSettings()
         {
+            var pref = Preferences.Instance;
+
             if (Content is TextDiffContext ctx)
             {
-                var pref = Preferences.Instance;
-
-                if ((pref.UseFullTextDiff && _info.UnifiedLines != _entireFileLine) ||
-                    (!pref.UseFullTextDiff && _info.UnifiedLines == _entireFileLine) ||
+                if ((pref.UseFullTextDiff && _info.UnifiedLines != _entireFileLines) ||
+                    (!pref.UseFullTextDiff && _info.UnifiedLines == _entireFileLines) ||
                     (pref.IgnoreWhitespaceChangesInDiff != _info.IgnoreWhitespace))
                 {
                     LoadContent();
@@ -99,6 +99,11 @@ namespace SourceGit.ViewModels
 
                 if (ctx.IsSideBySide() != pref.UseSideBySideDiff)
                     Content = ctx.SwitchMode();
+            }
+            else if (Content is Models.NoOrEOLChange)
+            {
+                if (pref.IgnoreWhitespaceChangesInDiff != _info.IgnoreWhitespace)
+                    LoadContent();
             }
         }
 
@@ -114,7 +119,7 @@ namespace SourceGit.ViewModels
             Task.Run(async () =>
             {
                 var pref = Preferences.Instance;
-                var numLines = pref.UseFullTextDiff ? _entireFileLine : _unifiedLines;
+                var numLines = pref.UseFullTextDiff ? _entireFileLines : _unifiedLines;
                 var ignoreWhitespace = pref.IgnoreWhitespaceChangesInDiff;
                 var ignoreCRAtEOL = pref.IgnoreCRAtEOLInDiff;
 
@@ -326,7 +331,7 @@ namespace SourceGit.ViewModels
             }
         }
 
-        private readonly int _entireFileLine = 999999999;
+        private readonly int _entireFileLines = 999999999;
         private readonly string _repo;
         private readonly Models.DiffOption _option = null;
         private string _fileModeChange = string.Empty;

--- a/src/Views/DiffView.axaml
+++ b/src/Views/DiffView.axaml
@@ -182,15 +182,6 @@
 
             <ToggleButton Classes="line_path"
                           Width="28"
-                          IsChecked="{Binding Source={x:Static vm:Preferences.Instance}, Path=IgnoreWhitespaceChangesInDiff, Mode=TwoWay}"
-                          IsVisible="{Binding IsIgnoreWhitespaceVisible, Mode=OneWay}"
-                          ToolTip.Tip="{DynamicResource Text.Diff.IgnoreWhitespace}"
-                          PropertyChanged="OnToggleButtonPropertyChanged">
-              <Path Width="14" Height="14" Stretch="Uniform" Data="{StaticResource Icons.Whitespace}"/>
-            </ToggleButton>
-
-            <ToggleButton Classes="line_path"
-                          Width="28"
                           IsChecked="{Binding Source={x:Static vm:Preferences.Instance}, Path=ShowHiddenSymbolsInDiffView, Mode=TwoWay}"
                           IsVisible="{Binding IsTextDiff}"
                           ToolTip.Tip="{DynamicResource Text.Diff.ShowHiddenSymbols}">
@@ -205,6 +196,15 @@
                           ToolTip.Tip="{DynamicResource Text.Diff.SideBySide}"
                           PropertyChanged="OnToggleButtonPropertyChanged">
               <Path Width="12" Height="12" Data="{StaticResource Icons.Layout}" Margin="0,2,0,0"/>
+            </ToggleButton>
+
+            <ToggleButton Classes="line_path"
+                          Width="28"
+                          IsChecked="{Binding Source={x:Static vm:Preferences.Instance}, Path=IgnoreWhitespaceChangesInDiff, Mode=TwoWay}"
+                          IsVisible="{Binding IsIgnoreWhitespaceVisible, Mode=OneWay}"
+                          ToolTip.Tip="{DynamicResource Text.Diff.IgnoreWhitespace}"
+                          PropertyChanged="OnToggleButtonPropertyChanged">
+              <Path Width="14" Height="14" Stretch="Uniform" Data="{StaticResource Icons.Whitespace}"/>
             </ToggleButton>
 
             <Button x:Name="BtnOpenExternalMergeTool"


### PR DESCRIPTION
Also move the toggle-button to avoid having it jumping around when toggled (which is a UI-design no-no).

This fixes issue #2435.

(Additionally, renamed nearby variable from _entireFileLine to _entireFileLines, for clarity and consistency with variable _unifiedLines.)