### PR TITLE
ux: increase mouse scroll speed for launcher tabs

### DIFF
--- a/src/Views/LauncherTabBar.axaml
+++ b/src/Views/LauncherTabBar.axaml
@@ -15,7 +15,7 @@
                   Classes="icon_button"
                   Width="18" Height="28"
                   Margin="0,2,0,0"
-                  Click="ScrollTabsLeft"
+                  Click="OnScrollTabsLeft"
                   IsVisible="{Binding #ThisControl.IsScrollerVisible}">
       <Path Width="8" Height="14" Stretch="Fill" Data="{StaticResource Icons.TriangleLeft}"/>
     </RepeatButton>
@@ -26,7 +26,7 @@
                   HorizontalAlignment="Left"
                   HorizontalScrollBarVisibility="Hidden"
                   VerticalScrollBarVisibility="Disabled"
-                  PointerWheelChanged="ScrollTabs">
+                  PointerWheelChanged="OnScrollTabs">
       <StackPanel Orientation="Horizontal">
         <ListBox x:Name="LauncherTabsList"
                  Classes="launcher_page_tabbar"
@@ -148,7 +148,7 @@
     </ScrollViewer>
 
     <StackPanel Grid.Column="2" Orientation="Horizontal" IsVisible="{Binding #ThisControl.IsScrollerVisible}">
-      <RepeatButton Classes="icon_button" Width="18" Height="28" Margin="0,2,0,0" Click="ScrollTabsRight">
+      <RepeatButton Classes="icon_button" Width="18" Height="28" Margin="0,2,0,0" Click="OnScrollTabsRight">
         <Path Width="8" Height="14" Stretch="Fill" Data="{StaticResource Icons.TriangleRight}"/>
       </RepeatButton>
 

--- a/src/Views/LauncherTabBar.axaml.cs
+++ b/src/Views/LauncherTabBar.axaml.cs
@@ -162,28 +162,46 @@ namespace SourceGit.Views
                 InvalidateVisual();
         }
 
-        private void ScrollTabs(object _, PointerWheelEventArgs e)
+        private void OnScrollTabs(object _, PointerWheelEventArgs e)
         {
             if (!e.KeyModifiers.HasFlag(KeyModifiers.Shift))
             {
+                var lines = e.Pointer.Type switch
+                {
+                    PointerType.Mouse => 3,
+                    _ => 1
+                };
+
                 if (e.Delta.Y < 0)
-                    LauncherTabsScroller.LineRight();
+                    ScrollTabsRight(lines);
                 else if (e.Delta.Y > 0)
-                    LauncherTabsScroller.LineLeft();
+                    ScrollTabsLeft(lines);
                 e.Handled = true;
             }
         }
 
-        private void ScrollTabsLeft(object _, RoutedEventArgs e)
+        private void OnScrollTabsLeft(object _, RoutedEventArgs e)
         {
-            LauncherTabsScroller.LineLeft();
+            ScrollTabsLeft(3);
             e.Handled = true;
         }
 
-        private void ScrollTabsRight(object _, RoutedEventArgs e)
+        private void OnScrollTabsRight(object _, RoutedEventArgs e)
         {
-            LauncherTabsScroller.LineRight();
+            ScrollTabsRight(3);
             e.Handled = true;
+        }
+
+        private void ScrollTabsLeft(int lines)
+        {
+            for (var i = 0; i < lines; i++)
+                LauncherTabsScroller.LineLeft();
+        }
+
+        private void ScrollTabsRight(int lines)
+        {
+            for (var i = 0; i < lines; i++)
+                LauncherTabsScroller.LineRight();
         }
 
         private void OnTabsLayoutUpdated(object _1, EventArgs _2)


### PR DESCRIPTION
When having a lot of repository tabs open, scrolling through them becomes a chore because the scroll speed is so slow.

This change improves UX by simply increasing the speed.

Note: I would have preferred to do this by configuring the control itself, but Avalonia doesn't expose any options for it, hence the slightly clunky for loop.