### PR TITLE
fix: remote expanded nodes lost after checkout or create/rename branch

### DIFF
--- a/src/ViewModels/Repository.cs
+++ b/src/ViewModels/Repository.cs
@@ -806,7 +806,7 @@ namespace SourceGit.ViewModels
                     locals.Add(b);
             }
 
-            var builder = BuildBranchTree(locals, []);
+            var builder = BuildBranchTree(locals, _remotes);
             LocalBranchTrees = builder.Locals;
 
             RefreshCommits();
@@ -841,7 +841,7 @@ namespace SourceGit.ViewModels
                     locals.Add(b);
             }
 
-            var builder = BuildBranchTree(locals, []);
+            var builder = BuildBranchTree(locals, _remotes);
             LocalBranchTrees = builder.Locals;
             CurrentBranch = checkouted;
 
@@ -867,7 +867,7 @@ namespace SourceGit.ViewModels
                     locals.Add(branch);
             }
 
-            var builder = BuildBranchTree(locals, []);
+            var builder = BuildBranchTree(locals, _remotes);
             LocalBranchTrees = builder.Locals;
 
             RefreshCommits();


### PR DESCRIPTION
`RefreshAfterCreateBranch`, `RefreshAfterCheckoutBranch`, and
`RefreshAfterRenameBranch` call `BuildBranchTree` with an empty remotes
list, causing all `refs/remotes/*` entries in `ExpandedBranchNodesInSideBar`
to be incorrectly treated as invalid and removed.

Fix by passing `_remotes` instead of `[]`.
