### PR TITLE
feature: author filter and go-to-SHA jump in commit history

### DIFF
--- a/TRANSLATION.md
+++ b/TRANSLATION.md
@@ -6,7 +6,7 @@ This document shows the translation status of each locale file in the repository
 
 ### ![en_US](https://img.shields.io/badge/en__US-%E2%88%9A-brightgreen)
 
-### ![de__DE](https://img.shields.io/badge/de__DE-91.08%25-yellow)
+### ![de__DE](https://img.shields.io/badge/de__DE-90.63%25-yellow)
 
 <details>
 <summary>Missing keys in de_DE.axaml</summary>
@@ -55,6 +55,11 @@ This document shows the translation status of each locale file in the repository
 - Text.GitFlow.StartAt
 - Text.GitFlow.StartName
 - Text.GotoRevisionSelector
+- Text.Histories.Filter.Author
+- Text.Histories.Filter.MoreContributors
+- Text.Histories.GoToSHA
+- Text.Histories.GoToSHA.Hint
+- Text.Histories.GoToSHA.NotFound
 - Text.Histories.HighlightsInGraph
 - Text.Histories.HighlightsInGraph.All
 - Text.Histories.HighlightsInGraph.CurrentBranchOnly
@@ -104,7 +109,7 @@ This document shows the translation status of each locale file in the repository
 
 </details>
 
-### ![el__GR](https://img.shields.io/badge/el__GR-98.22%25-yellow)
+### ![el__GR](https://img.shields.io/badge/el__GR-97.73%25-yellow)
 
 <details>
 <summary>Missing keys in el_GR.axaml</summary>
@@ -124,13 +129,18 @@ This document shows the translation status of each locale file in the repository
 - Text.GitFlow.FinishWithRebase
 - Text.GitFlow.StartAt
 - Text.GitFlow.StartName
+- Text.Histories.Filter.Author
+- Text.Histories.Filter.MoreContributors
+- Text.Histories.GoToSHA
+- Text.Histories.GoToSHA.Hint
+- Text.Histories.GoToSHA.NotFound
 - Text.TagCM.Checkout
 - Text.TagCM.Merge
 - Text.UpdateSubmodules.Recursive
 
 </details>
 
-### ![es__ES](https://img.shields.io/badge/es__ES-98.22%25-yellow)
+### ![es__ES](https://img.shields.io/badge/es__ES-97.73%25-yellow)
 
 <details>
 <summary>Missing keys in es_ES.axaml</summary>
@@ -150,13 +160,18 @@ This document shows the translation status of each locale file in the repository
 - Text.GitFlow.FinishWithRebase
 - Text.GitFlow.StartAt
 - Text.GitFlow.StartName
+- Text.Histories.Filter.Author
+- Text.Histories.Filter.MoreContributors
+- Text.Histories.GoToSHA
+- Text.Histories.GoToSHA.Hint
+- Text.Histories.GoToSHA.NotFound
 - Text.TagCM.Checkout
 - Text.TagCM.Merge
 - Text.UpdateSubmodules.Recursive
 
 </details>
 
-### ![fr__FR](https://img.shields.io/badge/fr__FR-97.13%25-yellow)
+### ![fr__FR](https://img.shields.io/badge/fr__FR-96.65%25-yellow)
 
 <details>
 <summary>Missing keys in fr_FR.axaml</summary>
@@ -178,6 +193,11 @@ This document shows the translation status of each locale file in the repository
 - Text.GitFlow.FinishWithRebase
 - Text.GitFlow.StartAt
 - Text.GitFlow.StartName
+- Text.Histories.Filter.Author
+- Text.Histories.Filter.MoreContributors
+- Text.Histories.GoToSHA
+- Text.Histories.GoToSHA.Hint
+- Text.Histories.GoToSHA.NotFound
 - Text.Merge.Test
 - Text.Merge.Test.NoConflicts
 - Text.Merge.Test.UnknownError
@@ -193,7 +213,7 @@ This document shows the translation status of each locale file in the repository
 
 </details>
 
-### ![he__IL](https://img.shields.io/badge/he__IL-97.13%25-yellow)
+### ![he__IL](https://img.shields.io/badge/he__IL-96.65%25-yellow)
 
 <details>
 <summary>Missing keys in he_IL.axaml</summary>
@@ -215,6 +235,11 @@ This document shows the translation status of each locale file in the repository
 - Text.GitFlow.FinishWithRebase
 - Text.GitFlow.StartAt
 - Text.GitFlow.StartName
+- Text.Histories.Filter.Author
+- Text.Histories.Filter.MoreContributors
+- Text.Histories.GoToSHA
+- Text.Histories.GoToSHA.Hint
+- Text.Histories.GoToSHA.NotFound
 - Text.Merge.Test
 - Text.Merge.Test.NoConflicts
 - Text.Merge.Test.UnknownError
@@ -230,7 +255,7 @@ This document shows the translation status of each locale file in the repository
 
 </details>
 
-### ![id__ID](https://img.shields.io/badge/id__ID-83.94%25-yellow)
+### ![id__ID](https://img.shields.io/badge/id__ID-83.53%25-yellow)
 
 <details>
 <summary>Missing keys in id_ID.axaml</summary>
