### PR TITLE
[enhancement] Add flag '--ignore-blank-lines' when ignoring whitespace

### DIFF
--- a/src/Commands/Diff.cs
+++ b/src/Commands/Diff.cs
@@ -20,7 +20,7 @@ namespace SourceGit.Commands
         private const string PREFIX_LFS_DEL = "-version https://git-lfs.github.com/spec/";
         private const string PREFIX_LFS_MODIFY = " version https://git-lfs.github.com/spec/";
 
-        public Diff(string repo, Models.DiffOption opt, int unified, bool ignoreWhitespace, bool ignoreCRAtEOL)
+        public Diff(string repo, Models.DiffOption opt, int numContextLines, bool ignoreWhitespace, bool ignoreCRAtEOL)
         {
             _result.TextDiff = new Models.TextDiff();
 
@@ -30,10 +30,10 @@ namespace SourceGit.Commands
             var builder = new StringBuilder(256);
             builder.Append("diff --no-color --no-ext-diff --full-index --patch ");
             if (ignoreWhitespace)
-                builder.Append("--ignore-space-change ");
+                builder.Append("--ignore-space-change --ignore-blank-lines ");
             if (ignoreCRAtEOL)
                 builder.Append("--ignore-cr-at-eol ");
-            builder.Append("--unified=").Append(unified).Append(' ');
+            builder.Append("--unified=").Append(numContextLines).Append(' ');
             builder.Append(opt.ToString());
 
             Args = builder.ToString();


### PR DESCRIPTION
Inspired by a discussion in PR #2411.
* With the added option `--ignore-blank-lines`, some more cases of changes in (added / removed) empty lines will be ignored (but apparently not when there are also other unignored changes in the same file).
* Still, it's a useful addition wherever it applies, since it helps in quickly skipping over files that have only empty-line / line-break changes (by displaying the `No changes or only EOL changes` panel).
* Also renamed argument `unified` to `numContextLines`, for clarity.