### PR TITLE
feature: locale-aware commit messages

### DIFF
--- a/src/AI/Agent.cs
+++ b/src/AI/Agent.cs
@@ -14,7 +14,7 @@ namespace SourceGit.AI
             _service = service;
         }
 
-        public async Task GenerateCommitMessageAsync(string repo, string changeList, Action<string> onUpdate, CancellationToken cancellation)
+        public async Task GenerateCommitMessageAsync(string repo, string changeList, Action<string> onUpdate, CancellationToken cancellation, string locale = null)
         {
             var chatClient = _service.GetChatClient();
             if (chatClient == null)
@@ -26,6 +26,7 @@ namespace SourceGit.AI
                 .AppendLine("Generate a commit message (follow the rule of conventional commit message) for given git repository.")
                 .AppendLine("- Read all given changed files before generating. Only binary files (such as images, audios ...) can be skipped.")
                 .AppendLine("- Output the conventional commit message (with detail changes in list) directly. Do not explain your output nor introduce your answer.")
+                .AppendLine($"Write the commit message in {DiffPrompts.GetOutputLanguage(locale ?? "en_US")}. Keep file paths, class names, method names, code symbols, and fixed UI labels unchanged.")
                 .AppendLine(_service.AdditionalPrompt)
                 .Append("Repository path: ").AppendLine(repo.Quoted())
                 .AppendLine("Changed files ('A' means added, 'M' means modified, 'D' means deleted, 'T' means type changed, 'R' means renamed, 'C' means copied): ")

--- a/src/ViewModels/AIAssistant.cs
+++ b/src/ViewModels/AIAssistant.cs
@@ -87,7 +87,7 @@ namespace SourceGit.ViewModels
                     }
 
                     Dispatcher.UIThread.Post(() => Text = builder.ToString());
-                }, _cancel.Token);
+                }, _cancel.Token, Preferences.Instance.Locale);
 
                 Response = responseBuilder.ToString().Trim();
             }


### PR DESCRIPTION
The "Generate commit message with AI" feature previously sent a fully English prompt to
the AI, so commit messages were always generated in English — regardless of the user's
UI language setting.

This PR adds a single language instruction line to the prompt, derived from the app's
current locale. For example, when the UI is set to Traditional Chinese, the prompt now
includes "Write the commit message in Traditional Chinese."

- `Agent.cs`: added optional `locale` parameter to `GenerateCommitMessageAsync`,
  injects language instruction using the existing `DiffPrompts.GetOutputLanguage()` mapping
  (supports 16 languages)
- `AIAssistant.cs`: passes `Preferences.Instance.Locale` to the agent call
- Backward compatible — defaults to English when locale is not provided
- Works with existing `AdditionalPrompt` customization (language instruction is placed
  before `AdditionalPrompt`)

2 files changed, 3 insertions, 2 deletions.