@@ -304,6 +329,11 @@ This document shows the translation status of each locale file in the repository
 - Text.GitLFS.Locks.UnlockAllMyLocks
 - Text.GitLFS.Locks.UnlockAllMyLocks.Confirm
 - Text.GotoRevisionSelector
+- Text.Histories.Filter.Author
+- Text.Histories.Filter.MoreContributors
+- Text.Histories.GoToSHA
+- Text.Histories.GoToSHA.Hint
+- Text.Histories.GoToSHA.NotFound
 - Text.Histories.HighlightsInGraph
 - Text.Histories.HighlightsInGraph.All
 - Text.Histories.HighlightsInGraph.CurrentBranchOnly
@@ -400,7 +430,7 @@ This document shows the translation status of each locale file in the repository
 
 </details>
 
-### ![it__IT](https://img.shields.io/badge/it__IT-90.58%25-yellow)
+### ![it__IT](https://img.shields.io/badge/it__IT-90.14%25-yellow)
 
 <details>
 <summary>Missing keys in it_IT.axaml</summary>
@@ -450,6 +480,11 @@ This document shows the translation status of each locale file in the repository
 - Text.GitFlow.StartAt
 - Text.GitFlow.StartName
 - Text.GotoRevisionSelector
+- Text.Histories.Filter.Author
+- Text.Histories.Filter.MoreContributors
+- Text.Histories.GoToSHA
+- Text.Histories.GoToSHA.Hint
+- Text.Histories.GoToSHA.NotFound
 - Text.Histories.HighlightsInGraph
 - Text.Histories.HighlightsInGraph.All
 - Text.Histories.HighlightsInGraph.CurrentBranchOnly
@@ -503,7 +538,7 @@ This document shows the translation status of each locale file in the repository
 
 </details>
 
-### ![ja__JP](https://img.shields.io/badge/ja__JP-91.38%25-yellow)
+### ![ja__JP](https://img.shields.io/badge/ja__JP-90.93%25-yellow)
 
 <details>
 <summary>Missing keys in ja_JP.axaml</summary>
@@ -551,6 +586,11 @@ This document shows the translation status of each locale file in the repository
 - Text.GitFlow.FinishWithRebase
 - Text.GitFlow.StartAt
 - Text.GitFlow.StartName
+- Text.Histories.Filter.Author
+- Text.Histories.Filter.MoreContributors
+- Text.Histories.GoToSHA
+- Text.Histories.GoToSHA.Hint
+- Text.Histories.GoToSHA.NotFound
 - Text.Histories.HighlightsInGraph
 - Text.Histories.HighlightsInGraph.All
 - Text.Histories.HighlightsInGraph.CurrentBranchOnly
@@ -598,7 +638,7 @@ This document shows the translation status of each locale file in the repository
 
 </details>
 
-### ![ko__KR](https://img.shields.io/badge/ko__KR-98.61%25-yellow)
+### ![ko__KR](https://img.shields.io/badge/ko__KR-98.13%25-yellow)
 
 <details>
 <summary>Missing keys in ko_KR.axaml</summary>
@@ -614,13 +654,18 @@ This document shows the translation status of each locale file in the repository
 - Text.GitFlow.FinishWithRebase
 - Text.GitFlow.StartAt
 - Text.GitFlow.StartName
+- Text.Histories.Filter.Author
+- Text.Histories.Filter.MoreContributors
+- Text.Histories.GoToSHA
+- Text.Histories.GoToSHA.Hint
+- Text.Histories.GoToSHA.NotFound
 - Text.TagCM.Checkout
 - Text.TagCM.Merge
 - Text.UpdateSubmodules.Recursive
 
 </details>
 
-### ![pt__BR](https://img.shields.io/badge/pt__BR-63.83%25-red)
+### ![pt__BR](https://img.shields.io/badge/pt__BR-63.51%25-red)
 
 <details>
 <summary>Missing keys in pt_BR.axaml</summary>
@@ -780,6 +825,11 @@ This document shows the translation status of each locale file in the repository
 - Text.GitLFS.Locks.UnlockAllMyLocks
 - Text.GitLFS.Locks.UnlockAllMyLocks.Confirm
 - Text.GotoRevisionSelector
+- Text.Histories.Filter.Author
+- Text.Histories.Filter.MoreContributors
+- Text.Histories.GoToSHA
+- Text.Histories.GoToSHA.Hint
+- Text.Histories.GoToSHA.NotFound
 - Text.Histories.HighlightsInGraph
 - Text.Histories.HighlightsInGraph.All
 - Text.Histories.HighlightsInGraph.CurrentBranchOnly
@@ -993,7 +1043,7 @@ This document shows the translation status of each locale file in the repository
 
 </details>
 
-### ![ru__RU](https://img.shields.io/badge/ru__RU-98.61%25-yellow)
+### ![ru__RU](https://img.shields.io/badge/ru__RU-98.13%25-yellow)
 
 <details>
 <summary>Missing keys in ru_RU.axaml</summary>
@@ -1009,13 +1059,18 @@ This document shows the translation status of each locale file in the repository
 - Text.GitFlow.FinishWithRebase
 - Text.GitFlow.StartAt
 - Text.GitFlow.StartName
