### PR TITLE
fix: local branches count not updated immediately after creating branch

### DIFF
--- a/src/ViewModels/Repository.cs
+++ b/src/ViewModels/Repository.cs
@@ -799,6 +799,14 @@ namespace SourceGit.ViewModels
             var builder = BuildBranchTree(locals, [], false);
             LocalBranchTrees = builder.Locals;
 
+            var localBranchesCount = 0;
+            foreach (var b in locals)
+            {
+                if (!b.IsDetachedHead)
+                    localBranchesCount++;
+            }
+            LocalBranchesCount = localBranchesCount;
+
             RefreshCommits();
             RefreshWorkingCopyChanges();
             RefreshWorktrees();


### PR DESCRIPTION
After creating a branch, the count next to "LOCAL BRANCHES" in the
sidebar is not updated until the watcher triggers a full refresh.

`RefreshAfterCreateBranch` calls `MarkBranchUpdated()` which suppresses
the watcher, but does not update `LocalBranchesCount` itself.
`LocalBranchesCount` is only set inside `RefreshBranches()`.

Fix by computing the count from the already-built `locals` list and
assigning `LocalBranchesCount` after `LocalBranchTrees` is updated,
consistent with how `RefreshBranches()` calculates it.