### PR TITLE
Fix: sort staged+amend changes the same way as ordinary staged changes

### DIFF
--- a/src/ViewModels/WorkingCopy.cs
+++ b/src/ViewModels/WorkingCopy.cs
@@ -708,7 +708,11 @@ namespace SourceGit.ViewModels
         private List<Models.Change> GetStagedChanges(List<Models.Change> cached)
         {
             if (_useAmend)
-                return new Commands.QueryStagedChangesWithAmend(_repo.FullPath).GetResult();
+            {
+                var changes = new Commands.QueryStagedChangesWithAmend(_repo.FullPath).GetResult();
+                changes.Sort((l, r) => Models.NumericSort.Compare(l.Path, r.Path));
+                return changes;
+            }
 
             var rs = new List<Models.Change>();
             foreach (var c in cached)


### PR DESCRIPTION
This is a simple fix, to make sure `Staged changes with Amend` are sorted the same way as ordinary `Staged` (and `Unstaged`) changes (i.e. using the case-insensitive `Models.NumericSort.Compare()` function).

For reference, the latter (existing) sorting is performed in `ViewModels.Repository.RefreshWorkingCopyChanges()`.