+- Text.Histories.Filter.Author
+- Text.Histories.Filter.MoreContributors
+- Text.Histories.GoToSHA
+- Text.Histories.GoToSHA.Hint
+- Text.Histories.GoToSHA.NotFound
 - Text.TagCM.Checkout
 - Text.TagCM.Merge
 - Text.UpdateSubmodules.Recursive
 
 </details>
 
-### ![ta__IN](https://img.shields.io/badge/ta__IN-65.71%25-red)
+### ![ta__IN](https://img.shields.io/badge/ta__IN-65.38%25-red)
 
 <details>
 <summary>Missing keys in ta_IN.axaml</summary>
@@ -1189,6 +1244,11 @@ This document shows the translation status of each locale file in the repository
 - Text.GitLFS.Locks.UnlockAllMyLocks
 - Text.GitLFS.Locks.UnlockAllMyLocks.Confirm
 - Text.GotoRevisionSelector
+- Text.Histories.Filter.Author
+- Text.Histories.Filter.MoreContributors
+- Text.Histories.GoToSHA
+- Text.Histories.GoToSHA.Hint
+- Text.Histories.GoToSHA.NotFound
 - Text.Histories.HighlightsInGraph
 - Text.Histories.HighlightsInGraph.All
 - Text.Histories.HighlightsInGraph.CurrentBranchOnly
@@ -1369,7 +1429,7 @@ This document shows the translation status of each locale file in the repository
 
 </details>
 
-### ![uk__UA](https://img.shields.io/badge/uk__UA-66.50%25-red)
+### ![uk__UA](https://img.shields.io/badge/uk__UA-66.17%25-red)
 
 <details>
 <summary>Missing keys in uk_UA.axaml</summary>
@@ -1539,6 +1599,11 @@ This document shows the translation status of each locale file in the repository
 - Text.GitLFS.Locks.UnlockAllMyLocks
 - Text.GitLFS.Locks.UnlockAllMyLocks.Confirm
 - Text.GotoRevisionSelector
+- Text.Histories.Filter.Author
+- Text.Histories.Filter.MoreContributors
+- Text.Histories.GoToSHA
+- Text.Histories.GoToSHA.Hint
+- Text.Histories.GoToSHA.NotFound
 - Text.Histories.HighlightsInGraph
 - Text.Histories.HighlightsInGraph.All
 - Text.Histories.HighlightsInGraph.CurrentBranchOnly
@@ -1715,6 +1780,28 @@ This document shows the translation status of each locale file in the repository
 
 </details>
 
-### ![zh__CN](https://img.shields.io/badge/zh__CN-%E2%88%9A-brightgreen)
+### ![zh__CN](https://img.shields.io/badge/zh__CN-99.51%25-yellow)
 
-### ![zh__TW](https://img.shields.io/badge/zh__TW-%E2%88%9A-brightgreen)
+<details>
+<summary>Missing keys in zh_CN.axaml</summary>
+
+- Text.Histories.Filter.Author
+- Text.Histories.Filter.MoreContributors
+- Text.Histories.GoToSHA
+- Text.Histories.GoToSHA.Hint
+- Text.Histories.GoToSHA.NotFound
+
+</details>
+
+### ![zh__TW](https://img.shields.io/badge/zh__TW-99.51%25-yellow)
+
+<details>
+<summary>Missing keys in zh_TW.axaml</summary>
+
+- Text.Histories.Filter.Author
+- Text.Histories.Filter.MoreContributors
+- Text.Histories.GoToSHA
+- Text.Histories.GoToSHA.Hint
+- Text.Histories.GoToSHA.NotFound
+
+</details>

--- a/src/Resources/Locales/en_US.axaml
+++ b/src/Resources/Locales/en_US.axaml
@@ -497,6 +497,11 @@
   <x:String x:Key="Text.GitLFS.TrackByExtension" xml:space="preserve">Track all *{0} files</x:String>
   <x:String x:Key="Text.GotoRevisionSelector" xml:space="preserve">Select Commit</x:String>
   <x:String x:Key="Text.Histories" xml:space="preserve">HISTORY</x:String>
+  <x:String x:Key="Text.Histories.Filter.Author" xml:space="preserve">Filter by author name or email</x:String>
+  <x:String x:Key="Text.Histories.Filter.MoreContributors" xml:space="preserve">Showing top 100 of {0}. Refine to narrow.</x:String>
+  <x:String x:Key="Text.Histories.GoToSHA" xml:space="preserve">Go to SHA</x:String>
+  <x:String x:Key="Text.Histories.GoToSHA.Hint" xml:space="preserve">Jumps to the commit with this SHA prefix.</x:String>
+  <x:String x:Key="Text.Histories.GoToSHA.NotFound" xml:space="preserve">No loaded commit matches this SHA prefix.</x:String>
   <x:String x:Key="Text.Histories.Header.Author" xml:space="preserve">AUTHOR</x:String>
   <x:String x:Key="Text.Histories.Header.AuthorTime" xml:space="preserve">AUTHOR TIME</x:String>
   <x:String x:Key="Text.Histories.Header.CommitTime" xml:space="preserve">COMMIT TIME</x:String>

--- a/src/ViewModels/Histories.cs
+++ b/src/ViewModels/Histories.cs
@@ -75,11 +75,76 @@ namespace SourceGit.ViewModels
             get => _commits;
             set
             {
-                GenerateGraph(value, true);
-                if (SetProperty(ref _commits, value))
-                    PostCommitsChanged();
+                _fullCommits = value ?? [];
+                RebuildContributors();
+                ApplyCommitFilters();
             }
         }
