### PR TITLE
fix: branch name in toolbar not updated immediately after renaming current branch

### DIFF
--- a/src/ViewModels/Repository.cs
+++ b/src/ViewModels/Repository.cs
@@ -847,8 +847,29 @@ namespace SourceGit.ViewModels
             var newFullName = $"refs/heads/{newName}";
             _uiStates.RenameBranchFilter(b.FullName, newFullName);
 
-            b.Name = newName;
-            b.FullName = newFullName;
+            var renamed = new Models.Branch
+            {
+                Name = newName,
+                FullName = newFullName,
+                CommitterDate = b.CommitterDate,
+                Head = b.Head,
+                IsLocal = b.IsLocal,
+                IsCurrent = b.IsCurrent,
+                IsDetachedHead = b.IsDetachedHead,
+                Upstream = b.Upstream,
+                Ahead = b.Ahead,
+                Behind = b.Behind,
+                Remote = b.Remote,
+                IsUpstreamGone = b.IsUpstreamGone,
+                WorktreePath = b.WorktreePath,
+            };
+
+            var idx = _branches.IndexOf(b);
+            if (idx >= 0)
+                _branches[idx] = renamed;
+
+            if (b.IsCurrent)
+                CurrentBranch = renamed;
 
             List<Models.Branch> locals = [];
             foreach (var branch in _branches)


### PR DESCRIPTION
When renaming the current branch, the branch name in the repository
toolbar is not updated until switching to another repository and back.

`RefreshAfterRenameBranch` mutates the existing `Branch` object
in-place and never reassigns `CurrentBranch`, so `SetProperty` sees
no reference change and emits no notification.

Fix by creating a new `Branch` object with the updated name, replacing
the old entry in `_branches`, and assigning `CurrentBranch = renamed`
when the renamed branch is current — consistent with how
`RefreshAfterCheckoutBranch` handles `CurrentBranch = checkouted`.