### PR TITLE
fix: let the diff view wake up before its first curtain call

### DIFF
--- a/src/ViewModels/CommitDetail.cs
+++ b/src/ViewModels/CommitDetail.cs
@@ -40,6 +40,7 @@ namespace SourceGit.ViewModels
                 if (value != _sharedData.ActiveTabIndex)
                 {
                     _sharedData.ActiveTabIndex = value;
+                    OnPropertyChanged(nameof(ActiveTabIndex));
 
                     if (value == 1 && DiffContext == null && _selectedChanges is { Count: 1 })
                         DiffContext = new DiffContext(_repo.FullPath, new Models.DiffOption(_commit, _selectedChanges[0]));

--- a/src/Views/CommitDetail.axaml.cs
+++ b/src/Views/CommitDetail.axaml.cs
@@ -6,7 +6,6 @@ using System.Text;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Input;
-using Avalonia.LogicalTree;
 using Avalonia.Platform.Storage;
 using Avalonia.VisualTree;
 
@@ -532,11 +531,8 @@ namespace SourceGit.Views
         {
             if (DataContext is ViewModels.CommitDetail detail && sender is Grid { DataContext: Models.Change change })
             {
-                var tabControl = this.FindLogicalDescendantOfType<TabControl>();
-                if (tabControl != null)
-                    tabControl.SelectedIndex = 1;
-
                 detail.SelectedChanges = new() { change };
+                detail.ActiveTabIndex = 1;
             }
 
             e.Handled = true;


### PR DESCRIPTION
Double-tapping a change in the Info tab raced against the tab switch: the view poked the TabControl directly while SelectedChanges was still clearing DiffContext to null, so the right-hand AvaloniaEdit rendered blank until a later file switch rebuilt it.

Drive the switch through the ViewModel instead -- set SelectedChanges first, then ActiveTabIndex, and raise OnPropertyChanged so the existing DiffContext compensation in the setter reliably fires before the Changes tab materializes.