### PR TITLE
ux: use tabular numbers for commit time

### DIFF
--- a/src/Views/Histories.axaml
+++ b/src/Views/Histories.axaml
@@ -218,6 +218,7 @@
               <DataTemplate DataType="m:Commit">
                 <Border Padding="8,0" Background="Transparent" ClipToBounds="True">
                   <v:CommitTimeTextBlock FontWeight="{Binding IsCurrentHead, Converter={x:Static c:BoolConverters.IsBoldToFontWeight}}"
+                                         FontFeatures="+tnum"
                                          Opacity="{Binding IsMerged, Converter={x:Static c:BoolConverters.IsMergedToOpacity}}"
                                          Timestamp="{Binding CommitterTime, Mode=OneWay}"
                                          ShowAsDateTime="{Binding Source={x:Static vm:Preferences.Instance}, Path=!DisplayTimeAsPeriodInHistories, Mode=OneWay}"


### PR DESCRIPTION
This PR enables tabular numbers for the `COMMIT TIME` column in the histories view to improve readability, so timestamp digits use consistent widths and align more cleanly across rows.

I believe this helps users who do not want to use a monospace font for the entire interface, but still want numbers to align nicely. Unfortunately, tabular numbers do not apply well to mixed alphanumeric content, so `SHA` cannot benefit from the same approach.

I don't think anyone will miss the "misaligned look" XD

## Before

The red line is a vertical alignment guide. You can see that `17:11:07` is noticeably narrower because it contains `11`.

<img src="https://github.com/user-attachments/assets/7ed1d91e-4d65-4716-bfcd-3adebc96efa8" />

## After

P.S. `HEAD` is bold, so it does not align with the other rows even with tabular numbers enabled.

<img src="https://github.com/user-attachments/assets/298fca3a-5393-4ec0-8df7-5714699d8f7c" />