+
+        public string CommitAuthorFilter
+        {
+            get => _commitAuthorFilter;
+            set
+            {
+                if (SetProperty(ref _commitAuthorFilter, value ?? string.Empty))
+                {
+                    OnPropertyChanged(nameof(IsAuthorFilterActive));
+                    UpdateVisibleContributors();
+                    ScheduleApplyCommitFilters();
+                }
+            }
+        }
+
+        public string GoToSHAInput
+        {
+            get => _goToSHAInput;
+            set
+            {
+                if (SetProperty(ref _goToSHAInput, value ?? string.Empty))
+                    TryGoToSHA(value);
+            }
+        }
+
+        public bool GoToSHANotFound
+        {
+            get => _goToSHANotFound;
+            private set => SetProperty(ref _goToSHANotFound, value);
+        }
+
+        public List<Models.StatisticsAuthor> VisibleContributors
+        {
+            get => _visibleContributors;
+            private set => SetProperty(ref _visibleContributors, value);
+        }
+
+        public int MatchedContributorsCount
+        {
+            get => _matchedContributorsCount;
+            private set => SetProperty(ref _matchedContributorsCount, value);
+        }
+
+        public bool HasMoreContributors
+        {
+            get => _hasMoreContributors;
+            private set => SetProperty(ref _hasMoreContributors, value);
+        }
+
+        public bool IsAuthorFilterActive
+        {
+            get => !string.IsNullOrEmpty(_commitAuthorFilter);
+        }
+
+        public Models.StatisticsAuthor SelectedContributor
+        {
+            get => _selectedContributor;
+            set
+            {
+                if (SetProperty(ref _selectedContributor, value) && value != null)
+                    PickContributor(value);
+            }
+        }
+
+        public event Action<Models.Commit> RequestBringIntoView;
 
         public Models.CommitGraph Graph
         {
@@ -193,6 +258,12 @@ namespace SourceGit.ViewModels
         {
             _repo = repo;
             _commitDetailSharedData = new CommitDetailSharedData();
+            _applyFiltersTimer = new DispatcherTimer() { Interval = TimeSpan.FromMilliseconds(200) };
+            _applyFiltersTimer.Tick += (_, _) =>
+            {
+                _applyFiltersTimer.Stop();
+                ApplyCommitFilters();
+            };
         }
 
         public void NotifyCurrentBranchChanged()
@@ -510,6 +581,144 @@ namespace SourceGit.ViewModels
                 GenerateGraph(_commits);
         }
 
+        public void PickContributor(Models.StatisticsAuthor contributor)
+        {
+            if (contributor?.User is not { } user)
+                return;
+
+            CommitAuthorFilter = string.IsNullOrEmpty(user.Email) ? user.Name : user.Email;
+        }
+
+        public void ClearAuthorFilter() => ClearAuthorFilterCore(debounce: true);
+
+        private void TryGoToSHA(string text)
+        {
+            var prefix = text?.Trim();
+            if (string.IsNullOrEmpty(prefix) || prefix.Length < 4)
+            {
+                GoToSHANotFound = false;
+                return;
+            }
+
+            var found = _fullCommits.Find(c => c.SHA.StartsWith(prefix, StringComparison.OrdinalIgnoreCase));
+            GoToSHANotFound = found == null;
+            NavigateToCommit(found);
+        }
+
+        private void NavigateToCommit(Models.Commit target, bool select = true, Models.Commit fallback = null)
+        {
+            var scrollTo = target ?? fallback;
+            if (scrollTo == null)
+                return;
+
+            if (!_commits.Contains(scrollTo))
+                ClearAuthorFilterImmediate();
+
+            if (select && target != null)
+                SelectedCommits = [target];
+
+            RequestBringIntoView?.Invoke(scrollTo);
+        }
+
+        private void ClearAuthorFilterImmediate() => ClearAuthorFilterCore(debounce: false);
+
+        private void ClearAuthorFilterCore(bool debounce)
+        {
+            SelectedContributor = null;
+            if (!SetProperty(ref _commitAuthorFilter, string.Empty, nameof(CommitAuthorFilter)))
+                return;
+
+            OnPropertyChanged(nameof(IsAuthorFilterActive));
+            UpdateVisibleContributors();
+            if (debounce)
+                ScheduleApplyCommitFilters();
+            else
+                ApplyCommitFilters();
+        }
+
+        private void RebuildContributors()
+        {
+            var map = new Dictionary<string, Models.StatisticsAuthor>();
+            foreach (var c in _fullCommits)
+            {
+                var user = c.Author;
+                var key = $"{user.Name}{user.Email}";
+                if (map.TryGetValue(key, out var exist))
+                    exist.Count++;
+                else
+                    map.Add(key, new Models.StatisticsAuthor(user, 1));
+            }
+
+            _allContributors = new List<Models.StatisticsAuthor>(map.Values);
+            _allContributors.Sort((l, r) => string.Compare(l.User.Name, r.User.Name, StringComparison.OrdinalIgnoreCase));
+
+            UpdateVisibleContributors();
+        }
+
+        private void UpdateVisibleContributors()
+        {
+            var filter = _commitAuthorFilter;
+            var hasFilter = !string.IsNullOrEmpty(filter);
+
+            var shown = new List<Models.StatisticsAuthor>();
+            var matched = 0;
+            foreach (var c in _allContributors)
+            {
+                if (hasFilter &&
+                    c.User.Name.IndexOf(filter, StringComparison.OrdinalIgnoreCase) < 0 &&
+                    c.User.Email.IndexOf(filter, StringComparison.OrdinalIgnoreCase) < 0)
+                    continue;
+
+                matched++;
+                if (shown.Count < MAX_VISIBLE_CONTRIBUTORS)
+                    shown.Add(c);
+            }
+
+            HasMoreContributors = matched > shown.Count;
+            MatchedContributorsCount = matched;
+            VisibleContributors = shown;
+        }
+
+        private void ScheduleApplyCommitFilters()
+        {
+            _applyFiltersTimer.Stop();
+            _applyFiltersTimer.Start();
+        }
+
+        private void ApplyCommitFilters()
+        {
+            _applyFiltersTimer.Stop();
+
+            var filtered = BuildFilteredCommits();
+            GenerateGraph(filtered, true);
+            if (SetProperty(ref _commits, filtered, nameof(Commits)))
+                PostCommitsChanged();
+        }
+
+        private List<Models.Commit> BuildFilteredCommits()
+        {
+            var author = _commitAuthorFilter;
+            if (string.IsNullOrEmpty(author))
+                return _fullCommits;
+
+            var result = new List<Models.Commit>();
+            foreach (var c in _fullCommits)
+            {
+                if (c.Author.Name.IndexOf(author, StringComparison.OrdinalIgnoreCase) < 0 &&
+                    c.Author.Email.IndexOf(author, StringComparison.OrdinalIgnoreCase) < 0)
+                    continue;
+
+                result.Add(c);
+            }
+
+            return result;
+        }
+
+        public void StopFilterTimer()
+        {
+            _applyFiltersTimer?.Stop();
+        }
+
         private void GenerateGraph(List<Models.Commit> commits, bool commitsChanged = false)
         {
             var firstParentOnly = _repo.UIStates.HistoryShowFlags.HasFlag(Models.HistoryShowFlags.FirstParentOnly);
@@ -525,10 +734,22 @@ namespace SourceGit.ViewModels
             Graph = Models.CommitGraph.Generate(commits, commitsChanged, firstParentOnly, highlighting, extraHeads);
         }
 
