### PR TITLE
fix: prevent unsafe browser targets from issue tracker links

### DIFF
--- a/src/Native/OS.cs
+++ b/src/Native/OS.cs
@@ -242,7 +242,24 @@ namespace SourceGit.Native
 
         public static void OpenBrowser(string url)
         {
+            if (!IsSafeBrowserTarget(url))
+            {
+                Models.Notification.Send(null, $"Blocked unsafe URL: {url}", true);
+                return;
+            }
+
             _backend.OpenBrowser(url);
+        }
+
+        private static bool IsSafeBrowserTarget(string url)
+        {
+            return Uri.IsWellFormedUriString(url, UriKind.Absolute) &&
+                Uri.TryCreate(url, UriKind.Absolute, out var uri) &&
+                (
+                    uri.Scheme == Uri.UriSchemeHttp ||
+                    uri.Scheme == Uri.UriSchemeHttps ||
+                    uri.Scheme == Uri.UriSchemeFtp
+                );
         }
 
         public static void OpenTerminal(string workdir)

--- a/src/Native/Windows.cs
+++ b/src/Native/Windows.cs
@@ -133,7 +133,8 @@ namespace SourceGit.Native
 
         public void OpenBrowser(string url)
         {
-            var info = new ProcessStartInfo("cmd", $"""/c start "" {url.Quoted()}""");
+            var info = new ProcessStartInfo(url);
+            info.UseShellExecute = true;
             info.CreateNoWindow = true;
             Process.Start(info);
         }


### PR DESCRIPTION
This PR prevents repository-provided issue tracker links from being passed to the Windows command shell when opening them in a browser. Shared `.issuetracker` rules can turn commit text into clickable links, we now validate browser targets before opening them and only allows well-formed absolute `http`, `https`, and `ftp` URLs.

On Windows, browser targets are now opened with `UseShellExecute` instead of `cmd /c` start, which avoids command-line parsing of link text and prevents characters in a URL from being interpreted as shell syntax. Unsafe targets are blocked with a notification instead of being opened.

I know `IsWellFormedUriString` is a bit picky in some cases, but given the security concerns, this approach seems reasonable, and the common URL formats I’ve tested so far should work properly.

## Before

A maliciously crafted `.issuetracker` rule could inject shell syntax into the generated browser target:

```ini
[issuetracker "Github ISSUE"]
	regex = "#(\\d+)"
	url = https://github.com/sourcegit-scm/sourcegit/issues/$1\\\" & calc.exe
```

https://github.com/user-attachments/assets/0f830e46-5975-4013-a8d4-96ff1d778927

## After

<img src="https://github.com/user-attachments/assets/245589e1-479e-4f0b-bc96-72339098c8f9" />
