### PR TITLE
fix: focus not following default selection in deal-with-local-changes dialog

### DIFF
--- a/src/Views/DealWithLocalChangesMethod.axaml.cs
+++ b/src/Views/DealWithLocalChangesMethod.axaml.cs
@@ -1,5 +1,6 @@
 ﻿using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Input;
 using Avalonia.Interactivity;
 
 namespace SourceGit.Views
@@ -21,6 +22,24 @@ namespace SourceGit.Views
         public DealWithLocalChangesMethod()
         {
             InitializeComponent();
+        }
+
+        protected override void OnLoaded(RoutedEventArgs e)
+        {
+            base.OnLoaded(e);
+
+            switch (Method)
+            {
+                case Models.DealWithLocalChanges.StashAndReapply:
+                    RadioStashAndReapply.Focus(NavigationMethod.Tab);
+                    break;
+                case Models.DealWithLocalChanges.Discard:
+                    RadioDiscard.Focus(NavigationMethod.Tab);
+                    break;
+                default:
+                    RadioDoNothing.Focus(NavigationMethod.Tab);
+                    break;
+            }
         }
 
         protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)


### PR DESCRIPTION
When "Stash & reapply changes by default" is enabled in preferences,
the second radio button is pre-selected but keyboard focus remains on
the first option, causing a mismatch between the focus indicator and
the selected item.

Fix by overriding `OnLoaded` in `DealWithLocalChangesMethod` to focus
the radio button that matches the current `Method` value after the
control is attached to the visual tree, consistent with how
`Reset.axaml.cs` handles initial focus via `OnLoaded`.