### PR TITLE
fix: null check for RevisionFileSearchSuggestion on key down

### DIFF
--- a/src/Views/RevisionFiles.axaml.cs
+++ b/src/Views/RevisionFiles.axaml.cs
@@ -29,7 +29,7 @@ namespace SourceGit.Views
             }
             else if (e.Key == Key.Down || e.Key == Key.Up)
             {
-                if (vm.RevisionFileSearchSuggestion.Count > 0)
+                if (vm.RevisionFileSearchSuggestion?.Count > 0)
                 {
                     SearchSuggestionBox.Focus(NavigationMethod.Tab);
                     SearchSuggestionBox.SelectedIndex = 0;


### PR DESCRIPTION
`RevisionFileSearchSuggestion` is initialized to `null` and reset to  
`null` by `CancelRevisionFileSuggestions`. Pressing Up or Down in the  
revision file search box calls `.Count` on a null reference, causing a crash.  
  
Fix by using `?.Count` instead of `.Count`.