### PR TITLE
fix: create branch dialog not respecting stash & reapply default preference

### DIFF
--- a/src/ViewModels/CreateBranch.cs
+++ b/src/ViewModels/CreateBranch.cs
@@ -77,7 +77,9 @@ namespace SourceGit.ViewModels
                 Name = branch.Name;
 
             BasedOn = branch;
-            DealWithLocalChanges = Models.DealWithLocalChanges.DoNothing;
+            DealWithLocalChanges = Preferences.Instance.UseStashAndReapplyByDefault ?
+                Models.DealWithLocalChanges.StashAndReapply :
+                Models.DealWithLocalChanges.DoNothing;
             UpdateOverrideTip();
         }
 
@@ -89,7 +91,9 @@ namespace SourceGit.ViewModels
             _head = commit.SHA;
 
             BasedOn = commit;
-            DealWithLocalChanges = Models.DealWithLocalChanges.DoNothing;
+            DealWithLocalChanges = Preferences.Instance.UseStashAndReapplyByDefault ?
+                Models.DealWithLocalChanges.StashAndReapply :
+                Models.DealWithLocalChanges.DoNothing;
             UpdateOverrideTip();
         }
 
@@ -101,7 +105,9 @@ namespace SourceGit.ViewModels
             _head = tag.SHA;
 
             BasedOn = tag;
-            DealWithLocalChanges = Models.DealWithLocalChanges.DoNothing;
+            DealWithLocalChanges = Preferences.Instance.UseStashAndReapplyByDefault ?
+                Models.DealWithLocalChanges.StashAndReapply :
+                Models.DealWithLocalChanges.DoNothing;
             UpdateOverrideTip();
         }
 


### PR DESCRIPTION
When "Stash & reapply changes by default" is enabled in preferences,
the local changes option in the Create Branch dialog always defaults
to "Do Nothing" instead of "Stash & Reapply".

All three `CreateBranch` constructors hardcode
`DealWithLocalChanges = DoNothing` without checking
`Preferences.Instance.UseStashAndReapplyByDefault`, unlike `Checkout`,
`Pull`, and `CheckoutAndFastForward` which all respect the preference.

Fix by applying the same conditional initialization in all three
`CreateBranch` constructors.