+        private const int MAX_VISIBLE_CONTRIBUTORS = 100;
+
         private Repository _repo = null;
         private CommitDetailSharedData _commitDetailSharedData = null;
         private bool _isLoading = true;
         private List<Models.Commit> _commits = [];
+        private List<Models.Commit> _fullCommits = [];
+        private string _commitAuthorFilter = string.Empty;
+        private string _goToSHAInput = string.Empty;
+        private bool _goToSHANotFound = false;
+        private Models.StatisticsAuthor _selectedContributor = null;
+        private List<Models.StatisticsAuthor> _allContributors = [];
+        private List<Models.StatisticsAuthor> _visibleContributors = [];
+        private bool _hasMoreContributors = false;
+        private int _matchedContributorsCount = 0;
+        private readonly DispatcherTimer _applyFiltersTimer = null;
         private Models.CommitGraph _graph = null;
         private List<Models.Commit> _selectedCommits = [];
         private Models.Bisect _bisect = null;

--- a/src/ViewModels/Repository.cs
+++ b/src/ViewModels/Repository.cs
@@ -499,8 +499,9 @@ namespace SourceGit.ViewModels
             if (_cancellationRefreshStashes is { IsCancellationRequested: false })
                 _cancellationRefreshStashes.Cancel();
 
+            _histories?.StopFilterTimer();
             _watcher?.Dispose();
-            _autoFetchTimer.Dispose();
+            _autoFetchTimer?.Dispose();
         }
 
         public void SendNotification(string message, bool isError = false)

--- a/src/Views/Histories.axaml
+++ b/src/Views/Histories.axaml
@@ -10,6 +10,105 @@
              x:Class="SourceGit.Views.Histories"
              x:DataType="vm:Histories"
              x:Name="ThisControl">
