### PR TITLE
fix: prevent crash in Chart.Render when repository has no commits

### DIFF
--- a/src/Views/Chart.cs
+++ b/src/Views/Chart.cs
@@ -54,7 +54,7 @@ namespace SourceGit.Views
             base.Render(context);
 
             var samples = _samples;
-            if (samples == null || samples.Count == 0)
+            if (samples == null || samples.Count <= 0)
                 return;
 
             var w = Bounds.Width;


### PR DESCRIPTION
Opening the Statistics view in an empty repository (no commits) crashes
with `ArgumentOutOfRangeException` in `NextSampleTime`.

When there are no commits, `StatisticsReport._minSampleTime` stays at
`DateTime.MaxValue` and `_maxSampleTime` stays at `DateTime.MinValue`.
For `StatisticsMode.All`, `Count` is calculated as
`(end.Year - start.Year) * 12 + ...`, which yields a large negative number.
The guard `samples.Count == 0` in `Chart.Render` does not catch negative
values, so rendering proceeds with `time = DateTime.MinValue` (year 1,
month 1). `NextSampleTime` then tries `new DateTime(0, 12, 1)`, which
throws `ArgumentOutOfRangeException`.

Fix by changing `samples.Count == 0` to `samples.Count <= 0`.