### PR TITLE
fix: escape BRE special characters when selecting author from suggestions

### DIFF
--- a/src/App.Extensions.cs
+++ b/src/App.Extensions.cs
@@ -18,6 +18,18 @@ namespace SourceGit
             return value.Replace("\"", "\\\"", StringComparison.Ordinal);
         }
 
+        public static string EscapeForBRE(this string value)
+        {
+            return value
+                .Replace("\\", "\\\\", StringComparison.Ordinal)
+                .Replace(".", "\\.", StringComparison.Ordinal)
+                .Replace("[", "\\[", StringComparison.Ordinal)
+                .Replace("*", "\\*", StringComparison.Ordinal)
+                .Replace("^", "\\^", StringComparison.Ordinal)
+                .Replace("$", "\\$", StringComparison.Ordinal)
+                .Replace("{", "\\{", StringComparison.Ordinal);
+        }
+
         public static string FormatFontNames(string input)
         {
             if (string.IsNullOrEmpty(input))

--- a/src/ViewModels/SearchCommitContext.cs
+++ b/src/ViewModels/SearchCommitContext.cs
@@ -27,6 +27,7 @@ namespace SourceGit.ViewModels
             get => _filter;
             set
             {
+                _isLiteralFilter = false;
                 if (SetProperty(ref _filter, value))
                     UpdateSuggestions();
             }
@@ -82,6 +83,14 @@ namespace SourceGit.ViewModels
             Results = null;
         }
 
+        public void SetLiteralFilter(string filter)
+        {
+            _isLiteralFilter = true;
+            _filter = filter;
+            OnPropertyChanged(nameof(Filter));
+            UpdateSuggestions();
+        }
+
         public void ClearSuggestions()
         {
             Suggestions = null;
@@ -109,6 +118,9 @@ namespace SourceGit.ViewModels
                 var result = new List<Models.Commit>();
                 var method = (Models.CommitSearchMethod)_method;
                 var repoPath = _repo.FullPath;
+                var filter = (_isLiteralFilter && method == Models.CommitSearchMethod.ByAuthor)
+                    ? _filter.EscapeForBRE()
+                    : _filter;
 
                 if (method == Models.CommitSearchMethod.BySHA)
                 {
@@ -131,7 +143,7 @@ namespace SourceGit.ViewModels
                 }
                 else if (_onlySearchCurrentBranch)
                 {
-                    result = await new Commands.QueryCommits(repoPath, _filter, method, true)
+                    result = await new Commands.QueryCommits(repoPath, filter, method, true)
                         .GetResultAsync()
                         .ConfigureAwait(false);
 
@@ -140,7 +152,7 @@ namespace SourceGit.ViewModels
                 }
                 else
                 {
-                    result = await new Commands.QueryCommits(repoPath, _filter, method, false)
+                    result = await new Commands.QueryCommits(repoPath, filter, method, false)
                         .GetResultAsync()
                         .ConfigureAwait(false);
 
@@ -290,6 +302,7 @@ namespace SourceGit.ViewModels
         private int _method = (int)Models.CommitSearchMethod.ByMessage;
         private string _filter = string.Empty;
         private bool _onlySearchCurrentBranch = false;
+        private bool _isLiteralFilter = false;
         private bool _isQuerying = false;
         private List<Models.Commit> _results = null;
         private Models.Commit _selected = null;

--- a/src/Views/Repository.axaml.cs
+++ b/src/Views/Repository.axaml.cs
@@ -328,7 +328,7 @@ namespace SourceGit.Views
                 else if (selected is Models.User user)
                 {
                     var apply = user.ToString();
-                    repo.SearchCommitContext.Filter = apply;
+                    repo.SearchCommitContext.SetLiteralFilter(apply);
                     TxtSearchCommitsBox.CaretIndex = apply.Length;
                 }
 
@@ -351,7 +351,7 @@ namespace SourceGit.Views
             else if (ctx is Models.User user)
             {
                 var apply = user.ToString();
-                repo.SearchCommitContext.Filter = apply;
+                repo.SearchCommitContext.SetLiteralFilter(apply);
                 TxtSearchCommitsBox.CaretIndex = apply.Length;
             }
 


### PR DESCRIPTION
## Problem

When a `User` suggestion (e.g. `github-actions[bot]`) is selected in the author search,
the filter is passed directly to `git log --author=` as a POSIX BRE pattern.
`[bot]` is interpreted as a character class, so no commits are found.

## Solution

- Add `EscapeForBRE()` to `StringExtensions` to escape BRE special characters
- Add `_isLiteralFilter` field and `SetLiteralFilter()` to `SearchCommitContext`
- Call `SetLiteralFilter()` when a `User` suggestion is selected; `StartSearch()` then
  applies `EscapeForBRE()` before passing the filter to `git log --author=`
- Manual text input resets `_isLiteralFilter`, preserving BRE regex for power users