+  <UserControl.Resources>
+    <Flyout x:Key="AuthorFilterFlyout" Placement="BottomEdgeAlignedRight">
+      <DockPanel x:DataType="vm:Histories" Width="248">
+        <TextBox DockPanel.Dock="Top"
+                 Height="26"
+                 BorderThickness="1"
+                 CornerRadius="4"
+                 BorderBrush="{DynamicResource Brush.Border2}"
+                 PlaceholderText="{DynamicResource Text.Histories.Filter.Author}"
+                 Text="{Binding CommitAuthorFilter, Mode=TwoWay}"
+                 VerticalContentAlignment="Center">
+          <TextBox.InnerLeftContent>
+            <Path Width="14" Height="14" Margin="6,0,0,0" Fill="{DynamicResource Brush.FG2}" Data="{StaticResource Icons.Search}"/>
+          </TextBox.InnerLeftContent>
+          <TextBox.InnerRightContent>
+            <Button Classes="icon_button"
+                    Width="16"
+                    Margin="0,0,6,0"
+                    HorizontalAlignment="Right"
+                    Command="{Binding ClearAuthorFilter}"
+                    IsVisible="{Binding CommitAuthorFilter, Converter={x:Static StringConverters.IsNotNullOrEmpty}}">
+              <Path Width="14" Height="14" Margin="0,1,0,0" Fill="{DynamicResource Brush.FG1}" Data="{StaticResource Icons.Clear}"/>
+            </Button>
+          </TextBox.InnerRightContent>
+        </TextBox>
+
+        <TextBlock DockPanel.Dock="Bottom"
+                   Margin="2,6,2,0"
+                   FontSize="11"
+                   Foreground="{DynamicResource Brush.FG2}"
+                   IsVisible="{Binding HasMoreContributors}"
+                   Text="{Binding MatchedContributorsCount, Converter={x:Static c:StringConverters.FormatByResourceKey}, ConverterParameter='Histories.Filter.MoreContributors'}"/>
+
+        <ListBox Margin="0,6,0,0"
+                 MaxHeight="280"
+                 Padding="0"
+                 BorderThickness="0"
+                 Background="Transparent"
+                 SelectionMode="Single"
+                 ScrollViewer.AllowAutoHide="False"
+                 ScrollViewer.HorizontalScrollBarVisibility="Disabled"
+                 ItemsSource="{Binding VisibleContributors}"
+                 SelectedItem="{Binding SelectedContributor, Mode=TwoWay}">
+          <ListBox.ItemsPanel>
+            <ItemsPanelTemplate>
+              <VirtualizingStackPanel Orientation="Vertical"/>
+            </ItemsPanelTemplate>
+          </ListBox.ItemsPanel>
+          <ListBox.Styles>
+            <Style Selector="ListBoxItem">
+              <Setter Property="Height" Value="38"/>
+              <Setter Property="Padding" Value="6,0"/>
+              <Setter Property="CornerRadius" Value="3"/>
+            </Style>
+          </ListBox.Styles>
+          <ListBox.ItemTemplate>
+            <DataTemplate DataType="m:StatisticsAuthor">
+              <Grid ColumnDefinitions="16,*" Background="Transparent">
+                <v:Avatar Grid.Column="0" Width="16" Height="16" VerticalAlignment="Center" IsHitTestVisible="False" User="{Binding User}"/>
+                <StackPanel Grid.Column="1" Margin="8,0,0,0" VerticalAlignment="Center">
+                  <TextBlock TextTrimming="CharacterEllipsis" Text="{Binding User.Name}"/>
+                  <TextBlock FontSize="11"
+                             Foreground="{DynamicResource Brush.FG2}"
+                             TextTrimming="CharacterEllipsis"
+                             IsVisible="{Binding User.Email, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"
+                             Text="{Binding User.Email}"/>
+                </StackPanel>
+              </Grid>
+            </DataTemplate>
+          </ListBox.ItemTemplate>
+        </ListBox>
+      </DockPanel>
+    </Flyout>
+
+    <Flyout x:Key="GoToSHAFlyout" Placement="BottomEdgeAlignedRight">
+      <StackPanel x:DataType="vm:Histories" Width="220" Spacing="4">
+        <TextBlock FontSize="11" Foreground="{DynamicResource Brush.FG2}" Text="{DynamicResource Text.Histories.GoToSHA}"/>
+        <TextBox Height="26"
+                 BorderThickness="1"
+                 CornerRadius="4"
+                 BorderBrush="{DynamicResource Brush.Border2}"
+                 FontFamily="{DynamicResource Fonts.Monospace}"
+                 PlaceholderText="a1b2c3d"
+                 Text="{Binding GoToSHAInput, Mode=TwoWay}"
+                 VerticalContentAlignment="Center">
+          <TextBox.InnerLeftContent>
+            <Path Width="13" Height="13" Margin="6,0,0,0" Fill="{DynamicResource Brush.FG2}" Data="{StaticResource Icons.Search}"/>
+          </TextBox.InnerLeftContent>
+        </TextBox>
+        <TextBlock FontSize="10" Foreground="{DynamicResource Brush.FG2}" TextWrapping="Wrap"
+                   IsVisible="{Binding !GoToSHANotFound}"
+                   Text="{DynamicResource Text.Histories.GoToSHA.Hint}"/>
+        <TextBlock FontSize="10" Foreground="{DynamicResource Brush.Conflict}" TextWrapping="Wrap"
+                   IsVisible="{Binding GoToSHANotFound}"
+                   Text="{DynamicResource Text.Histories.GoToSHA.NotFound}"/>
+      </StackPanel>
+    </Flyout>
+  </UserControl.Resources>
+
   <v:HistoriesLayout UseHorizontal="{Binding Source={x:Static vm:Preferences.Instance}, Path=UseTwoColumnsLayoutInHistories}">
     <v:HistoriesLayout.RowDefinitions>
       <RowDefinition Height="{Binding TopArea, Mode=TwoWay}" MinHeight="100"/>
@@ -148,7 +247,29 @@
 
           <DataGridTemplateColumn MinWidth="80" IsReadOnly="True" IsVisible="{Binding IsAuthorColumnVisible, Mode=OneWay}">
             <DataGridTemplateColumn.Header>
