### PR TITLE
perf: replace manual hex formatting with `Convert.ToHexStringLower`

### DIFF
--- a/src/Models/AvatarManager.cs
+++ b/src/Models/AvatarManager.cs
@@ -224,10 +224,7 @@ namespace SourceGit.Models
         {
             var lowered = email.ToLower(CultureInfo.CurrentCulture).Trim();
             var hash = MD5.HashData(Encoding.Default.GetBytes(lowered));
-            var builder = new StringBuilder(hash.Length * 2);
-            foreach (var c in hash)
-                builder.Append(c.ToString("x2"));
-            return builder.ToString();
+            return Convert.ToHexStringLower(hash);
         }
 
         private void NotifyResourceChanged(string email, Bitmap image)

--- a/src/Models/RepositorySettings.cs
+++ b/src/Models/RepositorySettings.cs
@@ -171,10 +171,7 @@ namespace SourceGit.Models
         private static string HashContent(string source)
         {
             var hash = MD5.HashData(Encoding.Default.GetBytes(source));
-            var builder = new StringBuilder(hash.Length * 2);
-            foreach (var c in hash)
-                builder.Append(c.ToString("x2"));
-            return builder.ToString();
+            return Convert.ToHexStringLower(hash);
         }
 
         private static Dictionary<string, RepositorySettings> _cache = new();


### PR DESCRIPTION
Replace manual hex formatting with `Convert.ToHexStringLower`

Simplifies hash string generation in `AvatarManager.GetEmailHash` and `RepositorySettings.HashContent` by using the .NET 9 API instead of a `StringBuilder` loop. No behavioral change (still produces lowercase hex), reduces allocations and improves readability.