### PR TITLE
style: fix visual inconsistencies between WorkingCopy and StashesPage

### DIFF
--- a/src/Views/StashesPage.axaml
+++ b/src/Views/StashesPage.axaml
@@ -121,9 +121,8 @@
           </TextBlock>
 
           <v:ChangeViewModeSwitcher Grid.Column="2"
-                                    Width="14" Height="14"
-                                    Margin="0,0,8,0"
-                                    HorizontalAlignment="Right"
+                                    Width="26" Height="14"
+                                    Margin="0,1,0,0"
                                     ViewMode="{Binding Source={x:Static vm:Preferences.Instance}, Path=StashChangeViewMode, Mode=TwoWay}"/>
         </Grid>
       </Border>

--- a/src/Views/WorkingCopy.axaml
+++ b/src/Views/WorkingCopy.axaml
@@ -11,7 +11,7 @@
   <Grid SizeChanged="OnMainLayoutSizeChanged">
     <Grid.ColumnDefinitions>
       <ColumnDefinition Width="{Binding Source={x:Static vm:Preferences.Instance}, Path=Layout.WorkingCopyLeftWidth, Mode=TwoWay}" MinWidth="300"/>
-      <ColumnDefinition Width="5"/>
+      <ColumnDefinition Width="4"/>
       <ColumnDefinition Width="*" MinWidth="300"/>
     </Grid.ColumnDefinitions>
 
@@ -145,7 +145,7 @@
                     Focusable="False"/>
 
       <!-- Staged -->
-      <Grid Grid.Row="3" RowDefinitions="28,*">
+      <Grid Grid.Row="3" RowDefinitions="27,*">
         <!-- Staged Toolbar -->
         <Border Grid.Row="0" BorderThickness="0,0,0,1" BorderBrush="{DynamicResource Brush.Border0}">
           <Grid ColumnDefinitions="Auto,Auto,Auto,*,Auto,Auto,Auto">


### PR DESCRIPTION
## Summary

Fix visual inconsistencies between `WorkingCopy` and `StashesPage` left panel toolbars.

### Changes

1. **`WorkingCopy.axaml`**: Reduce `GridSplitter` column width from `5` to `4` to match
   all other views in the codebase.

2. **`WorkingCopy.axaml`**: Reduce Staged toolbar row height from `28` to `27`.
   The `GridSplitter` occupies a separate `Height="1"` row above the Staged section,
   making the effective visual height 29px (1 + 28). Reducing to 27 aligns it with
   the Changes Bar in `StashesPage` (28px row with top border included).

3. **`StashesPage.axaml`**: Update `ChangeViewModeSwitcher` attributes to match
   the Staged toolbar in `WorkingCopy` (`Width="26"`, `Margin="0,1,0,0"`).

### Before / After

| | Before | After |
|---|---|---|
| LOCAL CHANGES | ![before](https://github.com/user-attachments/assets/9b2b2b49-7d06-4e9b-98a8-093f09305919) | ![after](https://github.com/user-attachments/assets/2f916fec-444a-404b-95cd-4789139cf956) |
| STASHES | ![before](https://github.com/user-attachments/assets/5e6957e8-ee99-4349-8060-266ecfdd63b0) | ![after](https://github.com/user-attachments/assets/7eefac7d-7673-4865-a2bb-f330ab22b2ff) |

> Light theme is used in the screenshots to make the differences more visible.