### PR TITLE
fix: crash when closing an unmanaged repository tab whose directory was removed

### DIFF
--- a/src/ViewModels/RepositoryNode.cs
+++ b/src/ViewModels/RepositoryNode.cs
@@ -205,13 +205,24 @@ namespace SourceGit.ViewModels
 
         public void SaveMinimalInfo(string gitDir)
         {
+            if (!Directory.Exists(gitDir))
+                return;
+
             var savedTo = Path.Combine(gitDir, "sourcegit.node");
             var minimalInfo = new RepositoryNodeMinimalInfo
             {
                 FriendlyName = Name,
                 Bookmark = Bookmark
             };
-            File.WriteAllText(savedTo, JsonSerializer.Serialize(minimalInfo, JsonCodeGen.Default.RepositoryNodeMinimalInfo));
+
+            try
+            {
+                File.WriteAllText(savedTo, JsonSerializer.Serialize(minimalInfo, JsonCodeGen.Default.RepositoryNodeMinimalInfo));
+            }
+            catch
+            {
+                // Ignore any error (e.g. the repository directory was removed while the tab was open).
+            }
         }
 
         private string _id = string.Empty;


### PR DESCRIPTION
Closes #2481

### Problem

Closing the tab of an *unmanaged* repository (a worktree/submodule opened via #2349) crashes the app with an unhandled `System.IO.DirectoryNotFoundException` when that repository's directory has been removed while the tab was still open.

Steps that trigger it:
1. Open a worktree (or submodule) — it opens as an unmanaged tab.
2. Remove the worktree (`git worktree remove`, or delete the folder) so its `$GIT_DIR` (e.g. `.git/worktrees/<name>/`) no longer exists.
3. Close the now-orphaned tab.

On close, `Launcher.CloseRepositoryInTab` (and the single-tab path in `CloseTab`) call `RepositoryNode.SaveMinimalInfo`, which writes `$GIT_DIR/sourcegit.node`. The write target no longer exists, so `File.WriteAllText` throws and the exception propagates out of the UI event handler, terminating the app.

```
System.IO.DirectoryNotFoundException: Could not find a part of the path '.../.git/worktrees/<name>/sourcegit.node'.
   at SourceGit.ViewModels.RepositoryNode.SaveMinimalInfo(String gitDir) in RepositoryNode.cs:line 214
   at SourceGit.ViewModels.Launcher.CloseRepositoryInTab(LauncherPage page, Boolean removeFromWorkspace)
   at SourceGit.ViewModels.Launcher.CloseTab(LauncherPage page)
```

### Fix

Make `SaveMinimalInfo` defensive, mirroring its sibling `LoadMinimalInfo` (which already early-returns and wraps its IO in `try/catch`): skip when the git dir no longer exists, and ignore write errors. Persisting this metadata is best-effort, so swallowing the error is the correct semantic and matches the existing pattern in the same file.

### Notes

- One-method, minimal change; no behavioral change on the normal path.
- Covers both call sites (`CloseRepositoryInTab` and the single-tab `CloseTab` path) since the guard now lives in the method itself.