-              <TextBlock Classes="table_header" Text="{DynamicResource Text.Histories.Header.Author}" HorizontalAlignment="Center"/>
+              <Grid>
+                <TextBlock Classes="table_header" Text="{DynamicResource Text.Histories.Header.Author}" HorizontalAlignment="Center"/>
+                <Border Width="16" Height="16" Margin="0,0,4,0"
+                        HorizontalAlignment="Right" VerticalAlignment="Center"
+                        Background="Transparent"
+                        ToolTip.Tip="{DynamicResource Text.Histories.Filter.Author}"
+                        FlyoutBase.AttachedFlyout="{StaticResource AuthorFilterFlyout}">
+                  <Panel>
+                    <Path Width="10" Height="10"
+                          HorizontalAlignment="Center" VerticalAlignment="Center"
+                          Data="{StaticResource Icons.Filter}"
+                          IsHitTestVisible="False"
+                          Fill="{DynamicResource Brush.FG2}"
+                          IsVisible="{Binding !IsAuthorFilterActive}"/>
+                    <Path Width="10" Height="10"
+                          HorizontalAlignment="Center" VerticalAlignment="Center"
+                          Data="{StaticResource Icons.Filter}"
+                          IsHitTestVisible="False"
+                          Fill="{DynamicResource Brush.Accent}"
+                          IsVisible="{Binding IsAuthorFilterActive}"/>
+                  </Panel>
+                </Border>
+              </Grid>
             </DataGridTemplateColumn.Header>
 
             <DataGridTemplateColumn.CellTemplate>
@@ -176,7 +297,21 @@
 
           <DataGridTemplateColumn MinWidth="100" IsReadOnly="True" IsVisible="{Binding IsSHAColumnVisible, Mode=OneWay}">
             <DataGridTemplateColumn.Header>
-              <TextBlock Classes="table_header" Text="{DynamicResource Text.Histories.Header.SHA}" HorizontalAlignment="Center"/>
+              <Grid>
+                <TextBlock Classes="table_header" Text="{DynamicResource Text.Histories.Header.SHA}" HorizontalAlignment="Center"/>
+                <Border Width="16" Height="16" Margin="0,0,4,0"
+                        Tag="GoToSHA"
+                        HorizontalAlignment="Right" VerticalAlignment="Center"
+                        Background="Transparent"
+                        ToolTip.Tip="{DynamicResource Text.Histories.GoToSHA}"
+                        FlyoutBase.AttachedFlyout="{StaticResource GoToSHAFlyout}">
+                  <Path Width="11" Height="11"
+                        HorizontalAlignment="Center" VerticalAlignment="Center"
+                        Data="{StaticResource Icons.Search}"
+                        IsHitTestVisible="False"
+                        Fill="{DynamicResource Brush.FG2}"/>
+                </Border>
+              </Grid>
             </DataGridTemplateColumn.Header>
 
             <DataGridTemplateColumn.CellTemplate>
@@ -236,7 +371,7 @@
               PointerMoved="OnCommitListHeaderPointerMoved"
               PointerPressed="OnCommitListHeaderPointerPressed"
               PointerReleased="OnCommitListHeaderPointerReleased"
-              ContextRequested="OnCommitListHeaderContextRequested"/>              
+              ContextRequested="OnCommitListHeaderContextRequested"/>
 
       <v:CommitGraph x:Name="CommitGraph"
                      Margin="0,24,0,0"

--- a/src/Views/Histories.axaml.cs
+++ b/src/Views/Histories.axaml.cs
@@ -420,10 +420,23 @@ namespace SourceGit.Views
 
         protected override void OnDataContextChanged(EventArgs e)
         {
+            if (_boundHistories != null)
+                _boundHistories.RequestBringIntoView -= OnRequestBringIntoView;
+
             base.OnDataContextChanged(e);
 
-            if (DataContext is ViewModels.Histories vm)
-                CommitListContainer.Columns[1].Width = new(vm.AuthorColumnWidth, DataGridLengthUnitType.Pixel);
+            _boundHistories = DataContext as ViewModels.Histories;
+            if (_boundHistories != null)
+            {
+                CommitListContainer.Columns[1].Width = new(_boundHistories.AuthorColumnWidth, DataGridLengthUnitType.Pixel);
+                _boundHistories.RequestBringIntoView += OnRequestBringIntoView;
+            }
+        }
+
+        private void OnRequestBringIntoView(Models.Commit commit)
+        {
+            if (commit != null)
+                CommitListContainer.ScrollIntoView(commit, null);
         }
 
         private void OnCommitListHeaderPointerMoved(object sender, PointerEventArgs e)
@@ -431,32 +444,48 @@ namespace SourceGit.Views
             if (sender is not Border border)
                 return;
 
-            if (DataContext is not ViewModels.Histories { IsAuthorColumnVisible: true } vm)
+            if (DataContext is not ViewModels.Histories vm)
                 return;
 
             var pos = e.GetPosition(border);
+
             if (_resizingAuthorColumn)
             {
+                if (!vm.IsAuthorColumnVisible)
+                {
+                    _resizingAuthorColumn = false;
+                    return;
+                }
+
                 var posX = CommitListContainer.Columns[0].ActualWidth;
                 var maxW = posX + CommitListContainer.Columns[1].ActualWidth - 100;
                 var delta = posX - pos.X;
                 var w = Math.Max(Math.Min(vm.AuthorColumnWidth + delta, maxW), 80);
                 CommitListContainer.Columns[1].Width = new(w, DataGridLengthUnitType.Pixel);
                 vm.AuthorColumnWidth = w;
+                return;
             }
