### PR TITLE
fix: hide file manager and terminal options for invalid repositories

### DIFF
--- a/src/ViewModels/RepositoryNode.cs
+++ b/src/ViewModels/RepositoryNode.cs
@@ -125,14 +125,14 @@ namespace SourceGit.ViewModels
 
         public void OpenInFileManager()
         {
-            if (!IsRepository)
+            if (!IsRepository || IsInvalid)
                 return;
             Native.OS.OpenInFileManager(_id);
         }
 
         public void OpenTerminal()
         {
-            if (!IsRepository)
+            if (!IsRepository || IsInvalid)
                 return;
             Native.OS.OpenTerminal(_id);
         }

--- a/src/Views/RepositoryToolbar.axaml.cs
+++ b/src/Views/RepositoryToolbar.axaml.cs
@@ -21,6 +21,10 @@ namespace SourceGit.Views
             if (sender is Button button && DataContext is ViewModels.Repository repo)
             {
                 var fullpath = repo.FullPath;
+
+                if (!System.IO.Directory.Exists(fullpath))
+                    return;
+
                 var menu = new ContextMenu();
                 menu.Placement = PlacementMode.BottomEdgeAlignedLeft;
 

--- a/src/Views/Welcome.axaml.cs
+++ b/src/Views/Welcome.axaml.cs
@@ -174,29 +174,32 @@ namespace SourceGit.Views
                         e.Handled = true;
                     };
 
-                    var explore = new MenuItem();
-                    explore.Header = App.Text("Repository.Explore");
-                    explore.Icon = this.CreateMenuIcon("Icons.Explore");
-                    explore.Click += (_, e) =>
-                    {
-                        node.OpenInFileManager();
-                        e.Handled = true;
-                    };
-
-                    var terminal = new MenuItem();
-                    terminal.Header = App.Text("Repository.Terminal");
-                    terminal.Icon = this.CreateMenuIcon("Icons.Terminal");
-                    terminal.Click += (_, e) =>
-                    {
-                        node.OpenTerminal();
-                        e.Handled = true;
-                    };
-
                     menu.Items.Add(open);
                     menu.Items.Add(new MenuItem() { Header = "-" });
-                    menu.Items.Add(explore);
-                    menu.Items.Add(terminal);
-                    menu.Items.Add(new MenuItem() { Header = "-" });
+
+                    if (!node.IsInvalid)
+                    {
+                        var explore = new MenuItem();
+                        explore.Header = App.Text("Repository.Explore");
+                        explore.Icon = this.CreateMenuIcon("Icons.Explore");
+                        explore.Click += (_, e) =>
+                        {
+                            node.OpenInFileManager();
+                            e.Handled = true;
+                        };
+
+                        var terminal = new MenuItem();
+                        terminal.Header = App.Text("Repository.Terminal");
+                        terminal.Icon = this.CreateMenuIcon("Icons.Terminal");
+                        terminal.Click += (_, e) =>
+                        {
+                            node.OpenTerminal();
+                            e.Handled = true;
+                        };
+                        menu.Items.Add(explore);
+                        menu.Items.Add(terminal);
+                        menu.Items.Add(new MenuItem() { Header = "-" });
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
When a repository folder has been deleted, two crash scenarios exist:

1. On the Welcome page, right-clicking the invalid repository node
   (shown with an exclamation mark) and selecting "Open in File Manager"
   or "Open in Terminal" crashes with `Win32Exception`.

2. Inside an open repository, if the folder is deleted while SourceGit
   is running, clicking the external tools button and selecting
   "Open in File Manager" or "Open in Terminal" also crashes.

Fix by:
- Hiding "Explore" and "Terminal" menu items in the Welcome page context
  menu when `node.IsInvalid` is true, with an early return guard in
  `RepositoryNode` as a defensive safety net.
- Adding a `Directory.Exists` check in `RepositoryToolbar.OpenWithExternalTools`
  before building the menu.