-            else
+
+            if (FindHeaderFlyoutOwner(e.GetPosition(CommitListContainer)) != null)
+            {
+                if (border.Cursor != _pointerCursor)
+                    border.Cursor = _pointerCursor;
+                return;
+            }
+
+            if (vm.IsAuthorColumnVisible)
             {
                 var dis = CommitListContainer.Columns[0].ActualWidth - 4 - pos.X;
                 if (dis < 4 && dis > -4)
                 {
                     if (border.Cursor != _resizingCursor)
                         border.Cursor = _resizingCursor;
-                }
-                else if (border.Cursor != Cursor.Default)
-                {
-                    border.Cursor = Cursor.Default;
+                    return;
                 }
             }
+
+            if (border.Cursor != Cursor.Default)
+                border.Cursor = Cursor.Default;
         }
 
         private void OnCommitListHeaderPointerPressed(object sender, PointerPressedEventArgs e)
@@ -464,16 +493,31 @@ namespace SourceGit.Views
             if (sender is not Border border)
                 return;
 
+            if (!e.GetCurrentPoint(border).Properties.IsLeftButtonPressed)
+                return;
+
             var pos = e.GetPosition(border);
+
+            var flyoutOwner = FindHeaderFlyoutOwner(e.GetPosition(CommitListContainer));
+            if (flyoutOwner != null)
+            {
+                if (flyoutOwner.Tag is "GoToSHA" && DataContext is ViewModels.Histories vm)
+                    vm.GoToSHAInput = string.Empty;
+
+                FlyoutBase.ShowAttachedFlyout(flyoutOwner);
+                e.Handled = true;
+                return;
+            }
+
+            if (DataContext is not ViewModels.Histories { IsAuthorColumnVisible: true })
+                return;
+
             var dis = CommitListContainer.Columns[0].ActualWidth - 4 - pos.X;
             if (dis > 4 || dis < -4)
                 return;
 
-            if (e.GetCurrentPoint(border).Properties.IsLeftButtonPressed)
-            {
-                _resizingAuthorColumn = true;
-                e.Handled = true;
-            }
+            _resizingAuthorColumn = true;
+            e.Handled = true;
         }
 
         private void OnCommitListHeaderPointerReleased(object sender, PointerReleasedEventArgs e)
@@ -500,6 +544,8 @@ namespace SourceGit.Views
             authorColumn.Click += (_, ev) =>
             {
                 vm.IsAuthorColumnVisible = !vm.IsAuthorColumnVisible;
+                if (!vm.IsAuthorColumnVisible)
+                    vm.CommitAuthorFilter = string.Empty;
                 ev.Handled = true;
             };
 
@@ -583,8 +629,8 @@ namespace SourceGit.Views
 
         private void OnScrollToTopPointerPressed(object sender, PointerPressedEventArgs e)
         {
-            if (DataContext is ViewModels.Histories histories)
-                CommitListContainer.ScrollIntoView(histories.Commits[0], null);
+            if (DataContext is ViewModels.Histories { Commits: { Count: > 0 } commits })
+                CommitListContainer.ScrollIntoView(commits[0], null);
         }
 
         private void OnCommitListContextRequested(object sender, ContextRequestedEventArgs e)
@@ -1692,7 +1738,25 @@ namespace SourceGit.Views
                 await this.ShowDialogAsync(new ViewModels.InteractiveRebase(repo, on, prefill));
         }
 
+        // The transparent header overlay sits above the grid and swallows clicks, so hit-test the
+        // grid's own subtree to reach the header icons and return whichever carries an attached flyout.
+        private Control FindHeaderFlyoutOwner(Point pointInGrid)
+        {
+            var hit = CommitListContainer.InputHitTest(pointInGrid) as Visual;
+            while (hit != null)
+            {
+                if (hit is Control control && FlyoutBase.GetAttachedFlyout(control) != null)
+                    return control;
+
+                hit = hit.GetVisualParent();
+            }
+
+            return null;
+        }
+
         private bool _resizingAuthorColumn = false;
         private Cursor _resizingCursor = new Cursor(StandardCursorType.SizeWestEast);
+        private Cursor _pointerCursor = new Cursor(StandardCursorType.Hand);
+        private ViewModels.Histories _boundHistories = null;
     }
 }


### PR DESCRIPTION
## What

Adds two affordances to the commit history column headers:

- **Author filter** — a funnel icon in the Author column header opens a filter popup (search box + contributor picker) that hides non-matching commits and rebuilds the graph. Filtering is debounced and leaves the full commit set intact.
- **Go-to-SHA** — a search icon in the SHA column header jumps/scrolls to the commit matching a typed prefix.


## Screenshots
<img width="2238" height="1218" alt="image" src="https://github.com/user-attachments/assets/f014058a-763d-496e-aac9-6c095e3d8046" />
<img width="2984" height="1194" alt="image" src="https://github.com/user-attachments/assets/65b31545-75a6-462f-8da7-1f3510534e52" />
