### PR TITLE
feat: SSH remote repository support (VSCode/JetBrains-style)

### DIFF
--- a/src/App.axaml.cs
+++ b/src/App.axaml.cs
@@ -357,6 +357,24 @@ namespace SourceGit
             });
             Console.Out.WriteLine($"[selftest] hash-object --stdin stdout={stdinRS.StdOut.Trim()} ok={stdinRS.IsSuccess}");
 
+            // watch (server FSW pushes watch_event notifications back to the client)
+            var gotWatch = new ManualResetEventSlim(false);
+            client.NotificationReceived += (method, pars) =>
+            {
+                if (method == "watch_event")
+                {
+                    Console.Out.WriteLine($"[selftest] watch_event file={pars?["file"]?.GetValue<string>()}");
+                    gotWatch.Set();
+                }
+            };
+            client.Call("watch_start", new { path = workingDir });
+            var watchTestFile = Path.Combine(workingDir, ".watch_selftest");
+            File.WriteAllText(watchTestFile, "trigger");
+            gotWatch.Wait(TimeSpan.FromSeconds(3));
+            File.Delete(watchTestFile);
+            client.Call("watch_stop", new { path = workingDir });
+            Console.Out.WriteLine($"[selftest] watch notification received={gotWatch.IsSet}");
+
             return 0;
         }
 

--- a/src/App.axaml.cs
+++ b/src/App.axaml.cs
@@ -357,6 +357,13 @@ namespace SourceGit
             });
             Console.Out.WriteLine($"[selftest] hash-object --stdin stdout={stdinRS.StdOut.Trim()} ok={stdinRS.IsSuccess}");
 
+            // directory browsing (powers the remote folder picker)
+            var home = client.Call("home_dir", new { })?["path"]?.GetValue<string>();
+            Console.Out.WriteLine($"[selftest] home_dir={home}");
+            var listing = client.Call("list_dir", new { path = workingDir });
+            var entryCount = listing?["entries"]?.AsArray().Count ?? -1;
+            Console.Out.WriteLine($"[selftest] list_dir({workingDir}) path={listing?["path"]?.GetValue<string>()} entries={entryCount}");
+
             // watch (server FSW pushes watch_event notifications back to the client)
             var gotWatch = new ManualResetEventSlim(false);
             client.NotificationReceived += (method, pars) =>

--- a/src/App.axaml.cs
+++ b/src/App.axaml.cs
@@ -39,6 +39,8 @@ namespace SourceGit
             {
                 if (TryLaunchAsRemoteSelfTest(args, out int exitSelfTest))
                     Environment.Exit(exitSelfTest);
+                else if (TryLaunchAsRemoteServerVersion(args, out int exitVersion))
+                    Environment.Exit(exitVersion);
                 else if (TryLaunchAsRemoteServer(args, out int exitRemote))
                     Environment.Exit(exitRemote);
                 else if (TryLaunchAsRebaseTodoEditor(args, out int exitTodo))
@@ -280,6 +282,21 @@ namespace SourceGit
         #endregion
 
         #region Launch Ways
+        private static bool TryLaunchAsRemoteServerVersion(string[] args, out int exitCode)
+        {
+            exitCode = -1;
+
+            if (args.Length == 0 || !args[0].Equals("--remote-server-version", StringComparison.Ordinal))
+                return false;
+
+            // One-shot version probe used by the client to decide whether the deployed
+            // server binary is stale and needs re-uploading. Prints the friendly build
+            // version (git describe) and exits.
+            Console.Out.WriteLine(Native.OS.GetAppVersion());
+            exitCode = 0;
+            return true;
+        }
+
         private static bool TryLaunchAsRemoteServer(string[] args, out int exitCode)
         {
             exitCode = -1;

--- a/src/App.axaml.cs
+++ b/src/App.axaml.cs
@@ -348,6 +348,15 @@ namespace SourceGit
             fs.DeleteFile(tmp);
             Console.Out.WriteLine($"[selftest] fs deleted tmp exists={fs.FileExists(tmp)}");
 
+            // stdin (commit message via -F -, pathspec via --pathspec-from-file=-)
+            var stdinRS = runner.ReadToEnd(new Commands.Command.RunSpec
+            {
+                Args = "hash-object --stdin",
+                WorkingDirectory = workingDir,
+                StdinContent = "hello-stdin",
+            });
+            Console.Out.WriteLine($"[selftest] hash-object --stdin stdout={stdinRS.StdOut.Trim()} ok={stdinRS.IsSuccess}");
+
             return 0;
         }
 

--- a/src/App.axaml.cs
+++ b/src/App.axaml.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Net.Http;
 using System.Text.Json;
+using System.Threading;
 using System.Threading.Tasks;
 
 using Avalonia;
@@ -36,7 +37,9 @@ namespace SourceGit
 
             try
             {
-                if (TryLaunchAsRemoteServer(args, out int exitRemote))
+                if (TryLaunchAsRemoteSelfTest(args, out int exitSelfTest))
+                    Environment.Exit(exitSelfTest);
+                else if (TryLaunchAsRemoteServer(args, out int exitRemote))
                     Environment.Exit(exitRemote);
                 else if (TryLaunchAsRebaseTodoEditor(args, out int exitTodo))
                     Environment.Exit(exitTodo);
@@ -290,6 +293,52 @@ namespace SourceGit
             var server = new Remote.RpcServer();
             exitCode = server.Run();
             return true;
+        }
+
+        private static bool TryLaunchAsRemoteSelfTest(string[] args, out int exitCode)
+        {
+            exitCode = -1;
+
+            if (args.Length == 0 || !args[0].Equals("--remote-selftest", StringComparison.Ordinal))
+                return false;
+
+            // Development/verification helper: spin up a local server and drive it through
+            // RemoteCommandRunner, exercising Start/ReadToEnd/ExecAsync. Not shipped UX.
+            exitCode = RunRemoteSelfTestAsync(args).GetAwaiter().GetResult();
+            return true;
+        }
+
+        private static async Task<int> RunRemoteSelfTestAsync(string[] args)
+        {
+            var dll = Path.Combine(AppContext.BaseDirectory, "SourceGit.dll");
+            var dotnet = Environment.ProcessPath ?? "dotnet";
+            var workingDir = args.Length > 1 ? args[1] : Directory.GetCurrentDirectory();
+
+            using var conn = new Remote.LocalProcessConnection(dotnet, $"\"{dll}\" --remote-server");
+            using var client = new Remote.RpcClient(conn.Input, conn.Output);
+            var runner = new Remote.RemoteCommandRunner(client);
+
+            Console.Out.WriteLine($"[selftest] working_dir={workingDir}");
+
+            var spec = new Commands.Command.RunSpec { Args = "log --oneline -3", WorkingDirectory = workingDir };
+            using (var proc = runner.Start(spec))
+            {
+                while (await proc.Stdout.ReadLineAsync() is { } line)
+                    Console.Out.WriteLine($"[selftest] log: {line}");
+                await proc.WaitForExitAsync(CancellationToken.None);
+                Console.Out.WriteLine($"[selftest] exit={proc.ExitCode}");
+            }
+
+            var rs = runner.ReadToEnd(new Commands.Command.RunSpec { Args = "status --porcelain", WorkingDirectory = workingDir });
+            Console.Out.WriteLine($"[selftest] status isSuccess={rs.IsSuccess} stdout={rs.StdOut.Trim()}");
+
+            var ok = await runner.ExecAsync(
+                new Commands.Command.RunSpec { Args = "branch --list", WorkingDirectory = workingDir },
+                line => Console.Out.WriteLine($"[selftest] branch: {line}"),
+                CancellationToken.None);
+            Console.Out.WriteLine($"[selftest] branch exec ok={ok}");
+
+            return 0;
         }
 
         private static bool TryLaunchAsRebaseTodoEditor(string[] args, out int exitCode)

--- a/src/App.axaml.cs
+++ b/src/App.axaml.cs
@@ -338,6 +338,16 @@ namespace SourceGit
                 CancellationToken.None);
             Console.Out.WriteLine($"[selftest] branch exec ok={ok}");
 
+            var fs = new Remote.RemoteFileSystem(client);
+            var readme = Path.Combine(workingDir, "README.md");
+            var version = Path.Combine(workingDir, "VERSION");
+            Console.Out.WriteLine($"[selftest] fs.FileExists(README)={fs.FileExists(readme)}");
+            Console.Out.WriteLine($"[selftest] fs.ReadAllText(VERSION)={fs.ReadAllText(version)}");
+            var tmp = fs.CreateTempFile("hello-remote");
+            Console.Out.WriteLine($"[selftest] fs.CreateTempFile={tmp} readback={fs.ReadAllText(tmp)}");
+            fs.DeleteFile(tmp);
+            Console.Out.WriteLine($"[selftest] fs deleted tmp exists={fs.FileExists(tmp)}");
+
             return 0;
         }
 

--- a/src/App.axaml.cs
+++ b/src/App.axaml.cs
@@ -36,7 +36,9 @@ namespace SourceGit
 
             try
             {
-                if (TryLaunchAsRebaseTodoEditor(args, out int exitTodo))
+                if (TryLaunchAsRemoteServer(args, out int exitRemote))
+                    Environment.Exit(exitRemote);
+                else if (TryLaunchAsRebaseTodoEditor(args, out int exitTodo))
                     Environment.Exit(exitTodo);
                 else if (TryLaunchAsRebaseMessageEditor(args, out int exitMessage))
                     Environment.Exit(exitMessage);
@@ -275,6 +277,21 @@ namespace SourceGit
         #endregion
 
         #region Launch Ways
+        private static bool TryLaunchAsRemoteServer(string[] args, out int exitCode)
+        {
+            exitCode = -1;
+
+            if (args.Length == 0 || !args[0].Equals("--remote-server", StringComparison.Ordinal))
+                return false;
+
+            // Run as a headless JSON-RPC server over stdio (typically launched via
+            // `ssh <host> sourcegit --remote-server`). No Avalonia desktop lifetime,
+            // no window; the loop blocks on stdin until the SSH channel closes.
+            var server = new Remote.RpcServer();
+            exitCode = server.Run();
+            return true;
+        }
+
         private static bool TryLaunchAsRebaseTodoEditor(string[] args, out int exitCode)
         {
             exitCode = -1;

--- a/src/Commands/Add.cs
+++ b/src/Commands/Add.cs
@@ -1,12 +1,13 @@
-﻿namespace SourceGit.Commands
+namespace SourceGit.Commands
 {
     public class Add : Command
     {
-        public Add(string repo, string pathspecFromFile)
+        public Add(string repo, string pathspec)
         {
             WorkingDirectory = repo;
             Context = repo;
-            Args = $"add --force --verbose --pathspec-from-file={pathspecFromFile.Quoted()}";
+            Stdin = pathspec;
+            Args = "add --force --verbose --pathspec-from-file=-";
         }
     }
 }

--- a/src/Commands/Apply.cs
+++ b/src/Commands/Apply.cs
@@ -4,10 +4,11 @@ namespace SourceGit.Commands
 {
     public class Apply : Command
     {
-        public Apply(string repo, string file, bool ignoreWhitespace, string whitespaceMode, string extra)
+        public Apply(string repo, string patch, bool ignoreWhitespace, string whitespaceMode, string extra)
         {
             WorkingDirectory = repo;
             Context = repo;
+            Stdin = patch;
 
             var builder = new StringBuilder(1024);
             builder.Append("apply ");
@@ -20,7 +21,7 @@ namespace SourceGit.Commands
             if (!string.IsNullOrEmpty(extra))
                 builder.Append(extra).Append(' ');
 
-            Args = builder.Append(file.Quoted()).ToString();
+            Args = builder.Append('-').ToString();
         }
     }
 }

--- a/src/Commands/Command.cs
+++ b/src/Commands/Command.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading;
@@ -26,6 +25,26 @@ namespace SourceGit.Commands
             RebaseEditor,
         }
 
+        /// <summary>
+        /// Immutable snapshot of the parameters needed to launch a git command.
+        /// Passed to <see cref="ICommandRunner"/> so the runner does not depend on the
+        /// mutable <see cref="Command"/> surface.
+        /// </summary>
+        public class RunSpec
+        {
+            public string Args = string.Empty;
+            public string WorkingDirectory = null;
+            public EditorType Editor = EditorType.CoreEditor;
+            public string SSHKey = string.Empty;
+
+            /// <summary>
+            /// Whether to redirect stdin so the caller can write to <see cref="ICommandProcess.Stdin"/>.
+            /// Off by default; set <c>true</c> for commands that take piped input
+            /// (pathspec, patch data, LFS smudge pointer).
+            /// </summary>
+            public bool RedirectStandardInput = false;
+        }
+
         public string Context { get; set; } = string.Empty;
         public string WorkingDirectory { get; set; } = null;
         public EditorType Editor { get; set; } = EditorType.CoreEditor;
@@ -37,186 +56,51 @@ namespace SourceGit.Commands
         public bool RaiseError { get; set; } = true;
         public Models.ICommandLog Log { get; set; } = null;
 
+        /// <summary>
+        /// Runner that actually launches git. Defaults to local process execution
+        /// (<see cref="LocalCommandRunner"/>); future remote support will substitute an
+        /// RPC-backed runner per repository host.
+        /// </summary>
+        protected ICommandRunner Runner { get; set; } = LocalCommandRunner.Instance;
+
+        /// <summary>
+        /// Snapshot the current execution parameters into a <see cref="RunSpec"/> for the runner.
+        /// </summary>
+        protected RunSpec BuildSpec() => new RunSpec
+        {
+            Args = Args,
+            WorkingDirectory = WorkingDirectory,
+            Editor = Editor,
+            SSHKey = SSHKey,
+        };
+
         public async Task<bool> ExecAsync()
         {
             Log?.AppendLine($"$ git {Args}\n");
 
             var errs = new List<string>();
-
-            using var proc = new Process();
-            proc.StartInfo = CreateGitStartInfo(true);
-            proc.OutputDataReceived += (_, e) => HandleOutput(e.Data, errs);
-            proc.ErrorDataReceived += (_, e) => HandleOutput(e.Data, errs);
-
-            var captured = new CapturedProcess() { Process = proc };
-            var capturedLock = new object();
-            try
-            {
-                proc.Start();
-
-                // Not safe, please only use `CancellationToken` in readonly commands.
-                if (CancellationToken.CanBeCanceled)
-                {
-                    CancellationToken.Register(() =>
-                    {
-                        lock (capturedLock)
-                        {
-                            if (captured is { Process: { HasExited: false } })
-                                captured.Process.Kill();
-                        }
-                    });
-                }
-            }
-            catch (Exception e)
-            {
-                if (RaiseError)
-                    RaiseException(e.Message);
-
-                Log?.AppendLine(string.Empty);
-                return false;
-            }
-
-            proc.BeginOutputReadLine();
-            proc.BeginErrorReadLine();
-
-            try
-            {
-                await proc.WaitForExitAsync(CancellationToken).ConfigureAwait(false);
-            }
-            catch (Exception e)
-            {
-                HandleOutput(e.Message, errs);
-            }
-
-            lock (capturedLock)
-            {
-                captured.Process = null;
-            }
+            var ok = await Runner.ExecAsync(BuildSpec(), line => HandleOutput(line, errs), CancellationToken).ConfigureAwait(false);
 
             Log?.AppendLine(string.Empty);
 
-            if (!CancellationToken.IsCancellationRequested && proc.ExitCode != 0)
+            if (!ok && !CancellationToken.IsCancellationRequested && RaiseError)
             {
-                if (RaiseError)
-                {
-                    var errMsg = string.Join("\n", errs).Trim();
-                    if (!string.IsNullOrEmpty(errMsg))
-                        RaiseException(errMsg);
-                }
-
-                return false;
+                var errMsg = string.Join("\n", errs).Trim();
+                if (!string.IsNullOrEmpty(errMsg))
+                    RaiseException(errMsg);
             }
 
-            return true;
+            return ok;
         }
 
         protected Result ReadToEnd()
         {
-            using var proc = new Process();
-            proc.StartInfo = CreateGitStartInfo(true);
-
-            try
-            {
-                proc.Start();
-            }
-            catch (Exception e)
-            {
-                return Result.Failed(e.Message);
-            }
-
-            var rs = new Result() { IsSuccess = true };
-            rs.StdOut = proc.StandardOutput.ReadToEnd();
-            rs.StdErr = proc.StandardError.ReadToEnd();
-            proc.WaitForExit();
-
-            rs.IsSuccess = proc.ExitCode == 0;
-            return rs;
+            return Runner.ReadToEnd(BuildSpec());
         }
 
         protected async Task<Result> ReadToEndAsync()
         {
-            using var proc = new Process();
-            proc.StartInfo = CreateGitStartInfo(true);
-
-            try
-            {
-                proc.Start();
-            }
-            catch (Exception e)
-            {
-                return Result.Failed(e.Message);
-            }
-
-            var rs = new Result() { IsSuccess = true };
-            rs.StdOut = await proc.StandardOutput.ReadToEndAsync(CancellationToken).ConfigureAwait(false);
-            rs.StdErr = await proc.StandardError.ReadToEndAsync(CancellationToken).ConfigureAwait(false);
-            await proc.WaitForExitAsync(CancellationToken).ConfigureAwait(false);
-
-            rs.IsSuccess = proc.ExitCode == 0;
-            return rs;
-        }
-
-        protected ProcessStartInfo CreateGitStartInfo(bool redirect)
-        {
-            var start = new ProcessStartInfo();
-            start.FileName = Native.OS.GitExecutable;
-            start.UseShellExecute = false;
-            start.CreateNoWindow = true;
-
-            if (redirect)
-            {
-                start.RedirectStandardOutput = true;
-                start.RedirectStandardError = true;
-                start.StandardOutputEncoding = Encoding.UTF8;
-                start.StandardErrorEncoding = Encoding.UTF8;
-            }
-
-            // Force using this app as SSH askpass program
-            var selfExecFile = Environment.ProcessPath;
-            start.Environment.Add("SSH_ASKPASS", selfExecFile); // Can not use parameter here, because it invoked by SSH with `exec`
-            start.Environment.Add("SSH_ASKPASS_REQUIRE", "prefer");
-            start.Environment.Add("SOURCEGIT_LAUNCH_AS_ASKPASS", "TRUE");
-            if (!OperatingSystem.IsLinux())
-                start.Environment.Add("DISPLAY", "required");
-
-            // If an SSH private key was provided, sets the environment.
-            if (!start.Environment.ContainsKey("GIT_SSH_COMMAND") && !string.IsNullOrEmpty(SSHKey))
-                start.Environment.Add("GIT_SSH_COMMAND", $"ssh -i '{SSHKey}' -F '/dev/null'");
-
-            // Force using en_US.UTF-8 locale
-            if (OperatingSystem.IsLinux())
-            {
-                start.Environment.Add("LANG", "C");
-                start.Environment.Add("LC_ALL", "C");
-            }
-
-            var builder = new StringBuilder(2048);
-            builder
-                .Append("--no-pager -c core.quotepath=off -c credential.helper=")
-                .Append(Native.OS.CredentialHelper)
-                .Append(' ');
-
-            switch (Editor)
-            {
-                case EditorType.CoreEditor:
-                    builder.Append($"""-c core.editor="\"{selfExecFile}\" --core-editor" """);
-                    break;
-                case EditorType.RebaseEditor:
-                    builder.Append($"""-c core.editor="\"{selfExecFile}\" --rebase-message-editor" -c sequence.editor="\"{selfExecFile}\" --rebase-todo-editor" -c rebase.abbreviateCommands=true """);
-                    break;
-                default:
-                    builder.Append("-c core.editor=true ");
-                    break;
-            }
-
-            builder.Append(Args);
-            start.Arguments = builder.ToString();
-
-            // Working directory
-            if (!string.IsNullOrEmpty(WorkingDirectory))
-                start.WorkingDirectory = WorkingDirectory;
-
-            return start;
+            return await Runner.ReadToEndAsync(BuildSpec(), CancellationToken).ConfigureAwait(false);
         }
 
         protected void RaiseException(string error)
@@ -246,11 +130,6 @@ namespace SourceGit.Commands
             }
 
             errs.Add(line);
-        }
-
-        private class CapturedProcess
-        {
-            public Process Process { get; set; } = null;
         }
 
         [GeneratedRegex(@"\d+%")]

--- a/src/Commands/Command.cs
+++ b/src/Commands/Command.cs
@@ -49,6 +49,13 @@ namespace SourceGit.Commands
             /// is implied and the runner writes it before reading output.
             /// </summary>
             public string StdinContent = null;
+
+            /// <summary>
+            /// When true (server-side exec), skip setting the GUI SSH_ASKPASS env so git/ssh
+            /// rely on the agent/identity from ssh config instead of trying to launch a GUI
+            /// askpass that does not exist on a headless host.
+            /// </summary>
+            public bool Headless = false;
         }
 
         public string Context { get; set; } = string.Empty;

--- a/src/Commands/Command.cs
+++ b/src/Commands/Command.cs
@@ -57,11 +57,11 @@ namespace SourceGit.Commands
         public Models.ICommandLog Log { get; set; } = null;
 
         /// <summary>
-        /// Runner that actually launches git. Defaults to local process execution
-        /// (<see cref="LocalCommandRunner"/>); future remote support will substitute an
-        /// RPC-backed runner per repository host.
+        /// Runner that actually launches git. Looks up a per-repository override in
+        /// <see cref="CommandRunnerRegistry"/> (registered for remote repositories);
+        /// falls back to <see cref="LocalCommandRunner"/> for local repositories.
         /// </summary>
-        protected ICommandRunner Runner { get; set; } = LocalCommandRunner.Instance;
+        protected ICommandRunner Runner => CommandRunnerRegistry.Get(WorkingDirectory) ?? LocalCommandRunner.Instance;
 
         /// <summary>
         /// Snapshot the current execution parameters into a <see cref="RunSpec"/> for the runner.

--- a/src/Commands/Command.cs
+++ b/src/Commands/Command.cs
@@ -43,6 +43,12 @@ namespace SourceGit.Commands
             /// (pathspec, patch data, LFS smudge pointer).
             /// </summary>
             public bool RedirectStandardInput = false;
+
+            /// <summary>
+            /// Optional content to pipe into git's stdin. When set, RedirectStandardInput
+            /// is implied and the runner writes it before reading output.
+            /// </summary>
+            public string StdinContent = null;
         }
 
         public string Context { get; set; } = string.Empty;
@@ -50,6 +56,9 @@ namespace SourceGit.Commands
         public EditorType Editor { get; set; } = EditorType.CoreEditor;
         public string SSHKey { get; set; } = string.Empty;
         public string Args { get; set; } = string.Empty;
+
+        /// <summary>Optional content piped to git's stdin (pathspec/patch/commit-message via -).</summary>
+        public string Stdin { get; set; } = null;
 
         // Only used in `ExecAsync` mode.
         public CancellationToken CancellationToken { get; set; } = CancellationToken.None;
@@ -72,6 +81,7 @@ namespace SourceGit.Commands
             WorkingDirectory = WorkingDirectory,
             Editor = Editor,
             SSHKey = SSHKey,
+            StdinContent = Stdin,
         };
 
         public async Task<bool> ExecAsync()

--- a/src/Commands/CommandRunnerRegistry.cs
+++ b/src/Commands/CommandRunnerRegistry.cs
@@ -1,0 +1,50 @@
+using System.Collections.Concurrent;
+
+namespace SourceGit.Commands
+{
+    /// <summary>
+    /// Maps a repository working-directory to the <see cref="ICommandRunner"/> that should
+    /// execute git for it.
+    /// <para>
+    /// Local repositories are not registered and fall back to
+    /// <see cref="LocalCommandRunner"/>. A remote repository, when opened, registers its
+    /// <see cref="Remote.RemoteCommandRunner"/> here so that every <c>new Commands.XXX(repo,...)</c>
+    /// — which only carries the path — still reaches the right runner without changing call
+    /// sites. The entry is removed when the repository is closed.
+    /// </para>
+    /// <para>
+    /// Lookup is by normalized path, so the same path string the Command base class sees as
+    /// <c>WorkingDirectory</c> resolves to the runner registered by Repository.
+    /// </para>
+    /// </summary>
+    public static class CommandRunnerRegistry
+    {
+        public static void Register(string workingDirectory, ICommandRunner runner)
+        {
+            if (string.IsNullOrEmpty(workingDirectory) || runner == null)
+                return;
+
+            _runners[Normalize(workingDirectory)] = runner;
+        }
+
+        public static void Unregister(string workingDirectory)
+        {
+            if (string.IsNullOrEmpty(workingDirectory))
+                return;
+
+            _runners.TryRemove(Normalize(workingDirectory), out _);
+        }
+
+        public static ICommandRunner Get(string workingDirectory)
+        {
+            if (string.IsNullOrEmpty(workingDirectory))
+                return null;
+
+            return _runners.TryGetValue(Normalize(workingDirectory), out var runner) ? runner : null;
+        }
+
+        private static string Normalize(string path) => path.Replace('\\', '/').TrimEnd('/');
+
+        private static readonly ConcurrentDictionary<string, ICommandRunner> _runners = new();
+    }
+}

--- a/src/Commands/Commit.cs
+++ b/src/Commands/Commit.cs
@@ -1,4 +1,3 @@
-﻿using System.IO;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -8,16 +7,12 @@ namespace SourceGit.Commands
     {
         public Commit(string repo, string message, bool signOff, bool noVerify, bool amend, bool resetAuthor)
         {
-            _tmpFile = Path.GetTempFileName();
-            _message = message;
-
             WorkingDirectory = repo;
             Context = repo;
+            Stdin = message;
 
             var builder = new StringBuilder();
-            builder.Append("commit --allow-empty --file=");
-            builder.Append(_tmpFile.Quoted());
-            builder.Append(' ');
+            builder.Append("commit --allow-empty --file=- ");
 
             if (signOff)
                 builder.Append("--signoff ");
@@ -40,18 +35,12 @@ namespace SourceGit.Commands
         {
             try
             {
-                await File.WriteAllTextAsync(_tmpFile, _message).ConfigureAwait(false);
-                var succ = await ExecAsync().ConfigureAwait(false);
-                File.Delete(_tmpFile);
-                return succ;
+                return await ExecAsync().ConfigureAwait(false);
             }
             catch
             {
                 return false;
             }
         }
-
-        private readonly string _tmpFile;
-        private readonly string _message;
     }
 }

--- a/src/Commands/CompareRevisions.cs
+++ b/src/Commands/CompareRevisions.cs
@@ -1,5 +1,5 @@
 ﻿using System.Collections.Generic;
-using System.Diagnostics;
+using System.Threading;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 
@@ -35,11 +35,9 @@ namespace SourceGit.Commands
             var changes = new List<Models.Change>();
             try
             {
-                using var proc = new Process();
-                proc.StartInfo = CreateGitStartInfo(true);
-                proc.Start();
+                using var proc = Runner.Start(BuildSpec());
 
-                while (await proc.StandardOutput.ReadLineAsync().ConfigureAwait(false) is { } line)
+                while (await proc.Stdout.ReadLineAsync().ConfigureAwait(false) is { } line)
                 {
                     var match = REG_FORMAT().Match(line);
                     if (!match.Success)
@@ -80,7 +78,7 @@ namespace SourceGit.Commands
                     }
                 }
 
-                await proc.WaitForExitAsync().ConfigureAwait(false);
+                await proc.WaitForExitAsync(CancellationToken.None).ConfigureAwait(false);
 
                 changes.Sort((l, r) => Models.NumericSort.Compare(l.Path, r.Path));
             }

--- a/src/Commands/Diff.cs
+++ b/src/Commands/Diff.cs
@@ -57,12 +57,10 @@ namespace SourceGit.Commands
         {
             try
             {
-                using var proc = new Process();
-                proc.StartInfo = CreateGitStartInfo(true);
-                proc.Start();
+                using var proc = Runner.Start(BuildSpec());
 
                 using var ms = new MemoryStream();
-                await proc.StandardOutput.BaseStream.CopyToAsync(ms, CancellationToken).ConfigureAwait(false);
+                await proc.StdoutStream.CopyToAsync(ms, CancellationToken).ConfigureAwait(false);
 
                 if (ms.TryGetBuffer(out var buffer))
                 {

--- a/src/Commands/DiffTool.cs
+++ b/src/Commands/DiffTool.cs
@@ -36,7 +36,7 @@ namespace SourceGit.Commands
 
             try
             {
-                Process.Start(CreateGitStartInfo(false));
+                Runner.StartDetached(BuildSpec());
             }
             catch (Exception ex)
             {

--- a/src/Commands/ICommandRunner.cs
+++ b/src/Commands/ICommandRunner.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SourceGit.Commands
+{
+    /// <summary>
+    /// Abstracts how a git command is actually launched.
+    /// <para>
+    /// The local implementation (<see cref="LocalCommandRunner"/>) wraps the existing
+    /// <c>Process.Start(git)</c> behavior and keeps everything unchanged for local
+    /// repositories. A future remote implementation will forward the same calls to a
+    /// lightweight server over an SSH channel, so that a repository living on a remote
+    /// host can be managed without cloning it locally.
+    /// </para>
+    /// </summary>
+    public interface ICommandRunner
+    {
+        /// <summary>
+        /// Start a git process and return a handle that exposes its stdout stream for
+        /// line-by-line or binary streaming reads. Used by query/diff commands that
+        /// parse output incrementally.
+        /// </summary>
+        ICommandProcess Start(Command.RunSpec spec);
+
+        /// <summary>
+        /// Run a git process to completion without capturing output, returning only the
+        /// exit code. Used by commands (replay/merge-tree) that only care about whether
+        /// the operation succeeded.
+        /// </summary>
+        Task<int> RunForExitCodeAsync(Command.RunSpec spec, CancellationToken ct);
+
+        /// <summary>
+        /// Start a git process fire-and-forget: do not wait, do not capture output.
+        /// Used by difftool which launches an external GUI tool and returns immediately.
+        /// </summary>
+        void StartDetached(Command.RunSpec spec);
+
+        /// <summary>
+        /// Run a git process to completion, capturing all stdout/stderr synchronously.
+        /// Replaces <see cref="Command.ReadToEnd"/>.
+        /// </summary>
+        Command.Result ReadToEnd(Command.RunSpec spec);
+
+        /// <summary>
+        /// Run a git process to completion, capturing all stdout/stderr asynchronously.
+        /// Replaces <see cref="Command.ReadToEndAsync"/>.
+        /// </summary>
+        Task<Command.Result> ReadToEndAsync(Command.RunSpec spec, CancellationToken ct);
+
+        /// <summary>
+        /// Run a git process, invoking <paramref name="onOutput"/> for each line emitted
+        /// on stdout or stderr. The callback receives raw lines (including <c>null</c> for
+        /// the end-of-stream marker); the caller owns filtering and logging. Returns
+        /// <c>true</c> when the process exits with code 0.
+        /// <para>
+        /// Replaces the streaming portion of <see cref="Command.ExecAsync"/>. The error
+        /// collection, progress filtering and notification raising stay in the
+        /// <see cref="Command"/> layer via the callback.
+        /// </para>
+        /// </summary>
+        Task<bool> ExecAsync(Command.RunSpec spec, Action<string> onOutput, CancellationToken ct);
+    }
+
+    /// <summary>
+    /// Handle to a running git process started via <see cref="ICommandRunner.Start"/>.
+    /// Allows streaming stdout reads and waiting for exit. Dispose to release the
+    /// underlying process.
+    /// </summary>
+    public interface ICommandProcess : IDisposable
+    {
+        /// <summary>Text reader over stdout, for <c>ReadLineAsync</c> usage.</summary>
+        StreamReader Stdout { get; }
+
+        /// <summary>Raw stdout stream (= <see cref="Stdout"/>'s BaseStream), for binary <c>CopyToAsync</c> usage.</summary>
+        Stream StdoutStream { get; }
+
+        /// <summary>
+        /// Text writer over stdin. Only valid when <see cref="Command.RunSpec.RedirectStandardInput"/>
+        /// was set on the spec passed to <see cref="ICommandRunner.Start"/>.
+        /// </summary>
+        StreamWriter Stdin { get; }
+
+        /// <summary>Text reader over stderr.</summary>
+        StreamReader Stderr { get; }
+
+        /// <summary>Wait for the process to exit.</summary>
+        Task WaitForExitAsync(CancellationToken ct);
+
+        /// <summary>Exit code after the process has exited.</summary>
+        int ExitCode { get; }
+    }
+}

--- a/src/Commands/ICommandRunner.cs
+++ b/src/Commands/ICommandRunner.cs
@@ -72,9 +72,9 @@ namespace SourceGit.Commands
     public interface ICommandProcess : IDisposable
     {
         /// <summary>Text reader over stdout, for <c>ReadLineAsync</c> usage.</summary>
-        StreamReader Stdout { get; }
+        TextReader Stdout { get; }
 
-        /// <summary>Raw stdout stream (= <see cref="Stdout"/>'s BaseStream), for binary <c>CopyToAsync</c> usage.</summary>
+        /// <summary>Raw stdout stream, for binary <c>CopyToAsync</c> usage.</summary>
         Stream StdoutStream { get; }
 
         /// <summary>
@@ -84,7 +84,7 @@ namespace SourceGit.Commands
         StreamWriter Stdin { get; }
 
         /// <summary>Text reader over stderr.</summary>
-        StreamReader Stderr { get; }
+        TextReader Stderr { get; }
 
         /// <summary>Wait for the process to exit.</summary>
         Task WaitForExitAsync(CancellationToken ct);

--- a/src/Commands/LocalCommandRunner.cs
+++ b/src/Commands/LocalCommandRunner.cs
@@ -251,10 +251,10 @@ namespace SourceGit.Commands
                 _proc = proc;
             }
 
-            public StreamReader Stdout => _proc.StandardOutput;
+            public TextReader Stdout => _proc.StandardOutput;
             public Stream StdoutStream => _proc.StandardOutput.BaseStream;
             public StreamWriter Stdin => _proc.StandardInput;
-            public StreamReader Stderr => _proc.StandardError;
+            public TextReader Stderr => _proc.StandardError;
             public Task WaitForExitAsync(CancellationToken ct) => _proc.WaitForExitAsync(ct);
             public int ExitCode => _proc.ExitCode;
 

--- a/src/Commands/LocalCommandRunner.cs
+++ b/src/Commands/LocalCommandRunner.cs
@@ -1,0 +1,248 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SourceGit.Commands
+{
+    /// <summary>
+    /// <see cref="ICommandRunner"/> implementation that launches git as a local child
+    /// process. This is a faithful relocation of the process logic that previously lived
+    /// inline in <see cref="Command"/>: the environment setup (SSH askpass, GIT_SSH_COMMAND,
+    /// locale), the global git arguments and the editor injection are kept identical so
+    /// that local repositories behave exactly as before.
+    /// </summary>
+    public sealed class LocalCommandRunner : ICommandRunner
+    {
+        public static readonly LocalCommandRunner Instance = new LocalCommandRunner();
+
+        public ICommandProcess Start(Command.RunSpec spec)
+        {
+            var proc = new Process();
+            proc.StartInfo = BuildStartInfo(spec, redirect: true);
+            proc.Start();
+            return new LocalCommandProcess(proc);
+        }
+
+        public async Task<int> RunForExitCodeAsync(Command.RunSpec spec, CancellationToken ct)
+        {
+            using var proc = new Process();
+            proc.StartInfo = BuildStartInfo(spec, redirect: false);
+
+            try
+            {
+                proc.Start();
+                await proc.WaitForExitAsync(ct).ConfigureAwait(false);
+                return proc.ExitCode;
+            }
+            catch
+            {
+                // Ignore any exceptions and just return -1, matching previous behavior.
+                return -1;
+            }
+        }
+
+        public void StartDetached(Command.RunSpec spec)
+        {
+            // Fire-and-forget: caller does not wait and does not capture output.
+            Process.Start(BuildStartInfo(spec, redirect: false));
+        }
+
+        public Command.Result ReadToEnd(Command.RunSpec spec)
+        {
+            using var proc = new Process();
+            proc.StartInfo = BuildStartInfo(spec, redirect: true);
+
+            try
+            {
+                proc.Start();
+            }
+            catch (Exception e)
+            {
+                return Command.Result.Failed(e.Message);
+            }
+
+            var rs = new Command.Result { IsSuccess = true };
+            rs.StdOut = proc.StandardOutput.ReadToEnd();
+            rs.StdErr = proc.StandardError.ReadToEnd();
+            proc.WaitForExit();
+
+            rs.IsSuccess = proc.ExitCode == 0;
+            return rs;
+        }
+
+        public async Task<Command.Result> ReadToEndAsync(Command.RunSpec spec, CancellationToken ct)
+        {
+            using var proc = new Process();
+            proc.StartInfo = BuildStartInfo(spec, redirect: true);
+
+            try
+            {
+                proc.Start();
+            }
+            catch (Exception e)
+            {
+                return Command.Result.Failed(e.Message);
+            }
+
+            var rs = new Command.Result { IsSuccess = true };
+            rs.StdOut = await proc.StandardOutput.ReadToEndAsync(ct).ConfigureAwait(false);
+            rs.StdErr = await proc.StandardError.ReadToEndAsync(ct).ConfigureAwait(false);
+            await proc.WaitForExitAsync(ct).ConfigureAwait(false);
+
+            rs.IsSuccess = proc.ExitCode == 0;
+            return rs;
+        }
+
+        public async Task<bool> ExecAsync(Command.RunSpec spec, Action<string> onOutput, CancellationToken ct)
+        {
+            using var proc = new Process();
+            proc.StartInfo = BuildStartInfo(spec, redirect: true);
+            proc.OutputDataReceived += (_, e) => onOutput(e.Data);
+            proc.ErrorDataReceived += (_, e) => onOutput(e.Data);
+
+            var captured = new CapturedProcess { Process = proc };
+            var capturedLock = new object();
+            try
+            {
+                proc.Start();
+
+                // Not safe, please only use `CancellationToken` in readonly commands.
+                if (ct.CanBeCanceled)
+                {
+                    ct.Register(() =>
+                    {
+                        lock (capturedLock)
+                        {
+                            if (captured is { Process: { HasExited: false } })
+                                captured.Process.Kill();
+                        }
+                    });
+                }
+            }
+            catch (Exception e)
+            {
+                onOutput(e.Message);
+                return false;
+            }
+
+            proc.BeginOutputReadLine();
+            proc.BeginErrorReadLine();
+
+            try
+            {
+                await proc.WaitForExitAsync(ct).ConfigureAwait(false);
+            }
+            catch (Exception e)
+            {
+                onOutput(e.Message);
+            }
+
+            lock (capturedLock)
+            {
+                captured.Process = null;
+            }
+
+            if (!ct.IsCancellationRequested && proc.ExitCode != 0)
+                return false;
+
+            return true;
+        }
+
+        private ProcessStartInfo BuildStartInfo(Command.RunSpec spec, bool redirect)
+        {
+            var start = new ProcessStartInfo();
+            start.FileName = Native.OS.GitExecutable;
+            start.UseShellExecute = false;
+            start.CreateNoWindow = true;
+
+            if (redirect)
+            {
+                start.RedirectStandardOutput = true;
+                start.RedirectStandardError = true;
+                start.StandardOutputEncoding = Encoding.UTF8;
+                start.StandardErrorEncoding = Encoding.UTF8;
+            }
+
+            if (spec.RedirectStandardInput)
+                start.RedirectStandardInput = true;
+
+            // Force using this app as SSH askpass program
+            var selfExecFile = Environment.ProcessPath;
+            start.Environment.Add("SSH_ASKPASS", selfExecFile); // Can not use parameter here, because it invoked by SSH with `exec`
+            start.Environment.Add("SSH_ASKPASS_REQUIRE", "prefer");
+            start.Environment.Add("SOURCEGIT_LAUNCH_AS_ASKPASS", "TRUE");
+            if (!OperatingSystem.IsLinux())
+                start.Environment.Add("DISPLAY", "required");
+
+            // If an SSH private key was provided, sets the environment.
+            if (!start.Environment.ContainsKey("GIT_SSH_COMMAND") && !string.IsNullOrEmpty(spec.SSHKey))
+                start.Environment.Add("GIT_SSH_COMMAND", $"ssh -i '{spec.SSHKey}' -F '/dev/null'");
+
+            // Force using en_US.UTF-8 locale
+            if (OperatingSystem.IsLinux())
+            {
+                start.Environment.Add("LANG", "C");
+                start.Environment.Add("LC_ALL", "C");
+            }
+
+            var builder = new StringBuilder(2048);
+            builder
+                .Append("--no-pager -c core.quotepath=off -c credential.helper=")
+                .Append(Native.OS.CredentialHelper)
+                .Append(' ');
+
+            switch (spec.Editor)
+            {
+                case Command.EditorType.CoreEditor:
+                    builder.Append($"""-c core.editor="\"{selfExecFile}\" --core-editor" """);
+                    break;
+                case Command.EditorType.RebaseEditor:
+                    builder.Append($"""-c core.editor="\"{selfExecFile}\" --rebase-message-editor" -c sequence.editor="\"{selfExecFile}\" --rebase-todo-editor" -c rebase.abbreviateCommands=true """);
+                    break;
+                default:
+                    builder.Append("-c core.editor=true ");
+                    break;
+            }
+
+            builder.Append(spec.Args);
+            start.Arguments = builder.ToString();
+
+            // Working directory
+            if (!string.IsNullOrEmpty(spec.WorkingDirectory))
+                start.WorkingDirectory = spec.WorkingDirectory;
+
+            return start;
+        }
+
+        private sealed class LocalCommandProcess : ICommandProcess
+        {
+            private readonly Process _proc;
+
+            public LocalCommandProcess(Process proc)
+            {
+                _proc = proc;
+            }
+
+            public StreamReader Stdout => _proc.StandardOutput;
+            public Stream StdoutStream => _proc.StandardOutput.BaseStream;
+            public StreamWriter Stdin => _proc.StandardInput;
+            public StreamReader Stderr => _proc.StandardError;
+            public Task WaitForExitAsync(CancellationToken ct) => _proc.WaitForExitAsync(ct);
+            public int ExitCode => _proc.ExitCode;
+
+            public void Dispose()
+            {
+                _proc.Dispose();
+            }
+        }
+
+        private sealed class CapturedProcess
+        {
+            public Process Process { get; set; }
+        }
+    }
+}

--- a/src/Commands/LocalCommandRunner.cs
+++ b/src/Commands/LocalCommandRunner.cs
@@ -144,6 +144,12 @@ namespace SourceGit.Commands
             proc.BeginOutputReadLine();
             proc.BeginErrorReadLine();
 
+            if (spec.StdinContent != null)
+            {
+                await proc.StandardInput.WriteAsync(spec.StdinContent).ConfigureAwait(false);
+                proc.StandardInput.Close();
+            }
+
             try
             {
                 await proc.WaitForExitAsync(ct).ConfigureAwait(false);

--- a/src/Commands/LocalCommandRunner.cs
+++ b/src/Commands/LocalCommandRunner.cs
@@ -65,6 +65,12 @@ namespace SourceGit.Commands
                 return Command.Result.Failed(e.Message);
             }
 
+            if (spec.StdinContent != null)
+            {
+                proc.StandardInput.Write(spec.StdinContent);
+                proc.StandardInput.Close();
+            }
+
             var rs = new Command.Result { IsSuccess = true };
             rs.StdOut = proc.StandardOutput.ReadToEnd();
             rs.StdErr = proc.StandardError.ReadToEnd();
@@ -86,6 +92,12 @@ namespace SourceGit.Commands
             catch (Exception e)
             {
                 return Command.Result.Failed(e.Message);
+            }
+
+            if (spec.StdinContent != null)
+            {
+                await proc.StandardInput.WriteAsync(spec.StdinContent).ConfigureAwait(false);
+                proc.StandardInput.Close();
             }
 
             var rs = new Command.Result { IsSuccess = true };
@@ -167,7 +179,7 @@ namespace SourceGit.Commands
                 start.StandardErrorEncoding = Encoding.UTF8;
             }
 
-            if (spec.RedirectStandardInput)
+            if (spec.RedirectStandardInput || spec.StdinContent != null)
                 start.RedirectStandardInput = true;
 
             // Force using this app as SSH askpass program

--- a/src/Commands/LocalCommandRunner.cs
+++ b/src/Commands/LocalCommandRunner.cs
@@ -188,13 +188,19 @@ namespace SourceGit.Commands
             if (spec.RedirectStandardInput || spec.StdinContent != null)
                 start.RedirectStandardInput = true;
 
-            // Force using this app as SSH askpass program
             var selfExecFile = Environment.ProcessPath;
-            start.Environment.Add("SSH_ASKPASS", selfExecFile); // Can not use parameter here, because it invoked by SSH with `exec`
-            start.Environment.Add("SSH_ASKPASS_REQUIRE", "prefer");
-            start.Environment.Add("SOURCEGIT_LAUNCH_AS_ASKPASS", "TRUE");
-            if (!OperatingSystem.IsLinux())
-                start.Environment.Add("DISPLAY", "required");
+
+            // Force using this app as SSH askpass program (GUI). Only for the local client;
+            // the headless remote server skips this so ssh uses the agent/identity from the
+            // user's ssh config instead of a non-existent GUI askpass.
+            if (!spec.Headless)
+            {
+                start.Environment.Add("SSH_ASKPASS", selfExecFile); // Can not use parameter here, because it invoked by SSH with `exec`
+                start.Environment.Add("SSH_ASKPASS_REQUIRE", "prefer");
+                start.Environment.Add("SOURCEGIT_LAUNCH_AS_ASKPASS", "TRUE");
+                if (!OperatingSystem.IsLinux())
+                    start.Environment.Add("DISPLAY", "required");
+            }
 
             // If an SSH private key was provided, sets the environment.
             if (!start.Environment.ContainsKey("GIT_SSH_COMMAND") && !string.IsNullOrEmpty(spec.SSHKey))

--- a/src/Commands/MergeTree.cs
+++ b/src/Commands/MergeTree.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics;
+﻿using System.Threading;
 using System.Threading.Tasks;
 
 namespace SourceGit.Commands
@@ -13,22 +13,7 @@ namespace SourceGit.Commands
 
         public async Task<int> GetExitCodeAsync()
         {
-            using var proc = new Process();
-            proc.StartInfo = CreateGitStartInfo(false);
-
-            var exitCode = -1;
-            try
-            {
-                proc.Start();
-                await proc.WaitForExitAsync().ConfigureAwait(false);
-                exitCode = proc.ExitCode;
-            }
-            catch
-            {
-                // Ignore any exceptions and just return -1
-            }
-
-            return exitCode;
+            return await Runner.RunForExitCodeAsync(BuildSpec(), CancellationToken.None).ConfigureAwait(false);
         }
     }
 }

--- a/src/Commands/QueryCommits.cs
+++ b/src/Commands/QueryCommits.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
+using System.Threading;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -55,12 +55,10 @@ namespace SourceGit.Commands
             var commits = new List<Models.Commit>();
             try
             {
-                using var proc = new Process();
-                proc.StartInfo = CreateGitStartInfo(true);
-                proc.Start();
+                using var proc = Runner.Start(BuildSpec());
 
                 var findHead = false;
-                while (await proc.StandardOutput.ReadLineAsync().ConfigureAwait(false) is { } line)
+                while (await proc.Stdout.ReadLineAsync().ConfigureAwait(false) is { } line)
                 {
                     var parts = line.Split('\0');
                     if (parts.Length != 8)
@@ -80,7 +78,7 @@ namespace SourceGit.Commands
                         findHead = true;
                 }
 
-                await proc.WaitForExitAsync().ConfigureAwait(false);
+                await proc.WaitForExitAsync(CancellationToken.None).ConfigureAwait(false);
 
                 if (_markMerged && !findHead && commits.Count > 0)
                 {

--- a/src/Commands/QueryCurrentBranchCommitHashes.cs
+++ b/src/Commands/QueryCurrentBranchCommitHashes.cs
@@ -1,5 +1,5 @@
 ﻿using System.Collections.Generic;
-using System.Diagnostics;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace SourceGit.Commands
@@ -19,14 +19,12 @@ namespace SourceGit.Commands
 
             try
             {
-                using var proc = new Process();
-                proc.StartInfo = CreateGitStartInfo(true);
-                proc.Start();
+                using var proc = Runner.Start(BuildSpec());
 
-                while (await proc.StandardOutput.ReadLineAsync().ConfigureAwait(false) is { Length: > 8 } line)
+                while (await proc.Stdout.ReadLineAsync().ConfigureAwait(false) is { Length: > 8 } line)
                     outs.Add(line);
 
-                await proc.WaitForExitAsync().ConfigureAwait(false);
+                await proc.WaitForExitAsync(CancellationToken.None).ConfigureAwait(false);
             }
             catch
             {

--- a/src/Commands/QueryFileContent.cs
+++ b/src/Commands/QueryFileContent.cs
@@ -1,6 +1,6 @@
-﻿using System;
-using System.Diagnostics;
+using System;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace SourceGit.Commands
@@ -9,21 +9,18 @@ namespace SourceGit.Commands
     {
         public static async Task<Stream> RunAsync(string repo, string revision, string file)
         {
-            var starter = new ProcessStartInfo();
-            starter.WorkingDirectory = repo;
-            starter.FileName = Native.OS.GitExecutable;
-            starter.Arguments = $"show {revision}:{file.Quoted()}";
-            starter.UseShellExecute = false;
-            starter.CreateNoWindow = true;
-            starter.WindowStyle = ProcessWindowStyle.Hidden;
-            starter.RedirectStandardOutput = true;
+            var spec = new Command.RunSpec
+            {
+                Args = $"show {revision}:{file.Quoted()}",
+                WorkingDirectory = repo,
+            };
 
             var stream = new MemoryStream();
             try
             {
-                using var proc = Process.Start(starter)!;
-                await proc.StandardOutput.BaseStream.CopyToAsync(stream).ConfigureAwait(false);
-                await proc.WaitForExitAsync().ConfigureAwait(false);
+                using var proc = LocalCommandRunner.Instance.Start(spec);
+                await proc.StdoutStream.CopyToAsync(stream).ConfigureAwait(false);
+                await proc.WaitForExitAsync(CancellationToken.None).ConfigureAwait(false);
             }
             catch (Exception e)
             {
@@ -36,25 +33,22 @@ namespace SourceGit.Commands
 
         public static async Task<Stream> FromLFSAsync(string repo, string oid, long size)
         {
-            var starter = new ProcessStartInfo();
-            starter.WorkingDirectory = repo;
-            starter.FileName = Native.OS.GitExecutable;
-            starter.Arguments = "lfs smudge";
-            starter.UseShellExecute = false;
-            starter.CreateNoWindow = true;
-            starter.WindowStyle = ProcessWindowStyle.Hidden;
-            starter.RedirectStandardInput = true;
-            starter.RedirectStandardOutput = true;
+            var spec = new Command.RunSpec
+            {
+                Args = "lfs smudge",
+                WorkingDirectory = repo,
+                RedirectStandardInput = true,
+            };
 
             var stream = new MemoryStream();
             try
             {
-                using var proc = Process.Start(starter)!;
-                await proc.StandardInput.WriteLineAsync("version https://git-lfs.github.com/spec/v1").ConfigureAwait(false);
-                await proc.StandardInput.WriteLineAsync($"oid sha256:{oid}").ConfigureAwait(false);
-                await proc.StandardInput.WriteLineAsync($"size {size}").ConfigureAwait(false);
-                await proc.StandardOutput.BaseStream.CopyToAsync(stream).ConfigureAwait(false);
-                await proc.WaitForExitAsync().ConfigureAwait(false);
+                using var proc = LocalCommandRunner.Instance.Start(spec);
+                await proc.Stdin.WriteLineAsync("version https://git-lfs.github.com/spec/v1").ConfigureAwait(false);
+                await proc.Stdin.WriteLineAsync($"oid sha256:{oid}").ConfigureAwait(false);
+                await proc.Stdin.WriteLineAsync($"size {size}").ConfigureAwait(false);
+                await proc.StdoutStream.CopyToAsync(stream).ConfigureAwait(false);
+                await proc.WaitForExitAsync(CancellationToken.None).ConfigureAwait(false);
             }
             catch (Exception e)
             {

--- a/src/Commands/QueryFileContent.cs
+++ b/src/Commands/QueryFileContent.cs
@@ -18,7 +18,7 @@ namespace SourceGit.Commands
             var stream = new MemoryStream();
             try
             {
-                using var proc = LocalCommandRunner.Instance.Start(spec);
+                using var proc = (CommandRunnerRegistry.Get(repo) ?? LocalCommandRunner.Instance).Start(spec);
                 await proc.StdoutStream.CopyToAsync(stream).ConfigureAwait(false);
                 await proc.WaitForExitAsync(CancellationToken.None).ConfigureAwait(false);
             }
@@ -43,7 +43,7 @@ namespace SourceGit.Commands
             var stream = new MemoryStream();
             try
             {
-                using var proc = LocalCommandRunner.Instance.Start(spec);
+                using var proc = (CommandRunnerRegistry.Get(repo) ?? LocalCommandRunner.Instance).Start(spec);
                 await proc.Stdin.WriteLineAsync("version https://git-lfs.github.com/spec/v1").ConfigureAwait(false);
                 await proc.Stdin.WriteLineAsync($"oid sha256:{oid}").ConfigureAwait(false);
                 await proc.Stdin.WriteLineAsync($"size {size}").ConfigureAwait(false);

--- a/src/Commands/QueryLocalChanges.cs
+++ b/src/Commands/QueryLocalChanges.cs
@@ -33,11 +33,9 @@ namespace SourceGit.Commands
 
             try
             {
-                using var proc = new Process();
-                proc.StartInfo = CreateGitStartInfo(true);
-                proc.Start();
+                using var proc = Runner.Start(BuildSpec());
 
-                while (await proc.StandardOutput.ReadLineAsync().ConfigureAwait(false) is { } line)
+                while (await proc.Stdout.ReadLineAsync().ConfigureAwait(false) is { } line)
                 {
                     var match = REG_FORMAT().Match(line);
                     if (!match.Success)

--- a/src/Commands/QueryPickableCommits.cs
+++ b/src/Commands/QueryPickableCommits.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace SourceGit.Commands
@@ -19,11 +19,9 @@ namespace SourceGit.Commands
             var commits = new List<Models.Commit>();
             try
             {
-                using var proc = new Process();
-                proc.StartInfo = CreateGitStartInfo(true);
-                proc.Start();
+                using var proc = Runner.Start(BuildSpec());
 
-                while (await proc.StandardOutput.ReadLineAsync().ConfigureAwait(false) is { } line)
+                while (await proc.Stdout.ReadLineAsync().ConfigureAwait(false) is { } line)
                 {
                     var parts = line.Split('\0');
                     if (parts.Length != 8)
@@ -40,7 +38,7 @@ namespace SourceGit.Commands
                     commits.Add(commit);
                 }
 
-                await proc.WaitForExitAsync().ConfigureAwait(false);
+                await proc.WaitForExitAsync(CancellationToken.None).ConfigureAwait(false);
             }
             catch (Exception e)
             {

--- a/src/Commands/QueryRevisionFileNames.cs
+++ b/src/Commands/QueryRevisionFileNames.cs
@@ -1,5 +1,5 @@
 ﻿using System.Collections.Generic;
-using System.Diagnostics;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace SourceGit.Commands
@@ -19,14 +19,12 @@ namespace SourceGit.Commands
 
             try
             {
-                using var proc = new Process();
-                proc.StartInfo = CreateGitStartInfo(true);
-                proc.Start();
+                using var proc = Runner.Start(BuildSpec());
 
-                while (await proc.StandardOutput.ReadLineAsync().ConfigureAwait(false) is { Length: > 0 } line)
+                while (await proc.Stdout.ReadLineAsync().ConfigureAwait(false) is { Length: > 0 } line)
                     outs.Add(line);
 
-                await proc.WaitForExitAsync().ConfigureAwait(false);
+                await proc.WaitForExitAsync(CancellationToken.None).ConfigureAwait(false);
             }
             catch
             {

--- a/src/Commands/QueryRevisionObjects.cs
+++ b/src/Commands/QueryRevisionObjects.cs
@@ -1,5 +1,5 @@
 ﻿using System.Collections.Generic;
-using System.Diagnostics;
+using System.Threading;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
@@ -30,11 +30,9 @@ namespace SourceGit.Commands
 
             try
             {
-                using var proc = new Process();
-                proc.StartInfo = CreateGitStartInfo(true);
-                proc.Start();
+                using var proc = Runner.Start(BuildSpec());
 
-                while (await proc.StandardOutput.ReadLineAsync().ConfigureAwait(false) is { } line)
+                while (await proc.Stdout.ReadLineAsync().ConfigureAwait(false) is { } line)
                 {
                     var match = REG_FORMAT().Match(line);
                     if (!match.Success)
@@ -57,7 +55,7 @@ namespace SourceGit.Commands
                     outs.Add(obj);
                 }
 
-                await proc.WaitForExitAsync().ConfigureAwait(false);
+                await proc.WaitForExitAsync(CancellationToken.None).ConfigureAwait(false);
             }
             catch
             {

--- a/src/Commands/Replay.cs
+++ b/src/Commands/Replay.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics;
+﻿using System.Threading;
 using System.Threading.Tasks;
 
 namespace SourceGit.Commands
@@ -15,22 +15,7 @@ namespace SourceGit.Commands
 
         public async Task<int> GetExitCodeAsync()
         {
-            using var proc = new Process();
-            proc.StartInfo = CreateGitStartInfo(false);
-
-            var exitCode = -1;
-            try
-            {
-                proc.Start();
-                await proc.WaitForExitAsync().ConfigureAwait(false);
-                exitCode = proc.ExitCode;
-            }
-            catch
-            {
-                // Ignore any exceptions and just return -1
-            }
-
-            return exitCode;
+            return await Runner.RunForExitCodeAsync(BuildSpec(), CancellationToken.None).ConfigureAwait(false);
         }
     }
 }

--- a/src/Commands/Reset.cs
+++ b/src/Commands/Reset.cs
@@ -1,4 +1,4 @@
-﻿namespace SourceGit.Commands
+namespace SourceGit.Commands
 {
     public class Reset : Command
     {
@@ -13,7 +13,8 @@
         {
             WorkingDirectory = repo;
             Context = repo;
-            Args = $"reset --pathspec-from-file={pathspec.Quoted()}";
+            Stdin = pathspec;
+            Args = "reset --pathspec-from-file=-";
         }
     }
 }

--- a/src/Commands/SaveChangesAsPatch.cs
+++ b/src/Commands/SaveChangesAsPatch.cs
@@ -1,7 +1,7 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace SourceGit.Commands
@@ -51,20 +51,17 @@ namespace SourceGit.Commands
 
         private static async Task<bool> ProcessSingleChangeAsync(string repo, Models.DiffOption opt, FileStream writer)
         {
-            var starter = new ProcessStartInfo();
-            starter.WorkingDirectory = repo;
-            starter.FileName = Native.OS.GitExecutable;
-            starter.Arguments = $"diff --no-color --no-ext-diff --ignore-cr-at-eol --unified=4 {opt}";
-            starter.UseShellExecute = false;
-            starter.CreateNoWindow = true;
-            starter.WindowStyle = ProcessWindowStyle.Hidden;
-            starter.RedirectStandardOutput = true;
+            var spec = new Command.RunSpec
+            {
+                Args = $"diff --no-color --no-ext-diff --ignore-cr-at-eol --unified=4 {opt}",
+                WorkingDirectory = repo,
+            };
 
             try
             {
-                using var proc = Process.Start(starter)!;
-                await proc.StandardOutput.BaseStream.CopyToAsync(writer).ConfigureAwait(false);
-                await proc.WaitForExitAsync().ConfigureAwait(false);
+                using var proc = LocalCommandRunner.Instance.Start(spec);
+                await proc.StdoutStream.CopyToAsync(writer).ConfigureAwait(false);
+                await proc.WaitForExitAsync(CancellationToken.None).ConfigureAwait(false);
                 return proc.ExitCode == 0;
             }
             catch (Exception e)

--- a/src/Commands/SaveChangesAsPatch.cs
+++ b/src/Commands/SaveChangesAsPatch.cs
@@ -59,7 +59,7 @@ namespace SourceGit.Commands
 
             try
             {
-                using var proc = LocalCommandRunner.Instance.Start(spec);
+                using var proc = (CommandRunnerRegistry.Get(repo) ?? LocalCommandRunner.Instance).Start(spec);
                 await proc.StdoutStream.CopyToAsync(writer).ConfigureAwait(false);
                 await proc.WaitForExitAsync(CancellationToken.None).ConfigureAwait(false);
                 return proc.ExitCode == 0;

--- a/src/Commands/SaveRevisionFile.cs
+++ b/src/Commands/SaveRevisionFile.cs
@@ -38,7 +38,7 @@ namespace SourceGit.Commands
             {
                 try
                 {
-                    using var proc = LocalCommandRunner.Instance.Start(spec);
+                    using var proc = (CommandRunnerRegistry.Get(repo) ?? LocalCommandRunner.Instance).Start(spec);
 
                     if (input != null)
                     {

--- a/src/Commands/SaveRevisionFile.cs
+++ b/src/Commands/SaveRevisionFile.cs
@@ -1,6 +1,6 @@
-﻿using System;
-using System.Diagnostics;
+using System;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace SourceGit.Commands
@@ -27,31 +27,27 @@ namespace SourceGit.Commands
 
         private static async Task ExecCmdAsync(string repo, string args, string outputFile, Stream input = null)
         {
-            var starter = new ProcessStartInfo();
-            starter.WorkingDirectory = repo;
-            starter.FileName = Native.OS.GitExecutable;
-            starter.Arguments = args;
-            starter.UseShellExecute = false;
-            starter.CreateNoWindow = true;
-            starter.WindowStyle = ProcessWindowStyle.Hidden;
-            starter.RedirectStandardInput = true;
-            starter.RedirectStandardOutput = true;
-            starter.RedirectStandardError = true;
+            var spec = new Command.RunSpec
+            {
+                Args = args,
+                WorkingDirectory = repo,
+                RedirectStandardInput = true,
+            };
 
             await using (var sw = File.Create(outputFile))
             {
                 try
                 {
-                    using var proc = Process.Start(starter)!;
+                    using var proc = LocalCommandRunner.Instance.Start(spec);
 
                     if (input != null)
                     {
                         var inputString = await new StreamReader(input).ReadToEndAsync().ConfigureAwait(false);
-                        await proc.StandardInput.WriteAsync(inputString).ConfigureAwait(false);
+                        await proc.Stdin.WriteAsync(inputString).ConfigureAwait(false);
                     }
 
-                    await proc.StandardOutput.BaseStream.CopyToAsync(sw).ConfigureAwait(false);
-                    await proc.WaitForExitAsync().ConfigureAwait(false);
+                    await proc.StdoutStream.CopyToAsync(sw).ConfigureAwait(false);
+                    await proc.WaitForExitAsync(CancellationToken.None).ConfigureAwait(false);
                 }
                 catch (Exception e)
                 {

--- a/src/Commands/Tag.cs
+++ b/src/Commands/Tag.cs
@@ -31,14 +31,11 @@ namespace SourceGit.Commands
 
             if (!string.IsNullOrEmpty(message))
             {
-                string tmp = Path.GetTempFileName();
-                await File.WriteAllTextAsync(tmp, message);
-                builder.Append(" -F ").Append(tmp.Quoted());
+                Stdin = message;
+                builder.Append(" -F -");
 
                 Args = builder.ToString();
-                var succ = await ExecAsync().ConfigureAwait(false);
-                File.Delete(tmp);
-                return succ;
+                return await ExecAsync().ConfigureAwait(false);
             }
 
             builder.Append(" -m ");

--- a/src/Commands/UpdateIndexInfo.cs
+++ b/src/Commands/UpdateIndexInfo.cs
@@ -59,7 +59,7 @@ namespace SourceGit.Commands
 
             try
             {
-                using var proc = LocalCommandRunner.Instance.Start(spec);
+                using var proc = (CommandRunnerRegistry.Get(_repo) ?? LocalCommandRunner.Instance).Start(spec);
                 await proc.Stdin.WriteAsync(_patchBuilder.ToString());
                 proc.Stdin.Close();
 

--- a/src/Commands/UpdateIndexInfo.cs
+++ b/src/Commands/UpdateIndexInfo.cs
@@ -1,7 +1,7 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace SourceGit.Commands
@@ -50,27 +50,21 @@ namespace SourceGit.Commands
 
         public async Task<bool> ExecAsync()
         {
-            var starter = new ProcessStartInfo();
-            starter.WorkingDirectory = _repo;
-            starter.FileName = Native.OS.GitExecutable;
-            starter.Arguments = "-c core.editor=true update-index --index-info";
-            starter.UseShellExecute = false;
-            starter.CreateNoWindow = true;
-            starter.WindowStyle = ProcessWindowStyle.Hidden;
-            starter.RedirectStandardInput = true;
-            starter.RedirectStandardOutput = false;
-            starter.RedirectStandardError = true;
-            starter.StandardInputEncoding = new UTF8Encoding(false);
-            starter.StandardErrorEncoding = Encoding.UTF8;
+            var spec = new Command.RunSpec
+            {
+                Args = "-c core.editor=true update-index --index-info",
+                WorkingDirectory = _repo,
+                RedirectStandardInput = true,
+            };
 
             try
             {
-                using var proc = Process.Start(starter)!;
-                await proc.StandardInput.WriteAsync(_patchBuilder.ToString());
-                proc.StandardInput.Close();
+                using var proc = LocalCommandRunner.Instance.Start(spec);
+                await proc.Stdin.WriteAsync(_patchBuilder.ToString());
+                proc.Stdin.Close();
 
-                var err = await proc.StandardError.ReadToEndAsync().ConfigureAwait(false);
-                await proc.WaitForExitAsync().ConfigureAwait(false);
+                var err = await proc.Stderr.ReadToEndAsync().ConfigureAwait(false);
+                await proc.WaitForExitAsync(CancellationToken.None).ConfigureAwait(false);
                 var rs = proc.ExitCode == 0;
 
                 if (!rs)

--- a/src/Models/IFileSystem.cs
+++ b/src/Models/IFileSystem.cs
@@ -1,0 +1,49 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace SourceGit.Models
+{
+    /// <summary>
+    /// Abstracts filesystem access to the repository working tree and the <c>.git</c>
+    /// directory.
+    /// <para>
+    /// The local implementation delegates directly to <see cref="File"/>/<see cref="Directory"/>
+    /// and keeps existing behavior unchanged. A future remote implementation will route
+    /// these calls to a lightweight server over an SSH channel, so that operations on a
+    /// repository living on a remote host do not require the files to exist locally.
+    /// </para>
+    /// <para>
+    /// Only paths that refer to the managed repository (working tree or <c>.git</c>
+    /// internals) need to go through this interface. Application data living under
+    /// <c>Native.OS.DataDir</c> (preferences, avatar cache, etc.) stays local on both
+    /// sides and continues to use <see cref="File"/>/<see cref="Directory"/> directly.
+    /// </para>
+    /// </summary>
+    public interface IFileSystem
+    {
+        bool FileExists(string path);
+        bool DirectoryExists(string path);
+
+        string ReadAllText(string path);
+        Task<string> ReadAllTextAsync(string path);
+
+        void WriteAllText(string path, string content);
+        Task WriteAllTextAsync(string path, string content);
+        Task WriteAllLinesAsync(string path, IEnumerable<string> lines);
+
+        void DeleteFile(string path);
+        void DeleteDirectory(string path, bool recursive);
+
+        Stream OpenRead(string path);
+        Stream Create(string path);
+
+        /// <summary>
+        /// Create a temporary file reachable by the git process and write the given
+        /// content into it, returning the path. Locally this is <c>Path.GetTempFileName</c>
+        /// followed by a write; remotely the file is created on the server hosting git.
+        /// Used for pathspec/commit-message/patch data that git must read from disk.
+        /// </summary>
+        string CreateTempFile(string content);
+    }
+}

--- a/src/Models/IRepositoryHost.cs
+++ b/src/Models/IRepositoryHost.cs
@@ -1,0 +1,27 @@
+namespace SourceGit.Models
+{
+    /// <summary>
+    /// Represents the host a repository lives on.
+    /// <para>
+    /// A local repository is backed by <see cref="SourceGit.Commands.LocalCommandRunner"/>
+    /// and a passthrough filesystem, matching today's behavior exactly. A remote
+    /// repository (future SSH support) is backed by an RPC connection to a lightweight
+    /// server running on the remote host.
+    /// </para>
+    /// <para>
+    /// Phase 0 only wires the abstraction in place; <see cref="IsRemote"/> is always
+    /// <c>false</c> for now and the local implementations are used everywhere.
+    /// </para>
+    /// </summary>
+    public interface IRepositoryHost
+    {
+        /// <summary>Whether the repository lives on a remote host accessed over SSH.</summary>
+        bool IsRemote { get; }
+
+        /// <summary>Runner used to execute git commands for repositories on this host.</summary>
+        Commands.ICommandRunner Runner { get; }
+
+        /// <summary>Filesystem accessor for the working tree and <c>.git</c> internals.</summary>
+        IFileSystem FileSystem { get; }
+    }
+}

--- a/src/Models/LocalFileSystem.cs
+++ b/src/Models/LocalFileSystem.cs
@@ -1,0 +1,39 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace SourceGit.Models
+{
+    /// <summary>
+    /// <see cref="IFileSystem"/> implementation that delegates directly to <see cref="File"/>/
+    /// <see cref="Directory"/>. This is the local-repository behavior, preserved exactly when
+    /// the filesystem abstraction is used in place of raw File./Directory. calls.
+    /// </summary>
+    public sealed class LocalFileSystem : IFileSystem
+    {
+        public static readonly LocalFileSystem Instance = new();
+
+        public bool FileExists(string path) => File.Exists(path);
+        public bool DirectoryExists(string path) => Directory.Exists(path);
+
+        public string ReadAllText(string path) => File.ReadAllText(path);
+        public Task<string> ReadAllTextAsync(string path) => File.ReadAllTextAsync(path);
+
+        public void WriteAllText(string path, string content) => File.WriteAllText(path, content);
+        public Task WriteAllTextAsync(string path, string content) => File.WriteAllTextAsync(path, content);
+        public Task WriteAllLinesAsync(string path, IEnumerable<string> lines) => File.WriteAllLinesAsync(path, lines);
+
+        public void DeleteFile(string path) => File.Delete(path);
+        public void DeleteDirectory(string path, bool recursive) => Directory.Delete(path, recursive);
+
+        public Stream OpenRead(string path) => File.OpenRead(path);
+        public Stream Create(string path) => File.Create(path);
+
+        public string CreateTempFile(string content)
+        {
+            var path = Path.GetTempFileName();
+            File.WriteAllText(path, content);
+            return path;
+        }
+    }
+}

--- a/src/Models/RemoteHost.cs
+++ b/src/Models/RemoteHost.cs
@@ -1,0 +1,26 @@
+using System.Text.Json.Serialization;
+
+namespace SourceGit.Models
+{
+    /// <summary>
+    /// Configuration for a remote host that serves repositories over SSH.
+    /// <para>
+    /// <see cref="Host"/> is passed straight to <c>ssh</c>, so it should be either a
+    /// <c>user@host</c> pair or — preferred — an alias defined in the user's
+    /// <c>~/.ssh/config</c>. Reusing the SSH config means ProxyJump (jump hosts / multi-hop),
+    /// identity files, agent forwarding, port and passwordless auth are all honored exactly
+    /// as the user already configured them, without bespoke options here.
+    /// </para>
+    /// </summary>
+    public class RemoteHost
+    {
+        public string Name { get; set; } = string.Empty;
+
+        [JsonPropertyName("host")]
+        public string Host { get; set; } = string.Empty;
+
+        /// <summary>Absolute path to the sourcegit executable on the remote host.</summary>
+        [JsonPropertyName("remote_server_path")]
+        public string RemoteServerPath { get; set; } = "sourcegit";
+    }
+}

--- a/src/Models/RemoteHost.cs
+++ b/src/Models/RemoteHost.cs
@@ -1,3 +1,4 @@
+using System.Collections.ObjectModel;
 using System.Text.Json.Serialization;
 
 using Avalonia.Media;
@@ -75,6 +76,10 @@ namespace SourceGit.Models
             get => _statusMessage;
             set => SetProperty(ref _statusMessage, value);
         }
+
+        /// <summary>Scrolling log of connect/test/reset steps, newest appended at bottom.</summary>
+        [JsonIgnore]
+        public ObservableCollection<string> StatusLog { get; } = new();
 
         [JsonIgnore]
         public bool IsConnected => _state == RemoteHostState.Connected;

--- a/src/Models/RemoteHost.cs
+++ b/src/Models/RemoteHost.cs
@@ -5,11 +5,16 @@ namespace SourceGit.Models
     /// <summary>
     /// Configuration for a remote host that serves repositories over SSH.
     /// <para>
-    /// <see cref="Host"/> is passed straight to <c>ssh</c>, so it should be either a
-    /// <c>user@host</c> pair or — preferred — an alias defined in the user's
+    /// <see cref="Host"/> is passed straight to <c>ssh</c>/<c>scp</c>, so it should be either
+    /// a <c>user@host</c> pair or — preferred — an alias defined in the user's
     /// <c>~/.ssh/config</c>. Reusing the SSH config means ProxyJump (jump hosts / multi-hop),
     /// identity files, agent forwarding, port and passwordless auth are all honored exactly
-    /// as the user already configured them, without bespoke options here.
+    /// as the user already configured them.
+    /// </para>
+    /// <para>
+    /// The remote server binary is auto-deployed to <c>~/.sourcegit-server/sourcegit</c> on
+    /// the remote host (see <see cref="Remote.RemoteRepositoryOpener"/>), so no server path
+    /// is configured here.
     /// </para>
     /// </summary>
     public class RemoteHost
@@ -18,9 +23,5 @@ namespace SourceGit.Models
 
         [JsonPropertyName("host")]
         public string Host { get; set; } = string.Empty;
-
-        /// <summary>Absolute path to the sourcegit executable on the remote host.</summary>
-        [JsonPropertyName("remote_server_path")]
-        public string RemoteServerPath { get; set; } = "sourcegit";
     }
 }

--- a/src/Models/RemoteHost.cs
+++ b/src/Models/RemoteHost.cs
@@ -81,6 +81,14 @@ namespace SourceGit.Models
         [JsonIgnore]
         public ObservableCollection<string> StatusLog { get; } = new();
 
+        /// <summary>Joined log text for copy-friendly display in a read-only TextBox.</summary>
+        [JsonIgnore]
+        public string StatusLogText
+        {
+            get => _statusLogText;
+            set => SetProperty(ref _statusLogText, value);
+        }
+
         [JsonIgnore]
         public bool IsConnected => _state == RemoteHostState.Connected;
 
@@ -101,5 +109,6 @@ namespace SourceGit.Models
         private string _host = string.Empty;
         private RemoteHostState _state = RemoteHostState.Disconnected;
         private string _statusMessage = string.Empty;
+        private string _statusLogText = string.Empty;
     }
 }

--- a/src/Models/RemoteHost.cs
+++ b/src/Models/RemoteHost.cs
@@ -1,7 +1,24 @@
 using System.Text.Json.Serialization;
 
+using Avalonia.Media;
+
+using CommunityToolkit.Mvvm.ComponentModel;
+
 namespace SourceGit.Models
 {
+    /// <summary>
+    /// Lifecycle state of a remote host connection. Drives the status indicator in the
+    /// settings page and gates whether the host can be used to open repositories.
+    /// </summary>
+    public enum RemoteHostState
+    {
+        Disconnected,
+        Testing,
+        Connecting,
+        Connected,
+        Failed,
+    }
+
     /// <summary>
     /// Configuration for a remote host that serves repositories over SSH.
     /// <para>
@@ -13,15 +30,71 @@ namespace SourceGit.Models
     /// </para>
     /// <para>
     /// The remote server binary is auto-deployed to <c>~/.sourcegit-server/sourcegit</c> on
-    /// the remote host (see <see cref="Remote.RemoteRepositoryOpener"/>), so no server path
-    /// is configured here.
+    /// the remote host (see <see cref="Remote.RemoteHostSession"/>), so no server path is
+    /// configured here.
+    /// </para>
+    /// <para>
+    /// <see cref="Name"/> and <see cref="Host"/> are persisted; the connection
+    /// <see cref="State"/> and <see cref="StatusMessage"/> are runtime-only and updated by
+    /// <see cref="Remote.RemoteHostManager"/>.
     /// </para>
     /// </summary>
-    public class RemoteHost
+    public class RemoteHost : ObservableObject
     {
-        public string Name { get; set; } = string.Empty;
+        public string Name
+        {
+            get => _name;
+            set => SetProperty(ref _name, value);
+        }
 
         [JsonPropertyName("host")]
-        public string Host { get; set; } = string.Empty;
+        public string Host
+        {
+            get => _host;
+            set => SetProperty(ref _host, value);
+        }
+
+        [JsonIgnore]
+        public RemoteHostState State
+        {
+            get => _state;
+            set
+            {
+                if (SetProperty(ref _state, value))
+                {
+                    OnPropertyChanged(nameof(IsConnected));
+                    OnPropertyChanged(nameof(IsBusy));
+                    OnPropertyChanged(nameof(StatusBrush));
+                }
+            }
+        }
+
+        [JsonIgnore]
+        public string StatusMessage
+        {
+            get => _statusMessage;
+            set => SetProperty(ref _statusMessage, value);
+        }
+
+        [JsonIgnore]
+        public bool IsConnected => _state == RemoteHostState.Connected;
+
+        [JsonIgnore]
+        public bool IsBusy => _state is RemoteHostState.Testing or RemoteHostState.Connecting;
+
+        [JsonIgnore]
+        public IBrush StatusBrush => _state switch
+        {
+            RemoteHostState.Connected => Brushes.ForestGreen,
+            RemoteHostState.Connecting => Brushes.Goldenrod,
+            RemoteHostState.Testing => Brushes.Goldenrod,
+            RemoteHostState.Failed => Brushes.IndianRed,
+            _ => Brushes.Gray,
+        };
+
+        private string _name = string.Empty;
+        private string _host = string.Empty;
+        private RemoteHostState _state = RemoteHostState.Disconnected;
+        private string _statusMessage = string.Empty;
     }
 }

--- a/src/Native/OS.cs
+++ b/src/Native/OS.cs
@@ -189,6 +189,17 @@ namespace SourceGit.Native
             return _backend.FindGitExecutable();
         }
 
+        /// <summary>
+        /// Path to the bundled Linux remote-server binary inside the app bundle
+        /// (Contents/Resources/remote-server/linux-x64/sourcegit). Returns null when not
+        /// running from a .app bundle (e.g. dev builds) so the caller can fall back.
+        /// </summary>
+        public static string GetBundledRemoteServerPath()
+        {
+            var candidate = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "Resources", "remote-server", "linux-x64", "sourcegit"));
+            return File.Exists(candidate) ? candidate : null;
+        }
+
         public static bool TestShellOrTerminal(Models.ShellOrTerminal shell)
         {
             return !string.IsNullOrEmpty(_backend.FindTerminal(shell));

--- a/src/Native/OS.cs
+++ b/src/Native/OS.cs
@@ -190,12 +190,18 @@ namespace SourceGit.Native
         }
 
         /// <summary>
-        /// Path to the bundled Linux remote-server binary inside the app bundle
-        /// (Contents/Resources/remote-server/linux-x64/sourcegit). Returns null when not
-        /// running from a .app bundle (e.g. dev builds) so the caller can fall back.
+        /// Path to the remote-server binary that gets deployed to the host. Prefers the
+        /// <c>SOURCEGIT_REMOTE_SERVER</c> environment override (handy for development, where
+        /// the app is not packaged), then falls back to the bundled Linux binary inside the
+        /// app bundle (Contents/Resources/remote-server/linux-x64/sourcegit). Returns null
+        /// when neither is available so the caller can report a clear error.
         /// </summary>
         public static string GetBundledRemoteServerPath()
         {
+            var overridePath = Environment.GetEnvironmentVariable("SOURCEGIT_REMOTE_SERVER");
+            if (!string.IsNullOrEmpty(overridePath) && File.Exists(overridePath))
+                return overridePath;
+
             var candidate = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "Resources", "remote-server", "linux-x64", "sourcegit"));
             return File.Exists(candidate) ? candidate : null;
         }

--- a/src/Native/OS.cs
+++ b/src/Native/OS.cs
@@ -206,6 +206,25 @@ namespace SourceGit.Native
             return File.Exists(candidate) ? candidate : null;
         }
 
+        /// <summary>
+        /// Friendly build version (git describe, e.g. <c>v2026.14-24-aa693967-dirty</c>) baked
+        /// into the assembly as <c>AssemblyMetadata("FriendlyVersion")</c>. Used to decide
+        /// whether the deployed remote server is out of date and needs re-uploading.
+        /// </summary>
+        public static string GetAppVersion()
+        {
+            var assembly = Assembly.GetExecutingAssembly();
+            foreach (var attr in assembly.GetCustomAttributes<AssemblyMetadataAttribute>())
+            {
+                if (attr.Key.Equals("FriendlyVersion", StringComparison.OrdinalIgnoreCase) &&
+                    !string.IsNullOrWhiteSpace(attr.Value))
+                    return attr.Value;
+            }
+
+            var ver = assembly.GetName().Version;
+            return ver != null ? $"v{ver.Major}.{ver.Minor:D2}" : "unknown";
+        }
+
         public static bool TestShellOrTerminal(Models.ShellOrTerminal shell)
         {
             return !string.IsNullOrEmpty(_backend.FindTerminal(shell));

--- a/src/Remote/Connections.cs
+++ b/src/Remote/Connections.cs
@@ -15,9 +15,7 @@ namespace SourceGit.Remote
     }
 
     /// <summary>
-    /// Connection to a server launched as a local child process (e.g.
-    /// <c>dotnet SourceGit.dll --remote-server</c>). Mainly used for testing and for a
-    /// possible "local server" mode; real remote repositories use <see cref="SshConnection"/>.
+    /// Connection to a server launched as a local child process (testing / local mode).
     /// </summary>
     public sealed class LocalProcessConnection : IConnection
     {
@@ -54,10 +52,9 @@ namespace SourceGit.Remote
     }
 
     /// <summary>
-    /// Connection to a remote server reached over SSH. Launches
-    /// <c>ssh &lt;user&gt;@&lt;host&gt; &lt;remote-sourcegit&gt; --remote-server</c> and pipes
-    /// JSON-RPC over the SSH channel's stdin/stdout. Authentication is non-interactive
-    /// (BatchMode) via an identity file or the SSH agent.
+    /// Connection to a remote server reached over SSH. Reuses the user's ~/.ssh/config:
+    /// <paramref name="host"/> may be a config alias carrying ProxyJump (jump hosts /
+    /// multi-hop), identity, agent, port and passwordless auth.
     /// </summary>
     public sealed class SshConnection : IConnection
     {
@@ -65,11 +62,6 @@ namespace SourceGit.Remote
 
         public SshConnection(string host, string remoteServerCommand)
         {
-            // Reuse the user's ~/.ssh/config: `host` may be a config alias carrying
-            // ProxyJump (jump hosts / multi-hop), IdentityAgent/identity, port, user, etc.
-            // We only force no-tty and first-time host key acceptance; everything else
-            // comes from config so passwordless auth, jump hosts and multi-hop all work
-            // as the user already configured them.
             var args = $"-T -o StrictHostKeyChecking=accept-new {host} {remoteServerCommand}";
 
             var psi = new ProcessStartInfo("ssh", args)
@@ -93,6 +85,74 @@ namespace SourceGit.Remote
         {
             try { if (!_proc.HasExited) _proc.Kill(); } catch { }
             _proc.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// Run a one-shot command on the remote host over SSH (non-interactive: BatchMode so it
+    /// never prompts for a password — relies on the ssh config's key/agent). Used to probe
+    /// for the deployed server binary and to mkdir/chmod around the upload.
+    /// </summary>
+    public static class SshExec
+    {
+        public static (string stdout, int exitCode) Run(string host, string command)
+        {
+            var args = $"-T -o BatchMode=yes -o StrictHostKeyChecking=accept-new {host} {command}";
+            var psi = new ProcessStartInfo("ssh", args)
+            {
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                CreateNoWindow = true,
+            };
+
+            try
+            {
+                using var p = Process.Start(psi);
+                if (p == null)
+                    return (string.Empty, -1);
+
+                var stdout = p.StandardOutput.ReadToEnd();
+                p.WaitForExit();
+                return (stdout, p.ExitCode);
+            }
+            catch
+            {
+                return (string.Empty, -1);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Upload a local file to the remote host via scp, reusing the same host alias so
+    /// ~/.ssh/config (ProxyJump/agent/key) applies. Non-interactive (BatchMode).
+    /// </summary>
+    public static class ScpUpload
+    {
+        public static int Upload(string host, string localFile, string remotePath)
+        {
+            var args = $"-o BatchMode=yes -o StrictHostKeyChecking=accept-new \"{localFile}\" {host}:{remotePath}";
+            var psi = new ProcessStartInfo("scp", args)
+            {
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                CreateNoWindow = true,
+            };
+
+            try
+            {
+                using var p = Process.Start(psi);
+                if (p == null)
+                    return -1;
+
+                p.WaitForExit();
+                return p.ExitCode;
+            }
+            catch
+            {
+                return -1;
+            }
         }
     }
 }

--- a/src/Remote/Connections.cs
+++ b/src/Remote/Connections.cs
@@ -63,16 +63,14 @@ namespace SourceGit.Remote
     {
         private readonly Process _proc;
 
-        public SshConnection(string host, string user, int port, string identityFile, string remoteServerCommand)
+        public SshConnection(string host, string remoteServerCommand)
         {
-            var args = "-T -o BatchMode=yes -o StrictHostKeyChecking=accept-new";
-            if (port > 0)
-                args += $" -p {port}";
-            if (!string.IsNullOrEmpty(identityFile))
-                args += $" -i \"{identityFile}\"";
-
-            var target = string.IsNullOrEmpty(user) ? host : $"{user}@{host}";
-            args += $" {target} {remoteServerCommand}";
+            // Reuse the user's ~/.ssh/config: `host` may be a config alias carrying
+            // ProxyJump (jump hosts / multi-hop), IdentityAgent/identity, port, user, etc.
+            // We only force no-tty and first-time host key acceptance; everything else
+            // comes from config so passwordless auth, jump hosts and multi-hop all work
+            // as the user already configured them.
+            var args = $"-T -o StrictHostKeyChecking=accept-new {host} {remoteServerCommand}";
 
             var psi = new ProcessStartInfo("ssh", args)
             {

--- a/src/Remote/Connections.cs
+++ b/src/Remote/Connections.cs
@@ -136,6 +136,18 @@ namespace SourceGit.Remote
     {
         public static int Upload(string host, string localFile, string remotePath)
         {
+            // Prefer scp; it is the common case and handles progress/permissions natively.
+            var scpCode = TryScp(host, localFile, remotePath);
+            if (scpCode == 0)
+                return 0;
+
+            // Fallback for minimal/container hosts where scp is not installed: stream the file
+            // over a plain ssh channel with `cat > remote`. Works everywhere ssh works.
+            return UploadViaSshCat(host, localFile, remotePath);
+        }
+
+        private static int TryScp(string host, string localFile, string remotePath)
+        {
             var args = $"-o BatchMode=yes -o StrictHostKeyChecking=accept-new \"{localFile}\" {host}:{remotePath}";
             var psi = new ProcessStartInfo("scp", args)
             {
@@ -151,10 +163,44 @@ namespace SourceGit.Remote
                 if (p == null)
                     return -1;
 
-                // scp writes progress to stderr; if we don't drain both pipes the process
-                // blocks once the OS buffer fills (e.g. on a ~100MB server upload).
                 var stdoutTask = p.StandardOutput.ReadToEndAsync();
                 var stderrTask = p.StandardError.ReadToEndAsync();
+                p.WaitForExit();
+                Task.WaitAll(stdoutTask, stderrTask);
+                return p.ExitCode;
+            }
+            catch
+            {
+                return -1;
+            }
+        }
+
+        private static int UploadViaSshCat(string host, string localFile, string remotePath)
+        {
+            var args = $"-T -o BatchMode=yes -o StrictHostKeyChecking=accept-new {host} \"cat > {remotePath}\"";
+            var psi = new ProcessStartInfo("ssh", args)
+            {
+                UseShellExecute = false,
+                RedirectStandardInput = true,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                CreateNoWindow = true,
+            };
+
+            try
+            {
+                using var p = Process.Start(psi);
+                if (p == null)
+                    return -1;
+
+                // Stream the local file into ssh stdin; drain stdout/stderr to avoid pipe deadlock.
+                var stdoutTask = p.StandardOutput.ReadToEndAsync();
+                var stderrTask = p.StandardError.ReadToEndAsync();
+
+                using var fs = File.OpenRead(localFile);
+                fs.CopyTo(p.StandardInput.BaseStream);
+                p.StandardInput.Close();
+
                 p.WaitForExit();
                 Task.WaitAll(stdoutTask, stderrTask);
                 return p.ExitCode;

--- a/src/Remote/Connections.cs
+++ b/src/Remote/Connections.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Diagnostics;
 using System.IO;
+using System.Threading.Tasks;
 
 namespace SourceGit.Remote
 {
@@ -112,9 +113,13 @@ namespace SourceGit.Remote
                 if (p == null)
                     return (string.Empty, -1);
 
-                var stdout = p.StandardOutput.ReadToEnd();
+                // Drain both streams concurrently; reading only stdout can deadlock if the
+                // remote command writes enough to stderr to fill the OS pipe buffer.
+                var stdoutTask = p.StandardOutput.ReadToEndAsync();
+                var stderrTask = p.StandardError.ReadToEndAsync();
                 p.WaitForExit();
-                return (stdout, p.ExitCode);
+                Task.WaitAll(stdoutTask, stderrTask);
+                return (stdoutTask.Result, p.ExitCode);
             }
             catch
             {
@@ -146,7 +151,12 @@ namespace SourceGit.Remote
                 if (p == null)
                     return -1;
 
+                // scp writes progress to stderr; if we don't drain both pipes the process
+                // blocks once the OS buffer fills (e.g. on a ~100MB server upload).
+                var stdoutTask = p.StandardOutput.ReadToEndAsync();
+                var stderrTask = p.StandardError.ReadToEndAsync();
                 p.WaitForExit();
+                Task.WaitAll(stdoutTask, stderrTask);
                 return p.ExitCode;
             }
             catch

--- a/src/Remote/Connections.cs
+++ b/src/Remote/Connections.cs
@@ -1,0 +1,100 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+
+namespace SourceGit.Remote
+{
+    /// <summary>
+    /// A duplex stream pair to a running <c>sourcegit --remote-server</c> process.
+    /// <see cref="Input"/> reads the server's stdout; <see cref="Output"/> writes its stdin.
+    /// </summary>
+    public interface IConnection : IDisposable
+    {
+        Stream Input { get; }
+        Stream Output { get; }
+    }
+
+    /// <summary>
+    /// Connection to a server launched as a local child process (e.g.
+    /// <c>dotnet SourceGit.dll --remote-server</c>). Mainly used for testing and for a
+    /// possible "local server" mode; real remote repositories use <see cref="SshConnection"/>.
+    /// </summary>
+    public sealed class LocalProcessConnection : IConnection
+    {
+        private readonly Process _proc;
+
+        public LocalProcessConnection(string fileName, string arguments)
+        {
+            var psi = new ProcessStartInfo
+            {
+                FileName = fileName,
+                Arguments = arguments,
+                UseShellExecute = false,
+                RedirectStandardInput = true,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                CreateNoWindow = true,
+            };
+
+            _proc = Process.Start(psi)
+                ?? throw new Exception($"failed to start remote server: {fileName} {arguments}");
+
+            Input = _proc.StandardOutput.BaseStream;
+            Output = _proc.StandardInput.BaseStream;
+        }
+
+        public Stream Input { get; }
+        public Stream Output { get; }
+
+        public void Dispose()
+        {
+            try { if (!_proc.HasExited) _proc.Kill(); } catch { }
+            _proc.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// Connection to a remote server reached over SSH. Launches
+    /// <c>ssh &lt;user&gt;@&lt;host&gt; &lt;remote-sourcegit&gt; --remote-server</c> and pipes
+    /// JSON-RPC over the SSH channel's stdin/stdout. Authentication is non-interactive
+    /// (BatchMode) via an identity file or the SSH agent.
+    /// </summary>
+    public sealed class SshConnection : IConnection
+    {
+        private readonly Process _proc;
+
+        public SshConnection(string host, string user, int port, string identityFile, string remoteServerCommand)
+        {
+            var args = "-T -o BatchMode=yes -o StrictHostKeyChecking=accept-new";
+            if (port > 0)
+                args += $" -p {port}";
+            if (!string.IsNullOrEmpty(identityFile))
+                args += $" -i \"{identityFile}\"";
+
+            var target = string.IsNullOrEmpty(user) ? host : $"{user}@{host}";
+            args += $" {target} {remoteServerCommand}";
+
+            var psi = new ProcessStartInfo("ssh", args)
+            {
+                UseShellExecute = false,
+                RedirectStandardInput = true,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                CreateNoWindow = true,
+            };
+
+            _proc = Process.Start(psi) ?? throw new Exception("failed to start ssh");
+            Input = _proc.StandardOutput.BaseStream;
+            Output = _proc.StandardInput.BaseStream;
+        }
+
+        public Stream Input { get; }
+        public Stream Output { get; }
+
+        public void Dispose()
+        {
+            try { if (!_proc.HasExited) _proc.Kill(); } catch { }
+            _proc.Dispose();
+        }
+    }
+}

--- a/src/Remote/Connections.cs
+++ b/src/Remote/Connections.cs
@@ -134,48 +134,12 @@ namespace SourceGit.Remote
     /// </summary>
     public static class ScpUpload
     {
-        public static int Upload(string host, string localFile, string remotePath)
-        {
-            // Prefer scp; it is the common case and handles progress/permissions natively.
-            var scpCode = TryScp(host, localFile, remotePath);
-            if (scpCode == 0)
-                return 0;
-
-            // Fallback for minimal/container hosts where scp is not installed: stream the file
-            // over a plain ssh channel with `cat > remote`. Works everywhere ssh works.
-            return UploadViaSshCat(host, localFile, remotePath);
-        }
-
-        private static int TryScp(string host, string localFile, string remotePath)
-        {
-            var args = $"-o BatchMode=yes -o StrictHostKeyChecking=accept-new \"{localFile}\" {host}:{remotePath}";
-            var psi = new ProcessStartInfo("scp", args)
-            {
-                UseShellExecute = false,
-                RedirectStandardOutput = true,
-                RedirectStandardError = true,
-                CreateNoWindow = true,
-            };
-
-            try
-            {
-                using var p = Process.Start(psi);
-                if (p == null)
-                    return -1;
-
-                var stdoutTask = p.StandardOutput.ReadToEndAsync();
-                var stderrTask = p.StandardError.ReadToEndAsync();
-                p.WaitForExit();
-                Task.WaitAll(stdoutTask, stderrTask);
-                return p.ExitCode;
-            }
-            catch
-            {
-                return -1;
-            }
-        }
-
-        private static int UploadViaSshCat(string host, string localFile, string remotePath)
+        /// <summary>
+        /// Upload a local file to the remote host by streaming it over a plain ssh channel
+        /// (<c>cat &gt; remote</c>). This works even on hosts without <c>scp</c> and lets us
+        /// report real progress/speed to the caller.
+        /// </summary>
+        public static int Upload(string host, string localFile, string remotePath, Action<long, long> onProgress = null)
         {
             var args = $"-T -o BatchMode=yes -o StrictHostKeyChecking=accept-new {host} \"cat > {remotePath}\"";
             var psi = new ProcessStartInfo("ssh", args)
@@ -193,14 +157,23 @@ namespace SourceGit.Remote
                 if (p == null)
                     return -1;
 
-                // Stream the local file into ssh stdin; drain stdout/stderr to avoid pipe deadlock.
                 var stdoutTask = p.StandardOutput.ReadToEndAsync();
                 var stderrTask = p.StandardError.ReadToEndAsync();
 
                 using var fs = File.OpenRead(localFile);
-                fs.CopyTo(p.StandardInput.BaseStream);
-                p.StandardInput.Close();
+                var total = fs.Length;
+                long sent = 0;
+                var buf = new byte[64 * 1024];
+                int read;
 
+                while ((read = fs.Read(buf, 0, buf.Length)) > 0)
+                {
+                    p.StandardInput.BaseStream.Write(buf, 0, read);
+                    sent += read;
+                    onProgress?.Invoke(sent, total);
+                }
+
+                p.StandardInput.Close();
                 p.WaitForExit();
                 Task.WaitAll(stdoutTask, stderrTask);
                 return p.ExitCode;

--- a/src/Remote/Protocol.cs
+++ b/src/Remote/Protocol.cs
@@ -1,0 +1,59 @@
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
+
+namespace SourceGit.Remote
+{
+    /// <summary>
+    /// Wire format for the sourcegit remote server protocol.
+    /// <para>
+    /// The client launches the server with <c>ssh &lt;host&gt; sourcegit --remote-server</c>;
+    /// the SSH channel then carries one JSON-RPC message per line on stdin/stdout.
+    /// Requests carry an <c>id</c>; the server replies with a <see cref="Response"/>
+    /// bearing the same id. The server may also push <c>Notification</c>s (no id) for
+    /// events such as working-copy changes (added in a later phase).
+    /// </para>
+    /// </summary>
+    public class Request
+    {
+        [JsonPropertyName("id")] public long Id { get; set; }
+        [JsonPropertyName("method")] public string Method { get; set; }
+        [JsonPropertyName("params")] public JsonNode Params { get; set; }
+    }
+
+    public class RpcError
+    {
+        [JsonPropertyName("code")] public int Code { get; set; }
+        [JsonPropertyName("message")] public string Message { get; set; }
+    }
+
+    public class Response
+    {
+        [JsonPropertyName("id")] public long Id { get; set; }
+        [JsonPropertyName("result")] public JsonNode Result { get; set; }
+        [JsonPropertyName("error")] public RpcError Error { get; set; }
+    }
+
+    public class Notification
+    {
+        [JsonPropertyName("method")] public string Method { get; set; }
+        [JsonPropertyName("params")] public JsonNode Params { get; set; }
+    }
+
+    /// <summary>Parameters for the <c>exec_git</c> method.</summary>
+    public class ExecGitParams
+    {
+        [JsonPropertyName("args")] public string Args { get; set; }
+        [JsonPropertyName("working_dir")] public string WorkingDir { get; set; }
+        [JsonPropertyName("ssh_key")] public string SshKey { get; set; }
+        [JsonPropertyName("editor")] public string Editor { get; set; }
+        [JsonPropertyName("stdin")] public string Stdin { get; set; }
+    }
+
+    /// <summary>Result of the <c>exec_git</c> method.</summary>
+    public class ExecGitResult
+    {
+        [JsonPropertyName("stdout")] public string Stdout { get; set; }
+        [JsonPropertyName("stderr")] public string Stderr { get; set; }
+        [JsonPropertyName("exit_code")] public int ExitCode { get; set; }
+    }
+}

--- a/src/Remote/Protocol.cs
+++ b/src/Remote/Protocol.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
 
@@ -55,5 +56,19 @@ namespace SourceGit.Remote
         [JsonPropertyName("stdout")] public string Stdout { get; set; }
         [JsonPropertyName("stderr")] public string Stderr { get; set; }
         [JsonPropertyName("exit_code")] public int ExitCode { get; set; }
+    }
+
+    /// <summary>One entry returned by the <c>list_dir</c> method.</summary>
+    public class ListDirEntry
+    {
+        [JsonPropertyName("name")] public string Name { get; set; }
+        [JsonPropertyName("is_dir")] public bool IsDir { get; set; }
+    }
+
+    /// <summary>Result of the <c>list_dir</c> method.</summary>
+    public class ListDirResult
+    {
+        [JsonPropertyName("path")] public string Path { get; set; }
+        [JsonPropertyName("entries")] public List<ListDirEntry> Entries { get; set; } = new();
     }
 }

--- a/src/Remote/RemoteCommandRunner.cs
+++ b/src/Remote/RemoteCommandRunner.cs
@@ -38,9 +38,7 @@ namespace SourceGit.Remote
                 throw new NotSupportedException("RemoteCommandRunner.Start does not support stdin (handled in a later phase)");
 
             var r = ExecGit(spec);
-            var stdout = Encoding.UTF8.GetBytes(r.Stdout ?? string.Empty);
-            var stderr = Encoding.UTF8.GetBytes(r.Stderr ?? string.Empty);
-            return new RemoteCommandProcess(stdout, stderr, r.ExitCode);
+            return new RemoteCommandProcess(r.Stdout ?? string.Empty, r.Stderr ?? string.Empty, r.ExitCode);
         }
 
         public async Task<int> RunForExitCodeAsync(Command.RunSpec spec, CancellationToken ct)
@@ -99,31 +97,42 @@ namespace SourceGit.Remote
             if (result == null)
                 return new ExecGitResult();
 
-            return JsonSerializer.Deserialize<ExecGitResult>(result.ToJsonString());
+            // Pull fields directly from the JsonNode instead of round-tripping through
+            // ToJsonString()+Deserialize, which would allocate an extra large string for big
+            // git log outputs and cause GC pressure / UI jank.
+            return new ExecGitResult
+            {
+                Stdout = result["stdout"]?.GetValue<string>() ?? string.Empty,
+                Stderr = result["stderr"]?.GetValue<string>() ?? string.Empty,
+                ExitCode = result["exit_code"]?.GetValue<int>() ?? -1,
+            };
         }
 
         private sealed class RemoteCommandProcess : ICommandProcess
         {
-            private readonly byte[] _stdout;
-            private readonly byte[] _stderr;
+            private readonly string _stdout;
+            private readonly string _stderr;
             private readonly int _exitCode;
-            private StreamReader _stdoutReader;
-            private StreamReader _stderrReader;
+            private StringReader _stdoutReader;
+            private StringReader _stderrReader;
 
-            public RemoteCommandProcess(byte[] stdout, byte[] stderr, int exitCode)
+            public RemoteCommandProcess(string stdout, string stderr, int exitCode)
             {
                 _stdout = stdout;
                 _stderr = stderr;
                 _exitCode = exitCode;
             }
 
-            // Stdout/Stderr are cached so a consumer that calls ReadLineAsync in a loop sees a
-            // single continuous reader instead of a fresh reader (at position 0) each access.
-            // StdoutStream returns an independent fresh stream for callers that copy bytes.
-            public StreamReader Stdout => _stdoutReader ??= new StreamReader(new MemoryStream(_stdout, writable: false), Encoding.UTF8);
-            public Stream StdoutStream => new MemoryStream(_stdout, writable: false);
+            // Line-based callers (QueryCommits/CompareRevisions/...) read through Stdout as a
+            // TextReader. Using StringReader avoids converting the whole stdout to a byte[]
+            // and back, which was the main source of GC pressure for large git log outputs.
+            public TextReader Stdout => _stdoutReader ??= new StringReader(_stdout);
+
+            // Binary/copy callers (Diff) use StdoutStream. This is rare and the output is
+            // bounded, so allocating a byte[] here is acceptable.
+            public Stream StdoutStream => new MemoryStream(Encoding.UTF8.GetBytes(_stdout), writable: false);
             public StreamWriter Stdin => throw new NotSupportedException("remote process has no stdin via Start");
-            public StreamReader Stderr => _stderrReader ??= new StreamReader(new MemoryStream(_stderr, writable: false), Encoding.UTF8);
+            public TextReader Stderr => _stderrReader ??= new StringReader(_stderr);
             public Task WaitForExitAsync(CancellationToken ct) => Task.CompletedTask;
             public int ExitCode => _exitCode;
 

--- a/src/Remote/RemoteCommandRunner.cs
+++ b/src/Remote/RemoteCommandRunner.cs
@@ -41,8 +41,12 @@ namespace SourceGit.Remote
             // Use the streaming RPC so large outputs (git log) arrive in chunks instead of one
             // giant JSON string; the client-side process exposes a blocking stream that the
             // command parsers read line-by-line, exactly like a local git process.
+            var streamId = Guid.NewGuid().ToString();
+            var proc = new RemoteStreamProcess(_client, streamId);
+
             var parameters = new
             {
+                stream_id = streamId,
                 args = spec.Args,
                 working_dir = spec.WorkingDirectory,
                 ssh_key = spec.SSHKey,
@@ -50,12 +54,9 @@ namespace SourceGit.Remote
                 stdin = spec.StdinContent,
             };
 
-            var result = _client.Call("exec_git_stream", parameters);
-            var streamId = result?["stream_id"]?.GetValue<string>();
-            if (string.IsNullOrEmpty(streamId))
-                throw new Exception("remote server did not return a stream id");
-
-            return new RemoteStreamProcess(_client, streamId);
+            // The handler is already registered before the call, so no data chunks are lost.
+            _client.Call("exec_git_stream", parameters);
+            return proc;
         }
 
         public async Task<int> RunForExitCodeAsync(Command.RunSpec spec, CancellationToken ct)

--- a/src/Remote/RemoteCommandRunner.cs
+++ b/src/Remote/RemoteCommandRunner.cs
@@ -38,8 +38,8 @@ namespace SourceGit.Remote
                 throw new NotSupportedException("RemoteCommandRunner.Start does not support stdin (handled in a later phase)");
 
             var r = ExecGit(spec);
-            var stdout = new MemoryStream(Encoding.UTF8.GetBytes(r.Stdout ?? string.Empty), writable: false);
-            var stderr = new MemoryStream(Encoding.UTF8.GetBytes(r.Stderr ?? string.Empty), writable: false);
+            var stdout = Encoding.UTF8.GetBytes(r.Stdout ?? string.Empty);
+            var stderr = Encoding.UTF8.GetBytes(r.Stderr ?? string.Empty);
             return new RemoteCommandProcess(stdout, stderr, r.ExitCode);
         }
 
@@ -104,28 +104,33 @@ namespace SourceGit.Remote
 
         private sealed class RemoteCommandProcess : ICommandProcess
         {
-            private readonly MemoryStream _stdout;
-            private readonly MemoryStream _stderr;
+            private readonly byte[] _stdout;
+            private readonly byte[] _stderr;
             private readonly int _exitCode;
+            private StreamReader _stdoutReader;
+            private StreamReader _stderrReader;
 
-            public RemoteCommandProcess(MemoryStream stdout, MemoryStream stderr, int exitCode)
+            public RemoteCommandProcess(byte[] stdout, byte[] stderr, int exitCode)
             {
                 _stdout = stdout;
                 _stderr = stderr;
                 _exitCode = exitCode;
             }
 
-            public StreamReader Stdout => new StreamReader(_stdout, Encoding.UTF8, leaveOpen: true);
-            public Stream StdoutStream => _stdout;
+            // Stdout/Stderr are cached so a consumer that calls ReadLineAsync in a loop sees a
+            // single continuous reader instead of a fresh reader (at position 0) each access.
+            // StdoutStream returns an independent fresh stream for callers that copy bytes.
+            public StreamReader Stdout => _stdoutReader ??= new StreamReader(new MemoryStream(_stdout, writable: false), Encoding.UTF8);
+            public Stream StdoutStream => new MemoryStream(_stdout, writable: false);
             public StreamWriter Stdin => throw new NotSupportedException("remote process has no stdin via Start");
-            public StreamReader Stderr => new StreamReader(_stderr, Encoding.UTF8, leaveOpen: true);
+            public StreamReader Stderr => _stderrReader ??= new StreamReader(new MemoryStream(_stderr, writable: false), Encoding.UTF8);
             public Task WaitForExitAsync(CancellationToken ct) => Task.CompletedTask;
             public int ExitCode => _exitCode;
 
             public void Dispose()
             {
-                _stdout.Dispose();
-                _stderr.Dispose();
+                _stdoutReader?.Dispose();
+                _stderrReader?.Dispose();
             }
         }
     }

--- a/src/Remote/RemoteCommandRunner.cs
+++ b/src/Remote/RemoteCommandRunner.cs
@@ -1,7 +1,8 @@
 using System;
+using System.Collections.Concurrent;
 using System.IO;
 using System.Text;
-using System.Text.Json;
+using System.Text.Json.Nodes;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -37,8 +38,24 @@ namespace SourceGit.Remote
             if (spec.RedirectStandardInput)
                 throw new NotSupportedException("RemoteCommandRunner.Start does not support stdin (handled in a later phase)");
 
-            var r = ExecGit(spec);
-            return new RemoteCommandProcess(r.Stdout ?? string.Empty, r.Stderr ?? string.Empty, r.ExitCode);
+            // Use the streaming RPC so large outputs (git log) arrive in chunks instead of one
+            // giant JSON string; the client-side process exposes a blocking stream that the
+            // command parsers read line-by-line, exactly like a local git process.
+            var parameters = new
+            {
+                args = spec.Args,
+                working_dir = spec.WorkingDirectory,
+                ssh_key = spec.SSHKey,
+                editor = spec.Editor.ToString(),
+                stdin = spec.StdinContent,
+            };
+
+            var result = _client.Call("exec_git_stream", parameters);
+            var streamId = result?["stream_id"]?.GetValue<string>();
+            if (string.IsNullOrEmpty(streamId))
+                throw new Exception("remote server did not return a stream id");
+
+            return new RemoteStreamProcess(_client, streamId);
         }
 
         public async Task<int> RunForExitCodeAsync(Command.RunSpec spec, CancellationToken ct)
@@ -108,39 +125,115 @@ namespace SourceGit.Remote
             };
         }
 
-        private sealed class RemoteCommandProcess : ICommandProcess
+        private sealed class RemoteStreamProcess : ICommandProcess
         {
-            private readonly string _stdout;
-            private readonly string _stderr;
-            private readonly int _exitCode;
-            private StringReader _stdoutReader;
+            private readonly RpcClient _client;
+            private readonly string _streamId;
+            private readonly BlockingCollection<byte[]> _blocks = new();
+            private readonly BlockingStream _stream;
+            private readonly TaskCompletionSource _done = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            private StreamReader _stdoutReader;
             private StringReader _stderrReader;
+            private int _exitCode = -1;
+            private string _stderr = string.Empty;
 
-            public RemoteCommandProcess(string stdout, string stderr, int exitCode)
+            public RemoteStreamProcess(RpcClient client, string streamId)
             {
-                _stdout = stdout;
-                _stderr = stderr;
-                _exitCode = exitCode;
+                _client = client;
+                _streamId = streamId;
+                _stream = new BlockingStream(_blocks);
+
+                _client.RegisterStreamHandler(streamId, OnStreamNotification);
             }
 
-            // Line-based callers (QueryCommits/CompareRevisions/...) read through Stdout as a
-            // TextReader. Using StringReader avoids converting the whole stdout to a byte[]
-            // and back, which was the main source of GC pressure for large git log outputs.
-            public TextReader Stdout => _stdoutReader ??= new StringReader(_stdout);
+            private void OnStreamNotification(string method, JsonNode pars)
+            {
+                if (method == "exec_git_stream_data")
+                {
+                    var data = pars?["data"]?.GetValue<string>();
+                    if (!string.IsNullOrEmpty(data))
+                    {
+                        try { _blocks.Add(Convert.FromBase64String(data)); }
+                        catch { /* ignore bad chunk */ }
+                    }
+                }
+                else if (method == "exec_git_stream_done")
+                {
+                    _exitCode = pars?["exit_code"]?.GetValue<int>() ?? -1;
+                    _stderr = pars?["stderr"]?.GetValue<string>() ?? string.Empty;
+                    _blocks.CompleteAdding();
+                    _done.TrySetResult();
+                }
+            }
 
-            // Binary/copy callers (Diff) use StdoutStream. This is rare and the output is
-            // bounded, so allocating a byte[] here is acceptable.
-            public Stream StdoutStream => new MemoryStream(Encoding.UTF8.GetBytes(_stdout), writable: false);
+            public TextReader Stdout => _stdoutReader ??= new StreamReader(_stream, Encoding.UTF8, leaveOpen: true);
+            public Stream StdoutStream => _stream;
             public StreamWriter Stdin => throw new NotSupportedException("remote process has no stdin via Start");
             public TextReader Stderr => _stderrReader ??= new StringReader(_stderr);
-            public Task WaitForExitAsync(CancellationToken ct) => Task.CompletedTask;
+            public Task WaitForExitAsync(CancellationToken ct) => _done.Task;
             public int ExitCode => _exitCode;
 
             public void Dispose()
             {
+                _client.UnregisterStreamHandler(_streamId);
+                _blocks.CompleteAdding();
                 _stdoutReader?.Dispose();
                 _stderrReader?.Dispose();
+                _stream.Dispose();
             }
+        }
+
+        /// <summary>
+        /// A read-only stream backed by a <see cref="BlockingCollection{Byte}"/> of chunks.
+        /// <see cref="Read"/> blocks until at least one byte is available or the collection is
+        /// completed. This lets a <see cref="StreamReader"/> read lines incrementally from a
+        /// remote streaming RPC, matching local process stdout behavior.
+        /// </summary>
+        private sealed class BlockingStream : Stream
+        {
+            private readonly BlockingCollection<byte[]> _blocks;
+            private byte[] _current = Array.Empty<byte>();
+            private int _pos = 0;
+
+            public BlockingStream(BlockingCollection<byte[]> blocks)
+            {
+                _blocks = blocks;
+            }
+
+            public override bool CanRead => true;
+            public override bool CanSeek => false;
+            public override bool CanWrite => false;
+            public override long Length => throw new NotSupportedException();
+            public override long Position { get => throw new NotSupportedException(); set => throw new NotSupportedException(); }
+
+            public override int Read(byte[] buffer, int offset, int count)
+            {
+                int written = 0;
+                while (written < count)
+                {
+                    if (_pos >= _current.Length)
+                    {
+                        if (!_blocks.TryTake(out _current, Timeout.Infinite))
+                        {
+                            // Collection completed and empty.
+                            break;
+                        }
+                        _pos = 0;
+                    }
+
+                    var n = Math.Min(count - written, _current.Length - _pos);
+                    Array.Copy(_current, _pos, buffer, offset + written, n);
+                    _pos += n;
+                    written += n;
+                }
+
+                return written;
+            }
+
+            public override void Flush() { }
+            public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+            public override void SetLength(long value) => throw new NotSupportedException();
+            public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
         }
     }
 }

--- a/src/Remote/RemoteCommandRunner.cs
+++ b/src/Remote/RemoteCommandRunner.cs
@@ -51,7 +51,7 @@ namespace SourceGit.Remote
 
         public void StartDetached(Command.RunSpec spec)
         {
-            throw new NotSupportedException("Remote detached start is not supported (difftool must run locally)");
+            throw new NotSupportedException("External diff/merge tools are not supported for remote repositories");
         }
 
         public Command.Result ReadToEnd(Command.RunSpec spec)

--- a/src/Remote/RemoteCommandRunner.cs
+++ b/src/Remote/RemoteCommandRunner.cs
@@ -1,0 +1,131 @@
+using System;
+using System.IO;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+using SourceGit.Commands;
+
+namespace SourceGit.Remote
+{
+    /// <summary>
+    /// <see cref="ICommandRunner"/> that forwards git execution to a remote
+    /// <c>sourcegit --remote-server</c> via <see cref="RpcClient"/>.
+    /// <para>
+    /// Because the RPC <c>exec_git</c> method returns the full stdout/stderr in one shot,
+    /// streaming reads (<see cref="Start"/>) are emulated by buffering the output into a
+    /// <see cref="MemoryStream"/>. This is fine for read-only queries (log/status/show/branch)
+    /// whose output is bounded; a streaming RPC variant can be added later if needed.
+    /// </para>
+    /// <para>
+    /// Stdin-driven commands (pathspec/patch/LFS smudge) and detached launch (difftool) are
+    /// not supported here yet — they are handled in later phases.
+    /// </para>
+    /// </summary>
+    public sealed class RemoteCommandRunner : ICommandRunner
+    {
+        private readonly RpcClient _client;
+
+        public RemoteCommandRunner(RpcClient client)
+        {
+            _client = client;
+        }
+
+        public ICommandProcess Start(Command.RunSpec spec)
+        {
+            if (spec.RedirectStandardInput)
+                throw new NotSupportedException("RemoteCommandRunner.Start does not support stdin (handled in a later phase)");
+
+            var r = ExecGit(spec);
+            var stdout = new MemoryStream(Encoding.UTF8.GetBytes(r.Stdout ?? string.Empty), writable: false);
+            var stderr = new MemoryStream(Encoding.UTF8.GetBytes(r.Stderr ?? string.Empty), writable: false);
+            return new RemoteCommandProcess(stdout, stderr, r.ExitCode);
+        }
+
+        public async Task<int> RunForExitCodeAsync(Command.RunSpec spec, CancellationToken ct)
+        {
+            var r = await Task.Run(() => ExecGit(spec)).ConfigureAwait(false);
+            return r.ExitCode;
+        }
+
+        public void StartDetached(Command.RunSpec spec)
+        {
+            throw new NotSupportedException("Remote detached start is not supported (difftool must run locally)");
+        }
+
+        public Command.Result ReadToEnd(Command.RunSpec spec)
+        {
+            var r = ExecGit(spec);
+            return new Command.Result { IsSuccess = r.ExitCode == 0, StdOut = r.Stdout, StdErr = r.Stderr };
+        }
+
+        public async Task<Command.Result> ReadToEndAsync(Command.RunSpec spec, CancellationToken ct)
+        {
+            var r = await Task.Run(() => ExecGit(spec)).ConfigureAwait(false);
+            return new Command.Result { IsSuccess = r.ExitCode == 0, StdOut = r.Stdout, StdErr = r.Stderr };
+        }
+
+        public async Task<bool> ExecAsync(Command.RunSpec spec, Action<string> onOutput, CancellationToken ct)
+        {
+            var r = await Task.Run(() => ExecGit(spec)).ConfigureAwait(false);
+            EmitLines(r.Stdout, onOutput);
+            EmitLines(r.Stderr, onOutput);
+            return r.ExitCode == 0;
+        }
+
+        private static void EmitLines(string text, Action<string> onOutput)
+        {
+            if (string.IsNullOrEmpty(text))
+                return;
+
+            using var reader = new StringReader(text);
+            while (reader.ReadLine() is { } line)
+                onOutput(line);
+        }
+
+        private ExecGitResult ExecGit(Command.RunSpec spec)
+        {
+            var parameters = new
+            {
+                args = spec.Args,
+                working_dir = spec.WorkingDirectory,
+                ssh_key = spec.SSHKey,
+                editor = spec.Editor.ToString(),
+            };
+
+            var result = _client.Call("exec_git", parameters);
+            if (result == null)
+                return new ExecGitResult();
+
+            return JsonSerializer.Deserialize<ExecGitResult>(result.ToJsonString());
+        }
+
+        private sealed class RemoteCommandProcess : ICommandProcess
+        {
+            private readonly MemoryStream _stdout;
+            private readonly MemoryStream _stderr;
+            private readonly int _exitCode;
+
+            public RemoteCommandProcess(MemoryStream stdout, MemoryStream stderr, int exitCode)
+            {
+                _stdout = stdout;
+                _stderr = stderr;
+                _exitCode = exitCode;
+            }
+
+            public StreamReader Stdout => new StreamReader(_stdout, Encoding.UTF8, leaveOpen: true);
+            public Stream StdoutStream => _stdout;
+            public StreamWriter Stdin => throw new NotSupportedException("remote process has no stdin via Start");
+            public StreamReader Stderr => new StreamReader(_stderr, Encoding.UTF8, leaveOpen: true);
+            public Task WaitForExitAsync(CancellationToken ct) => Task.CompletedTask;
+            public int ExitCode => _exitCode;
+
+            public void Dispose()
+            {
+                _stdout.Dispose();
+                _stderr.Dispose();
+            }
+        }
+    }
+}

--- a/src/Remote/RemoteCommandRunner.cs
+++ b/src/Remote/RemoteCommandRunner.cs
@@ -55,7 +55,16 @@ namespace SourceGit.Remote
             };
 
             // The handler is already registered before the call, so no data chunks are lost.
-            _client.Call("exec_git_stream", parameters);
+            try
+            {
+                _client.Call("exec_git_stream", parameters);
+            }
+            catch
+            {
+                // Connection broken — complete the process with an error so callers get an
+                // empty failed result instead of hanging or throwing.
+                proc.CompleteWithError("Remote connection lost");
+            }
             return proc;
         }
 
@@ -111,19 +120,27 @@ namespace SourceGit.Remote
                 stdin = spec.StdinContent,
             };
 
-            var result = _client.Call("exec_git", parameters);
-            if (result == null)
-                return new ExecGitResult();
-
-            // Pull fields directly from the JsonNode instead of round-tripping through
-            // ToJsonString()+Deserialize, which would allocate an extra large string for big
-            // git log outputs and cause GC pressure / UI jank.
-            return new ExecGitResult
+            try
             {
-                Stdout = result["stdout"]?.GetValue<string>() ?? string.Empty,
-                Stderr = result["stderr"]?.GetValue<string>() ?? string.Empty,
-                ExitCode = result["exit_code"]?.GetValue<int>() ?? -1,
-            };
+                var result = _client.Call("exec_git", parameters);
+                if (result == null)
+                    return new ExecGitResult();
+
+                return new ExecGitResult
+                {
+                    Stdout = result["stdout"]?.GetValue<string>() ?? string.Empty,
+                    Stderr = result["stderr"]?.GetValue<string>() ?? string.Empty,
+                    ExitCode = result["exit_code"]?.GetValue<int>() ?? -1,
+                };
+            }
+            catch
+            {
+                // Connection broken (pipe broken / server died). Return an empty failed result
+                // instead of throwing — callers like QueryCommits have their own try-catch that
+                // will surface a notification, and this prevents an unhandled exception from
+                // crashing the app.
+                return new ExecGitResult { ExitCode = -1, Stderr = "Remote connection lost" };
+            }
         }
 
         private sealed class RemoteStreamProcess : ICommandProcess
@@ -170,6 +187,15 @@ namespace SourceGit.Remote
             public TextReader Stdout => _stdoutReader ??= new StreamReader(_stream, Encoding.UTF8, leaveOpen: true);
             public Stream StdoutStream => _stream;
             public StreamWriter Stdin => throw new NotSupportedException("remote process has no stdin via Start");
+
+            /// <summary>Force-complete the process with an error (used when the call itself throws).</summary>
+            public void CompleteWithError(string stderr)
+            {
+                _stderr = stderr;
+                _exitCode = -1;
+                _blocks.CompleteAdding();
+                _done.TrySetResult();
+            }
             public TextReader Stderr => _stderrReader ??= new StringReader(_stderr);
             public Task WaitForExitAsync(CancellationToken ct) => _done.Task;
             public int ExitCode => _exitCode;

--- a/src/Remote/RemoteCommandRunner.cs
+++ b/src/Remote/RemoteCommandRunner.cs
@@ -216,7 +216,10 @@ namespace SourceGit.Remote
                     {
                         if (!_blocks.TryTake(out _current, Timeout.Infinite))
                         {
-                            // Collection completed and empty.
+                            // Collection completed and empty. Reset _current so a subsequent
+                            // Read call doesn't NRE on a null _current.
+                            _current = Array.Empty<byte>();
+                            _pos = 0;
                             break;
                         }
                         _pos = 0;

--- a/src/Remote/RemoteCommandRunner.cs
+++ b/src/Remote/RemoteCommandRunner.cs
@@ -92,6 +92,7 @@ namespace SourceGit.Remote
                 working_dir = spec.WorkingDirectory,
                 ssh_key = spec.SSHKey,
                 editor = spec.Editor.ToString(),
+                stdin = spec.StdinContent,
             };
 
             var result = _client.Call("exec_git", parameters);

--- a/src/Remote/RemoteFileSystem.cs
+++ b/src/Remote/RemoteFileSystem.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+
+using SourceGit.Models;
+
+namespace SourceGit.Remote
+{
+    /// <summary>
+    /// <see cref="IFileSystem"/> implementation that routes file operations to a remote
+    /// <c>sourcegit --remote-server</c> via <see cref="RpcClient"/>. The server runs on the
+    /// host where the repository lives, so these calls act on the real working tree and
+    /// <c>.git</c> internals.
+    /// <para>
+    /// Text-oriented operations are implemented now. Binary streaming (<see cref="OpenRead"/>/
+    /// <see cref="Create"/>) will follow once the protocol gains a chunked transfer; for now
+    /// <see cref="OpenRead"/> is text-based (sufficient for source files) and
+    /// <see cref="Create"/> throws.
+    /// </para>
+    /// </summary>
+    public sealed class RemoteFileSystem : IFileSystem, IDisposable
+    {
+        private readonly RpcClient _client;
+
+        public RemoteFileSystem(RpcClient client)
+        {
+            _client = client;
+        }
+
+        public bool FileExists(string path) => (bool)_client.Call("file_exists", new { path });
+        public bool DirectoryExists(string path) => (bool)_client.Call("dir_exists", new { path });
+
+        public string ReadAllText(string path) => (string)_client.Call("read_file", new { path })["content"];
+        public Task<string> ReadAllTextAsync(string path) => Task.FromResult(ReadAllText(path));
+
+        public void WriteAllText(string path, string content) => _client.Call("write_file", new { path, content });
+        public Task WriteAllTextAsync(string path, string content)
+        {
+            WriteAllText(path, content);
+            return Task.CompletedTask;
+        }
+
+        public async Task WriteAllLinesAsync(string path, IEnumerable<string> lines)
+        {
+            await WriteAllTextAsync(path, string.Join("\n", lines)).ConfigureAwait(false);
+        }
+
+        public void DeleteFile(string path) => _client.Call("delete_file", new { path });
+        public void DeleteDirectory(string path, bool recursive) => _client.Call("delete_dir", new { path, recursive });
+
+        public Stream OpenRead(string path)
+        {
+            // Text-based for now; binary chunked transfer is a later-phase addition.
+            var content = ReadAllText(path);
+            return new MemoryStream(Encoding.UTF8.GetBytes(content));
+        }
+
+        public Stream Create(string path) => throw new NotSupportedException("RemoteFileSystem.Create stream is not supported yet (later phase)");
+
+        public string CreateTempFile(string content) => (string)_client.Call("get_temp_file", new { content })["path"];
+
+        public void Dispose()
+        {
+            // The client/connection is owned by the caller (shared with RemoteCommandRunner).
+        }
+    }
+}

--- a/src/Remote/RemoteFileSystem.cs
+++ b/src/Remote/RemoteFileSystem.cs
@@ -14,10 +14,9 @@ namespace SourceGit.Remote
     /// host where the repository lives, so these calls act on the real working tree and
     /// <c>.git</c> internals.
     /// <para>
-    /// Text-oriented operations are implemented now. Binary streaming (<see cref="OpenRead"/>/
-    /// <see cref="Create"/>) will follow once the protocol gains a chunked transfer; for now
-    /// <see cref="OpenRead"/> is text-based (sufficient for source files) and
-    /// <see cref="Create"/> throws.
+    /// Text operations use the <c>read_file</c>/<c>write_file</c> RPCs; <see cref="OpenRead"/>
+    /// uses <c>read_file_base64</c> and spills to a local temp file so binary files (images,
+    /// blobs) are handled correctly. <see cref="Create"/> is still not supported remotely.
     /// </para>
     /// </summary>
     public sealed class RemoteFileSystem : IFileSystem, IDisposable
@@ -52,9 +51,15 @@ namespace SourceGit.Remote
 
         public Stream OpenRead(string path)
         {
-            // Text-based for now; binary chunked transfer is a later-phase addition.
-            var content = ReadAllText(path);
-            return new MemoryStream(Encoding.UTF8.GetBytes(content));
+            // Fetch the file as base64 so binary files (images, etc.) are not corrupted, then
+            // spill to a local temp file and return a stream that deletes it on close. The
+            // whole file is buffered in memory during transfer, which is fine for the image
+            // previews / blob views that are the typical binary use case here.
+            var b64 = (string)_client.Call("read_file_base64", new { path })["content"];
+            var bytes = Convert.FromBase64String(b64);
+            var tmp = Path.GetTempFileName();
+            File.WriteAllBytes(tmp, bytes);
+            return new FileStream(tmp, FileMode.Open, FileAccess.Read, FileShare.Read, 4096, FileOptions.DeleteOnClose);
         }
 
         public Stream Create(string path) => throw new NotSupportedException("RemoteFileSystem.Create stream is not supported yet (later phase)");

--- a/src/Remote/RemoteHostManager.cs
+++ b/src/Remote/RemoteHostManager.cs
@@ -27,6 +27,7 @@ namespace SourceGit.Remote
                 return;
 
             var wasConnected = host.IsConnected;
+            Dispatcher.UIThread.Post(() => host.StatusLog.Clear());
             SetState(host, Models.RemoteHostState.Testing, "Testing...");
 
             var session = GetOrCreate(host);
@@ -60,10 +61,10 @@ namespace SourceGit.Remote
             if (host.IsConnected && !forceRedeploy)
                 return true;
 
-            SetState(host, Models.RemoteHostState.Connecting, forceRedeploy ? "Re-deploying..." : "Connecting...");
-
-            // Start a fresh log for this attempt.
+            // Start a fresh log for this attempt. Clear before SetState so the state line is
+            // the first entry, not wiped by a later clear.
             Dispatcher.UIThread.Post(() => host.StatusLog.Clear());
+            SetState(host, Models.RemoteHostState.Connecting, forceRedeploy ? "Re-deploying..." : "Connecting...");
 
             var session = GetOrCreate(host);
             try

--- a/src/Remote/RemoteHostManager.cs
+++ b/src/Remote/RemoteHostManager.cs
@@ -4,6 +4,8 @@ using System.Threading.Tasks;
 
 using Avalonia.Threading;
 
+using SourceGit.ViewModels;
+
 namespace SourceGit.Remote
 {
     /// <summary>
@@ -107,11 +109,89 @@ namespace SourceGit.Remote
             SetState(host, Models.RemoteHostState.Disconnected, string.Empty);
         }
 
-        /// <summary>Reset a host: force a fresh deploy and reconnect.</summary>
-        public Task<bool> ResetAsync(Models.RemoteHost host)
+        /// <summary>
+        /// Reset a host: force a fresh deploy and reconnect. Instead of closing repository tabs,
+        /// they are put into a loading state and re-opened on the new connection so the user
+        /// doesn't lose their tab layout.
+        /// </summary>
+        public async Task<bool> ResetAsync(Models.RemoteHost host)
         {
-            CloseTabsForHost(host?.Host);
-            return ConnectAsync(host, forceRedeploy: true);
+            if (host == null)
+                return false;
+
+            var hostKey = Key(host.Host);
+            var pages = new List<LauncherPage>();
+
+            Dispatcher.UIThread.Invoke(() =>
+            {
+                var launcher = App.GetLauncher();
+                if (launcher == null)
+                    return;
+
+                foreach (var page in launcher.Pages)
+                {
+                    if (page.Node is { IsRemote: true, RemoteHost: { } rh } && Key(rh.Host) == hostKey)
+                        pages.Add(page);
+                }
+            });
+
+            // Put tabs into loading state instead of closing them.
+            Dispatcher.UIThread.Post(() =>
+            {
+                foreach (var page in pages)
+                {
+                    if (page.Data is Repository repo)
+                    {
+                        repo.Close();
+                        var hostDisplay = page.Node.RemoteHost?.Name ?? page.Node.RemoteHost?.Host ?? "";
+                        page.Data = new LoadingRemoteRepository
+                        {
+                            Host = hostDisplay,
+                            Path = page.Node.Id,
+                            Message = $"Reconnecting to {hostDisplay}...",
+                        };
+                    }
+                }
+            });
+
+            var connected = await ConnectAsync(host, forceRedeploy: true).ConfigureAwait(false);
+
+            if (connected)
+            {
+                Dispatcher.UIThread.Post(() =>
+                {
+                    var launcher = App.GetLauncher();
+                    if (launcher == null)
+                        return;
+
+                    foreach (var page in pages)
+                    {
+                        if (page.Data is LoadingRemoteRepository)
+                            launcher.OpenRepositoryInTab(page.Node, page);
+                    }
+                });
+            }
+            else
+            {
+                Dispatcher.UIThread.Post(() =>
+                {
+                    foreach (var page in pages)
+                    {
+                        if (page.Data is LoadingRemoteRepository)
+                        {
+                            page.Notifications.Add(new Models.Notification
+                            {
+                                Group = page.Node.Id,
+                                Message = $"Reconnect failed: {host.StatusMessage}",
+                                IsError = true,
+                            });
+                            page.Data = Welcome.Instance;
+                        }
+                    }
+                });
+            }
+
+            return connected;
         }
 
         /// <summary>

--- a/src/Remote/RemoteHostManager.cs
+++ b/src/Remote/RemoteHostManager.cs
@@ -40,7 +40,7 @@ namespace SourceGit.Remote
                 return; // a connect finished while testing; don't clobber it
 
             SetState(host, ok ? Models.RemoteHostState.Disconnected : Models.RemoteHostState.Failed,
-                ok ? "SSH reachable — click Connect to use" : message);
+                ok ? $"SSH reachable · latency {message}" : message);
         }
 
         /// <summary>

--- a/src/Remote/RemoteHostManager.cs
+++ b/src/Remote/RemoteHostManager.cs
@@ -20,24 +20,29 @@ namespace SourceGit.Remote
     {
         public static RemoteHostManager Instance { get; } = new();
 
-        /// <summary>Probe connectivity without deploying or launching the server.</summary>
+        /// <summary>Probe connectivity (and latency) without deploying or launching the server.</summary>
         public async Task TestAsync(Models.RemoteHost host)
         {
             if (host == null || host.IsBusy)
                 return;
 
-            // Testing a connected host would briefly clobber the green state and could leave it
-            // stuck gray; skip instead — the connection is already known to be alive.
-            if (host.IsConnected)
-                return;
-
+            var wasConnected = host.IsConnected;
             SetState(host, Models.RemoteHostState.Testing, "Testing...");
 
             var session = GetOrCreate(host);
             var (ok, message) = await Task.Run(session.Test).ConfigureAwait(false);
 
-            if (host.State == Models.RemoteHostState.Connected)
-                return; // a connect finished while testing; don't clobber it
+            // A connect/reset finished while we were testing; don't clobber it.
+            if (host.State == Models.RemoteHostState.Connected && !wasConnected)
+                return;
+
+            if (wasConnected)
+            {
+                // Preserve the green state, just surface the latency/ failure on top of it.
+                SetState(host, Models.RemoteHostState.Connected,
+                    ok ? $"Connected · latency {message}" : $"Connected (test failed: {message})");
+                return;
+            }
 
             SetState(host, ok ? Models.RemoteHostState.Disconnected : Models.RemoteHostState.Failed,
                 ok ? $"SSH reachable · latency {message}" : message);

--- a/src/Remote/RemoteHostManager.cs
+++ b/src/Remote/RemoteHostManager.cs
@@ -213,6 +213,24 @@ namespace SourceGit.Remote
         }
 
         /// <summary>
+        /// Called by <see cref="RemoteHostSession"/> when the RPC client detects the SSH channel
+        /// / server process has died. Updates the host state so the UI no longer shows green.
+        /// </summary>
+        public void MarkConnectionLost(Models.RemoteHost host)
+        {
+            if (host == null)
+                return;
+
+            lock (_sessions)
+            {
+                if (_sessions.TryGetValue(Key(host.Host), out var session))
+                    session.Disconnect();
+            }
+
+            SetState(host, Models.RemoteHostState.Failed, "Connection lost");
+        }
+
+        /// <summary>
         /// Return the connected session for a host, or <c>null</c> when the host is not
         /// currently connected. Used by the repository opener and the remote folder picker so
         /// they only ever work over an already-established connection.

--- a/src/Remote/RemoteHostManager.cs
+++ b/src/Remote/RemoteHostManager.cs
@@ -98,8 +98,11 @@ namespace SourceGit.Remote
 
             CloseTabsForHost(host.Host);
 
-            if (_sessions.TryGetValue(Key(host.Host), out var session))
-                session.Disconnect();
+            lock (_sessions)
+            {
+                if (_sessions.TryGetValue(Key(host.Host), out var session))
+                    session.Disconnect();
+            }
 
             SetState(host, Models.RemoteHostState.Disconnected, string.Empty);
         }
@@ -121,7 +124,8 @@ namespace SourceGit.Remote
             if (host == null || string.IsNullOrEmpty(host.Host))
                 return null;
 
-            return _sessions.TryGetValue(Key(host.Host), out var session) && session.IsConnected ? session : null;
+            lock (_sessions)
+                return _sessions.TryGetValue(Key(host.Host), out var session) && session.IsConnected ? session : null;
         }
 
         public RemoteHostSession GetConnectedSession(string host)
@@ -129,19 +133,23 @@ namespace SourceGit.Remote
             if (string.IsNullOrEmpty(host))
                 return null;
 
-            return _sessions.TryGetValue(Key(host), out var session) && session.IsConnected ? session : null;
+            lock (_sessions)
+                return _sessions.TryGetValue(Key(host), out var session) && session.IsConnected ? session : null;
         }
 
         private RemoteHostSession GetOrCreate(Models.RemoteHost host)
         {
             var key = Key(host.Host);
-            if (!_sessions.TryGetValue(key, out var session))
+            lock (_sessions)
             {
-                session = new RemoteHostSession(host);
-                _sessions[key] = session;
-            }
+                if (!_sessions.TryGetValue(key, out var session))
+                {
+                    session = new RemoteHostSession(host);
+                    _sessions[key] = session;
+                }
 
-            return session;
+                return session;
+            }
         }
 
         private void CloseTabsForHost(string host)

--- a/src/Remote/RemoteHostManager.cs
+++ b/src/Remote/RemoteHostManager.cs
@@ -26,6 +26,11 @@ namespace SourceGit.Remote
             if (host == null || host.IsBusy)
                 return;
 
+            // Testing a connected host would briefly clobber the green state and could leave it
+            // stuck gray; skip instead — the connection is already known to be alive.
+            if (host.IsConnected)
+                return;
+
             SetState(host, Models.RemoteHostState.Testing, "Testing...");
 
             var session = GetOrCreate(host);
@@ -51,6 +56,9 @@ namespace SourceGit.Remote
                 return true;
 
             SetState(host, Models.RemoteHostState.Connecting, forceRedeploy ? "Re-deploying..." : "Connecting...");
+
+            // Start a fresh log for this attempt.
+            Dispatcher.UIThread.Post(() => host.StatusLog.Clear());
 
             var session = GetOrCreate(host);
             try
@@ -160,7 +168,18 @@ namespace SourceGit.Remote
             {
                 host.State = state;
                 host.StatusMessage = message;
+                if (!string.IsNullOrEmpty(message))
+                    host.StatusLog.Add($"{DateTime.Now:HH:mm:ss}  {message}");
             });
+        }
+
+        /// <summary>Append a progress line to the host's scrolling log (used during deploy).</summary>
+        public void AppendLog(Models.RemoteHost host, string message)
+        {
+            if (host == null || string.IsNullOrEmpty(message))
+                return;
+
+            Dispatcher.UIThread.Post(() => host.StatusLog.Add($"{DateTime.Now:HH:mm:ss}  {message}"));
         }
 
         private static string Key(string host) => (host ?? string.Empty).Trim();

--- a/src/Remote/RemoteHostManager.cs
+++ b/src/Remote/RemoteHostManager.cs
@@ -34,7 +34,8 @@ namespace SourceGit.Remote
             if (host.State == Models.RemoteHostState.Connected)
                 return; // a connect finished while testing; don't clobber it
 
-            SetState(host, ok ? Models.RemoteHostState.Disconnected : Models.RemoteHostState.Failed, message);
+            SetState(host, ok ? Models.RemoteHostState.Disconnected : Models.RemoteHostState.Failed,
+                ok ? "SSH reachable — click Connect to use" : message);
         }
 
         /// <summary>

--- a/src/Remote/RemoteHostManager.cs
+++ b/src/Remote/RemoteHostManager.cs
@@ -27,7 +27,7 @@ namespace SourceGit.Remote
                 return;
 
             var wasConnected = host.IsConnected;
-            Dispatcher.UIThread.Post(() => host.StatusLog.Clear());
+            Dispatcher.UIThread.Post(() => { host.StatusLog.Clear(); host.StatusLogText = string.Empty; });
             SetState(host, Models.RemoteHostState.Testing, "Testing...");
 
             var session = GetOrCreate(host);
@@ -63,7 +63,7 @@ namespace SourceGit.Remote
 
             // Start a fresh log for this attempt. Clear before SetState so the state line is
             // the first entry, not wiped by a later clear.
-            Dispatcher.UIThread.Post(() => host.StatusLog.Clear());
+            Dispatcher.UIThread.Post(() => { host.StatusLog.Clear(); host.StatusLogText = string.Empty; });
             SetState(host, Models.RemoteHostState.Connecting, forceRedeploy ? "Re-deploying..." : "Connecting...");
 
             var session = GetOrCreate(host);
@@ -175,7 +175,10 @@ namespace SourceGit.Remote
                 host.State = state;
                 host.StatusMessage = message;
                 if (!string.IsNullOrEmpty(message))
+                {
                     host.StatusLog.Add($"{DateTime.Now:HH:mm:ss}  {message}");
+                    host.StatusLogText = string.Join("\n", host.StatusLog);
+                }
             });
         }
 
@@ -185,7 +188,24 @@ namespace SourceGit.Remote
             if (host == null || string.IsNullOrEmpty(message))
                 return;
 
-            Dispatcher.UIThread.Post(() => host.StatusLog.Add($"{DateTime.Now:HH:mm:ss}  {message}"));
+            Dispatcher.UIThread.Post(() =>
+            {
+                host.StatusLog.Add($"{DateTime.Now:HH:mm:ss}  {message}");
+                host.StatusLogText = string.Join("\n", host.StatusLog);
+            });
+        }
+
+        /// <summary>Clear the scrolling log (called when the settings window opens).</summary>
+        public void ClearLog(Models.RemoteHost host)
+        {
+            if (host == null)
+                return;
+
+            Dispatcher.UIThread.Post(() =>
+            {
+                host.StatusLog.Clear();
+                host.StatusLogText = string.Empty;
+            });
         }
 
         private static string Key(string host) => (host ?? string.Empty).Trim();

--- a/src/Remote/RemoteHostManager.cs
+++ b/src/Remote/RemoteHostManager.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 using Avalonia.Threading;
@@ -63,29 +65,45 @@ namespace SourceGit.Remote
             if (host.IsConnected && !forceRedeploy)
                 return true;
 
-            // Start a fresh log for this attempt. Clear before SetState so the state line is
-            // the first entry, not wiped by a later clear.
-            Dispatcher.UIThread.Post(() => { host.StatusLog.Clear(); host.StatusLogText = string.Empty; });
-            SetState(host, Models.RemoteHostState.Connecting, forceRedeploy ? "Re-deploying..." : "Connecting...");
-
-            var session = GetOrCreate(host);
+            // Serialize connect attempts per host so that multiple tabs restored on startup
+            // don't race to open the same SSH session / deploy the server concurrently.
+            var key = Key(host.Host);
+            var sem = _connectLocks.GetOrAdd(key, _ => new SemaphoreSlim(1, 1));
+            await sem.WaitAsync().ConfigureAwait(false);
             try
             {
-                await Task.Run(() =>
-                {
-                    if (forceRedeploy)
-                        session.Disconnect();
-                    session.Connect(forceRedeploy);
-                }).ConfigureAwait(false);
+                // Re-check after acquiring the lock — another caller may have connected already.
+                if (host.IsConnected && !forceRedeploy)
+                    return true;
 
-                SetState(host, Models.RemoteHostState.Connected, "Connected");
-                return true;
+                // Start a fresh log for this attempt. Clear before SetState so the state line is
+                // the first entry, not wiped by a later clear.
+                Dispatcher.UIThread.Post(() => { host.StatusLog.Clear(); host.StatusLogText = string.Empty; });
+                SetState(host, Models.RemoteHostState.Connecting, forceRedeploy ? "Re-deploying..." : "Connecting...");
+
+                var session = GetOrCreate(host);
+                try
+                {
+                    await Task.Run(() =>
+                    {
+                        if (forceRedeploy)
+                            session.Disconnect();
+                        session.Connect(forceRedeploy);
+                    }).ConfigureAwait(false);
+
+                    SetState(host, Models.RemoteHostState.Connected, "Connected");
+                    return true;
+                }
+                catch (Exception e)
+                {
+                    session.Disconnect();
+                    SetState(host, Models.RemoteHostState.Failed, e.Message);
+                    return false;
+                }
             }
-            catch (Exception e)
+            finally
             {
-                session.Disconnect();
-                SetState(host, Models.RemoteHostState.Failed, e.Message);
-                return false;
+                sem.Release();
             }
         }
 
@@ -299,5 +317,6 @@ namespace SourceGit.Remote
         private static string Key(string host) => (host ?? string.Empty).Trim();
 
         private readonly Dictionary<string, RemoteHostSession> _sessions = new();
+        private readonly ConcurrentDictionary<string, SemaphoreSlim> _connectLocks = new();
     }
 }

--- a/src/Remote/RemoteHostManager.cs
+++ b/src/Remote/RemoteHostManager.cs
@@ -1,0 +1,169 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+using Avalonia.Threading;
+
+namespace SourceGit.Remote
+{
+    /// <summary>
+    /// Owns the live <see cref="RemoteHostSession"/> for every configured remote host and
+    /// drives the connect / test / disconnect / reset workflow.
+    /// <para>
+    /// Sessions are keyed by the ssh host alias and shared across repository tabs, so a host
+    /// is connected once (from the settings page) and reused by every repository opened on
+    /// it. Connection state lives on the <see cref="Models.RemoteHost"/> model and is updated
+    /// on the UI thread so the settings page and the open-repository dropdown stay in sync.
+    /// </para>
+    /// </summary>
+    public sealed class RemoteHostManager
+    {
+        public static RemoteHostManager Instance { get; } = new();
+
+        /// <summary>Probe connectivity without deploying or launching the server.</summary>
+        public async Task TestAsync(Models.RemoteHost host)
+        {
+            if (host == null || host.IsBusy)
+                return;
+
+            SetState(host, Models.RemoteHostState.Testing, "Testing...");
+
+            var session = GetOrCreate(host);
+            var (ok, message) = await Task.Run(session.Test).ConfigureAwait(false);
+
+            if (host.State == Models.RemoteHostState.Connected)
+                return; // a connect finished while testing; don't clobber it
+
+            SetState(host, ok ? Models.RemoteHostState.Disconnected : Models.RemoteHostState.Failed, message);
+        }
+
+        /// <summary>
+        /// Deploy (if needed) and connect. <paramref name="forceRedeploy"/> re-uploads the
+        /// server binary even if one is already present (used by Reset).
+        /// </summary>
+        public async Task<bool> ConnectAsync(Models.RemoteHost host, bool forceRedeploy = false)
+        {
+            if (host == null)
+                return false;
+
+            if (host.IsConnected && !forceRedeploy)
+                return true;
+
+            SetState(host, Models.RemoteHostState.Connecting, forceRedeploy ? "Re-deploying..." : "Connecting...");
+
+            var session = GetOrCreate(host);
+            try
+            {
+                await Task.Run(() =>
+                {
+                    if (forceRedeploy)
+                        session.Disconnect();
+                    session.Connect(forceRedeploy);
+                }).ConfigureAwait(false);
+
+                SetState(host, Models.RemoteHostState.Connected, "Connected");
+                return true;
+            }
+            catch (Exception e)
+            {
+                session.Disconnect();
+                SetState(host, Models.RemoteHostState.Failed, e.Message);
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Disconnect a host and close every repository tab opened on it. Safe to call when
+        /// already disconnected.
+        /// </summary>
+        public void Disconnect(Models.RemoteHost host)
+        {
+            if (host == null)
+                return;
+
+            CloseTabsForHost(host.Host);
+
+            if (_sessions.TryGetValue(Key(host.Host), out var session))
+                session.Disconnect();
+
+            SetState(host, Models.RemoteHostState.Disconnected, string.Empty);
+        }
+
+        /// <summary>Reset a host: force a fresh deploy and reconnect.</summary>
+        public Task<bool> ResetAsync(Models.RemoteHost host)
+        {
+            CloseTabsForHost(host?.Host);
+            return ConnectAsync(host, forceRedeploy: true);
+        }
+
+        /// <summary>
+        /// Return the connected session for a host, or <c>null</c> when the host is not
+        /// currently connected. Used by the repository opener and the remote folder picker so
+        /// they only ever work over an already-established connection.
+        /// </summary>
+        public RemoteHostSession GetConnectedSession(Models.RemoteHost host)
+        {
+            if (host == null || string.IsNullOrEmpty(host.Host))
+                return null;
+
+            return _sessions.TryGetValue(Key(host.Host), out var session) && session.IsConnected ? session : null;
+        }
+
+        public RemoteHostSession GetConnectedSession(string host)
+        {
+            if (string.IsNullOrEmpty(host))
+                return null;
+
+            return _sessions.TryGetValue(Key(host), out var session) && session.IsConnected ? session : null;
+        }
+
+        private RemoteHostSession GetOrCreate(Models.RemoteHost host)
+        {
+            var key = Key(host.Host);
+            if (!_sessions.TryGetValue(key, out var session))
+            {
+                session = new RemoteHostSession(host);
+                _sessions[key] = session;
+            }
+
+            return session;
+        }
+
+        private void CloseTabsForHost(string host)
+        {
+            if (string.IsNullOrEmpty(host))
+                return;
+
+            Dispatcher.UIThread.Invoke(() =>
+            {
+                var launcher = App.GetLauncher();
+                if (launcher == null)
+                    return;
+
+                var key = Key(host);
+                var victims = new List<ViewModels.LauncherPage>();
+                foreach (var page in launcher.Pages)
+                {
+                    if (page.Node is { IsRemote: true, RemoteHost: { } rh } && Key(rh.Host) == key)
+                        victims.Add(page);
+                }
+
+                foreach (var page in victims)
+                    launcher.CloseTab(page);
+            });
+        }
+
+        private static void SetState(Models.RemoteHost host, Models.RemoteHostState state, string message)
+        {
+            Dispatcher.UIThread.Post(() =>
+            {
+                host.State = state;
+                host.StatusMessage = message;
+            });
+        }
+
+        private static string Key(string host) => (host ?? string.Empty).Trim();
+
+        private readonly Dictionary<string, RemoteHostSession> _sessions = new();
+    }
+}

--- a/src/Remote/RemoteHostSession.cs
+++ b/src/Remote/RemoteHostSession.cs
@@ -100,18 +100,36 @@ namespace SourceGit.Remote
         public void Dispose() => Disconnect();
 
         /// <summary>
-        /// Ensure the server binary exists and is executable on the remote host. Probes first
-        /// so the common case (already deployed) needs no upload; uploads the bundled binary
-        /// if missing or when <paramref name="forceRedeploy"/> is set. Throws on failure.
+        /// Ensure the server binary exists, is executable, and matches the client's build
+        /// version. Probes first so the common case (already deployed, up to date) needs no
+        /// upload; uploads the bundled binary when missing, when <paramref name="forceRedeploy"/>
+        /// is set, or when the deployed version differs from the client. Throws on failure.
         /// </summary>
         private static void EnsureRemoteServer(string host, bool forceRedeploy)
         {
-            if (!forceRedeploy)
+            var needUpload = forceRedeploy;
+
+            if (!needUpload)
             {
                 var probe = SshExec.Run(host, $"test -x {RemoteServerBinary} && echo OK");
-                if (probe.stdout.Trim() == "OK")
-                    return;
+                if (probe.stdout.Trim() != "OK")
+                {
+                    needUpload = true;
+                }
+                else
+                {
+                    // Ask the deployed binary for its build version. `timeout` guards against
+                    // very old builds that don't understand --remote-server-version and would
+                    // otherwise try to start a GUI over SSH and hang.
+                    var expected = Native.OS.GetAppVersion();
+                    var remote = SshExec.Run(host, $"timeout 5s {RemoteServerBinary} --remote-server-version");
+                    if (remote.exitCode != 0 || !remote.stdout.Trim().Equals(expected, StringComparison.Ordinal))
+                        needUpload = true;
+                }
             }
+
+            if (!needUpload)
+                return;
 
             var local = Native.OS.GetBundledRemoteServerPath();
             if (string.IsNullOrEmpty(local))

--- a/src/Remote/RemoteHostSession.cs
+++ b/src/Remote/RemoteHostSession.cs
@@ -19,7 +19,10 @@ namespace SourceGit.Remote
     public sealed class RemoteHostSession : IDisposable
     {
         // Fixed command that launches the auto-deployed server on the remote host.
-        private const string RemoteServerCommand = "~/.sourcegit-server/sourcegit --remote-server";
+        // `exec` replaces the remote login shell with the server process so that when the
+        // SSH channel closes the server receives SIGHUP and exits instead of being orphaned
+        // (some shells, e.g. fish, leave the child running otherwise).
+        private const string RemoteServerCommand = "exec ~/.sourcegit-server/sourcegit --remote-server";
         private const string RemoteServerDir = "~/.sourcegit-server";
         private const string RemoteServerBinary = "~/.sourcegit-server/sourcegit";
 

--- a/src/Remote/RemoteHostSession.cs
+++ b/src/Remote/RemoteHostSession.cs
@@ -81,6 +81,12 @@ namespace SourceGit.Remote
             {
                 var client = new RpcClient(conn.Input, conn.Output);
                 client.Call("ping", new { });
+                client.ConnectionLost += () =>
+                {
+                    // The SSH channel / server process died. Mark the host as failed so the
+                    // UI shows a red dot instead of pretending everything is fine.
+                    RemoteHostManager.Instance.MarkConnectionLost(Host);
+                };
                 _conn = conn;
                 Client = client;
             }

--- a/src/Remote/RemoteHostSession.cs
+++ b/src/Remote/RemoteHostSession.cs
@@ -155,10 +155,13 @@ namespace SourceGit.Remote
             var size = new System.IO.FileInfo(local).Length;
             onProgress?.Invoke($"Uploading server binary ({size / 1024 / 1024} MB)...");
 
+            // Upload to a temp path first, then atomically mv over the target. Overwriting a
+            // running binary directly fails with "Text file busy" on Linux.
+            var tempPath = RemoteServerBinary + ".new";
             var sw = Stopwatch.StartNew();
             long lastSent = 0;
             long lastTick = 0;
-            if (ScpUpload.Upload(host, local, RemoteServerBinary, (sent, total) =>
+            if (ScpUpload.Upload(host, local, tempPath, (sent, total) =>
                 {
                     var tick = sw.ElapsedMilliseconds;
                     if (total <= 0 || (tick - lastTick < 1000 && sent != total))
@@ -173,9 +176,14 @@ namespace SourceGit.Remote
                 throw new Exception($"Failed to upload server binary to '{host}'.");
 
             onProgress?.Invoke("Setting executable permissions...");
-            var chmod = SshExec.Run(host, $"chmod +x {RemoteServerBinary}");
+            var chmod = SshExec.Run(host, $"chmod +x {tempPath}");
             if (chmod.exitCode != 0)
                 throw new Exception($"Failed to chmod server binary on '{host}' (exit {chmod.exitCode}).");
+
+            onProgress?.Invoke("Activating new server binary...");
+            var mv = SshExec.Run(host, $"mv -f {tempPath} {RemoteServerBinary}");
+            if (mv.exitCode != 0)
+                throw new Exception($"Failed to activate server binary on '{host}' (exit {mv.exitCode}).");
         }
 
         private IConnection _conn;

--- a/src/Remote/RemoteHostSession.cs
+++ b/src/Remote/RemoteHostSession.cs
@@ -1,0 +1,131 @@
+using System;
+
+namespace SourceGit.Remote
+{
+    /// <summary>
+    /// A single live connection to one remote host.
+    /// <para>
+    /// Owns the underlying SSH <see cref="IConnection"/> and the <see cref="RpcClient"/> that
+    /// speaks to <c>sourcegit --remote-server</c> running on the host. The session is created
+    /// and torn down explicitly from the settings page (Test / Connect / Disconnect / Reset)
+    /// and is shared by every repository opened on that host, so the connection outlives any
+    /// individual repository tab.
+    /// </para>
+    /// <para>
+    /// All ssh/scp operations reuse the host alias, so <c>~/.ssh/config</c> (ProxyJump / jump
+    /// hosts, agent, identity, passwordless auth) applies throughout.
+    /// </para>
+    /// </summary>
+    public sealed class RemoteHostSession : IDisposable
+    {
+        // Fixed command that launches the auto-deployed server on the remote host.
+        private const string RemoteServerCommand = "~/.sourcegit-server/sourcegit --remote-server";
+        private const string RemoteServerDir = "~/.sourcegit-server";
+        private const string RemoteServerBinary = "~/.sourcegit-server/sourcegit";
+
+        public RemoteHostSession(Models.RemoteHost host)
+        {
+            Host = host;
+        }
+
+        public Models.RemoteHost Host { get; }
+
+        /// <summary>The live RPC client, or <c>null</c> when not connected.</summary>
+        public RpcClient Client { get; private set; }
+
+        public bool IsConnected => Client != null;
+
+        /// <summary>
+        /// Probe connectivity without deploying or starting the server. Runs a trivial
+        /// non-interactive command over ssh and reports whether it succeeded.
+        /// </summary>
+        public (bool ok, string message) Test()
+        {
+            var alias = Host.Host;
+            if (string.IsNullOrWhiteSpace(alias))
+                return (false, "Host is empty");
+
+            var (stdout, exit) = SshExec.Run(alias, "echo SOURCEGIT_OK");
+            if (exit == 0 && stdout.Trim() == "SOURCEGIT_OK")
+                return (true, "Reachable");
+
+            return (false, string.IsNullOrWhiteSpace(stdout) ? $"ssh exited with code {exit}" : stdout.Trim());
+        }
+
+        /// <summary>
+        /// Establish the connection: ensure the server binary is deployed (probe → upload if
+        /// missing → chmod), launch it over ssh, and verify it answers a ping. Idempotent —
+        /// returns immediately if already connected. Throws on failure.
+        /// </summary>
+        public void Connect(bool forceRedeploy = false)
+        {
+            if (IsConnected)
+                return;
+
+            var alias = Host.Host;
+            if (string.IsNullOrWhiteSpace(alias))
+                throw new Exception("Host is empty");
+
+            EnsureRemoteServer(alias, forceRedeploy);
+
+            var conn = new SshConnection(alias, RemoteServerCommand);
+            try
+            {
+                var client = new RpcClient(conn.Input, conn.Output);
+                client.Call("ping", new { });
+                _conn = conn;
+                Client = client;
+            }
+            catch
+            {
+                try { conn.Dispose(); } catch { /* best effort */ }
+                throw;
+            }
+        }
+
+        /// <summary>Tear down the connection. Safe to call when already disconnected.</summary>
+        public void Disconnect()
+        {
+            var client = Client;
+            Client = null;
+
+            try { client?.Dispose(); } catch { /* best effort */ }
+            try { _conn?.Dispose(); } catch { /* best effort */ }
+            _conn = null;
+        }
+
+        public void Dispose() => Disconnect();
+
+        /// <summary>
+        /// Ensure the server binary exists and is executable on the remote host. Probes first
+        /// so the common case (already deployed) needs no upload; uploads the bundled binary
+        /// if missing or when <paramref name="forceRedeploy"/> is set. Throws on failure.
+        /// </summary>
+        private static void EnsureRemoteServer(string host, bool forceRedeploy)
+        {
+            if (!forceRedeploy)
+            {
+                var probe = SshExec.Run(host, $"test -x {RemoteServerBinary} && echo OK");
+                if (probe.stdout.Trim() == "OK")
+                    return;
+            }
+
+            var local = Native.OS.GetBundledRemoteServerPath();
+            if (string.IsNullOrEmpty(local))
+                throw new Exception("Bundled remote server binary not found; please run from the installed app.");
+
+            var mkdir = SshExec.Run(host, $"mkdir -p {RemoteServerDir}");
+            if (mkdir.exitCode != 0)
+                throw new Exception($"Failed to create {RemoteServerDir} on '{host}' (exit {mkdir.exitCode}).");
+
+            if (ScpUpload.Upload(host, local, RemoteServerBinary) != 0)
+                throw new Exception($"Failed to upload server binary to '{host}'.");
+
+            var chmod = SshExec.Run(host, $"chmod +x {RemoteServerBinary}");
+            if (chmod.exitCode != 0)
+                throw new Exception($"Failed to chmod server binary on '{host}' (exit {chmod.exitCode}).");
+        }
+
+        private IConnection _conn;
+    }
+}

--- a/src/Remote/RemoteHostSession.cs
+++ b/src/Remote/RemoteHostSession.cs
@@ -69,8 +69,9 @@ namespace SourceGit.Remote
             if (string.IsNullOrWhiteSpace(alias))
                 throw new Exception("Host is empty");
 
-            EnsureRemoteServer(alias, forceRedeploy);
+            EnsureRemoteServer(alias, forceRedeploy, msg => RemoteHostManager.Instance.AppendLog(Host, msg));
 
+            RemoteHostManager.Instance.AppendLog(Host, "Starting remote server...");
             var conn = new SshConnection(alias, RemoteServerCommand);
             try
             {
@@ -105,12 +106,13 @@ namespace SourceGit.Remote
         /// upload; uploads the bundled binary when missing, when <paramref name="forceRedeploy"/>
         /// is set, or when the deployed version differs from the client. Throws on failure.
         /// </summary>
-        private static void EnsureRemoteServer(string host, bool forceRedeploy)
+        private static void EnsureRemoteServer(string host, bool forceRedeploy, Action<string> onProgress)
         {
             var needUpload = forceRedeploy;
 
             if (!needUpload)
             {
+                onProgress?.Invoke("Probing remote server binary...");
                 var probe = SshExec.Run(host, $"test -x {RemoteServerBinary} && echo OK");
                 if (probe.stdout.Trim() != "OK")
                 {
@@ -124,24 +126,34 @@ namespace SourceGit.Remote
                     var expected = Native.OS.GetAppVersion();
                     var remote = SshExec.Run(host, $"timeout 5s {RemoteServerBinary} --remote-server-version");
                     if (remote.exitCode != 0 || !remote.stdout.Trim().Equals(expected, StringComparison.Ordinal))
+                    {
+                        onProgress?.Invoke("Remote server binary is outdated; re-uploading...");
                         needUpload = true;
+                    }
                 }
             }
 
             if (!needUpload)
+            {
+                onProgress?.Invoke("Remote server binary is up to date.");
                 return;
+            }
 
             var local = Native.OS.GetBundledRemoteServerPath();
             if (string.IsNullOrEmpty(local))
                 throw new Exception("Bundled remote server binary not found; please run from the installed app.");
 
+            onProgress?.Invoke("Creating remote server directory...");
             var mkdir = SshExec.Run(host, $"mkdir -p {RemoteServerDir}");
             if (mkdir.exitCode != 0)
                 throw new Exception($"Failed to create {RemoteServerDir} on '{host}' (exit {mkdir.exitCode}).");
 
+            var size = new System.IO.FileInfo(local).Length;
+            onProgress?.Invoke($"Uploading server binary ({size / 1024 / 1024} MB)...");
             if (ScpUpload.Upload(host, local, RemoteServerBinary) != 0)
                 throw new Exception($"Failed to upload server binary to '{host}'.");
 
+            onProgress?.Invoke("Setting executable permissions...");
             var chmod = SshExec.Run(host, $"chmod +x {RemoteServerBinary}");
             if (chmod.exitCode != 0)
                 throw new Exception($"Failed to chmod server binary on '{host}' (exit {chmod.exitCode}).");

--- a/src/Remote/RemoteHostSession.cs
+++ b/src/Remote/RemoteHostSession.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 
 namespace SourceGit.Remote
 {
@@ -48,9 +49,12 @@ namespace SourceGit.Remote
             if (string.IsNullOrWhiteSpace(alias))
                 return (false, "Host is empty");
 
+            var sw = Stopwatch.StartNew();
             var (stdout, exit) = SshExec.Run(alias, "echo SOURCEGIT_OK");
+            sw.Stop();
+
             if (exit == 0 && stdout.Trim() == "SOURCEGIT_OK")
-                return (true, "Reachable");
+                return (true, $"{sw.ElapsedMilliseconds} ms");
 
             return (false, string.IsNullOrWhiteSpace(stdout) ? $"ssh exited with code {exit}" : stdout.Trim());
         }

--- a/src/Remote/RemoteHostSession.cs
+++ b/src/Remote/RemoteHostSession.cs
@@ -154,7 +154,22 @@ namespace SourceGit.Remote
 
             var size = new System.IO.FileInfo(local).Length;
             onProgress?.Invoke($"Uploading server binary ({size / 1024 / 1024} MB)...");
-            if (ScpUpload.Upload(host, local, RemoteServerBinary) != 0)
+
+            var sw = Stopwatch.StartNew();
+            long lastSent = 0;
+            long lastTick = 0;
+            if (ScpUpload.Upload(host, local, RemoteServerBinary, (sent, total) =>
+                {
+                    var tick = sw.ElapsedMilliseconds;
+                    if (total <= 0 || (tick - lastTick < 1000 && sent != total))
+                        return;
+
+                    var dt = (tick - lastTick) / 1000.0;
+                    var speed = dt > 0 ? (sent - lastSent) / 1024.0 / 1024.0 / dt : 0;
+                    onProgress?.Invoke($"  {sent * 100 / total}% · {speed:F1} MB/s");
+                    lastSent = sent;
+                    lastTick = tick;
+                }) != 0)
                 throw new Exception($"Failed to upload server binary to '{host}'.");
 
             onProgress?.Invoke("Setting executable permissions...");

--- a/src/Remote/RemoteRepositoryOpener.cs
+++ b/src/Remote/RemoteRepositoryOpener.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 
 using SourceGit.Commands;
 using SourceGit.ViewModels;
@@ -21,7 +22,20 @@ namespace SourceGit.Remote
         {
             var session = RemoteHostManager.Instance.GetConnectedSession(host);
             if (session == null)
-                throw new Exception($"Host '{host?.Name ?? host?.Host}' is not connected. Connect it from Preferences first.");
+            {
+                // Auto-connect when opening a remote repository (restored tabs, recent repos, etc.).
+                // This makes remote SSH repositories behave like local ones: they just open.
+                var connected = Task.Run(async () => await RemoteHostManager.Instance.ConnectAsync(host).ConfigureAwait(false))
+                    .GetAwaiter()
+                    .GetResult();
+
+                if (!connected)
+                    throw new Exception($"Host '{host?.Name ?? host?.Host}' could not be connected automatically.");
+
+                session = RemoteHostManager.Instance.GetConnectedSession(host);
+                if (session == null)
+                    throw new Exception($"Host '{host?.Name ?? host?.Host}' is not connected.");
+            }
 
             var client = session.Client;
             var runner = new RemoteCommandRunner(client);

--- a/src/Remote/RemoteRepositoryOpener.cs
+++ b/src/Remote/RemoteRepositoryOpener.cs
@@ -58,6 +58,7 @@ namespace SourceGit.Remote
 
             var repo = new Repository(isBare, remotePath, gitDir, isRemote: true);
             repo.RemoteConnection = conn;
+            repo.FileSystem = new RemoteFileSystem(client);
             return repo;
         }
     }

--- a/src/Remote/RemoteRepositoryOpener.cs
+++ b/src/Remote/RemoteRepositoryOpener.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Threading.Tasks;
 
 using SourceGit.Commands;
@@ -20,6 +21,11 @@ namespace SourceGit.Remote
     {
         public static Repository Open(Models.RemoteHost host, string remotePath)
         {
+            // Resolve to the instance stored in Preferences so connection state updates are
+            // visible in the settings page. Restored tabs carry a deserialized copy whose
+            // State/StatusMessage are never observed by the UI otherwise.
+            host = Preferences.Instance.RemoteHosts.FirstOrDefault(h => h.Host == host?.Host) ?? host;
+
             var session = RemoteHostManager.Instance.GetConnectedSession(host);
             if (session == null)
             {

--- a/src/Remote/RemoteRepositoryOpener.cs
+++ b/src/Remote/RemoteRepositoryOpener.cs
@@ -75,7 +75,7 @@ namespace SourceGit.Remote
                     RemoteHost = host,
                 };
                 repo.RemoteWatcher = new RemoteWatcher(repo, client);
-                client.Call("watch_start", new { path = remotePath });
+                client.Call("watch_start", new { path = remotePath, git_dir = gitDir });
                 return repo;
             }
             catch

--- a/src/Remote/RemoteRepositoryOpener.cs
+++ b/src/Remote/RemoteRepositoryOpener.cs
@@ -59,6 +59,8 @@ namespace SourceGit.Remote
             var repo = new Repository(isBare, remotePath, gitDir, isRemote: true);
             repo.RemoteConnection = conn;
             repo.FileSystem = new RemoteFileSystem(client);
+            repo.RemoteWatcher = new RemoteWatcher(repo, client);
+            client.Call("watch_start", new { path = remotePath });
             return repo;
         }
     }

--- a/src/Remote/RemoteRepositoryOpener.cs
+++ b/src/Remote/RemoteRepositoryOpener.cs
@@ -1,0 +1,63 @@
+using System;
+using System.IO;
+
+using SourceGit.Commands;
+using SourceGit.ViewModels;
+
+namespace SourceGit.Remote
+{
+    /// <summary>
+    /// Opens a repository that lives on a remote host. Establishes the SSH connection,
+    /// registers a <see cref="RemoteCommandRunner"/> for the remote path (so all
+    /// <c>Commands.XXX(remotePath,...)</c> reach the server), probes isBare/gitDir via RPC,
+    /// and constructs the <see cref="Repository"/>.
+    /// <para>
+    /// Probing is done with <c>git rev-parse</c> over RPC on purpose: the local
+    /// <c>IsBareRepository</c>/<c>GetRepositoryGitDir</c> helpers short-circuit on local
+    /// <c>Directory.Exists</c>/<c>File.Exists</c> checks that are meaningless for a path
+    /// that does not exist on this machine.
+    /// </para>
+    /// </summary>
+    public static class RemoteRepositoryOpener
+    {
+        /// <summary>
+        /// Open <paramref name="remotePath"/> on <paramref name="host"/>. The returned
+        /// <paramref name="connection"/> owns the SSH process and must be disposed when the
+        /// repository is closed.
+        /// </summary>
+        public static Repository Open(Models.RemoteHost host, string remotePath, out IDisposable connection)
+        {
+            var conn = new SshConnection(host.Host, $"{host.RemoteServerPath} --remote-server");
+            var client = new RpcClient(conn.Input, conn.Output);
+            var runner = new RemoteCommandRunner(client);
+
+            // Verify the server is alive before doing anything else.
+            client.Call("ping", new { });
+
+            // Register the runner so any Commands spawned with remotePath reach the remote.
+            CommandRunnerRegistry.Register(remotePath, runner);
+
+            // Probe isBare + gitDir via RPC.
+            var isBareRS = runner.ReadToEnd(new Command.RunSpec
+            {
+                Args = "rev-parse --is-bare-repository",
+                WorkingDirectory = remotePath,
+            });
+            var isBare = isBareRS.IsSuccess && isBareRS.StdOut.Trim() == "true";
+
+            var gitDirRS = runner.ReadToEnd(new Command.RunSpec
+            {
+                Args = "rev-parse --git-dir",
+                WorkingDirectory = remotePath,
+            });
+            var gitDir = gitDirRS.IsSuccess ? gitDirRS.StdOut.Trim() : remotePath;
+            if (string.IsNullOrEmpty(gitDir) || gitDir == ".")
+                gitDir = remotePath;
+            else if (!gitDir.StartsWith('/'))
+                gitDir = remotePath.TrimEnd('/') + "/" + gitDir;
+
+            connection = conn;
+            return new Repository(isBare, remotePath, gitDir, isRemote: true);
+        }
+    }
+}

--- a/src/Remote/RemoteRepositoryOpener.cs
+++ b/src/Remote/RemoteRepositoryOpener.cs
@@ -7,27 +7,25 @@ using SourceGit.ViewModels;
 namespace SourceGit.Remote
 {
     /// <summary>
-    /// Opens a repository that lives on a remote host. Establishes the SSH connection,
-    /// registers a <see cref="RemoteCommandRunner"/> for the remote path (so all
-    /// <c>Commands.XXX(remotePath,...)</c> reach the server), probes isBare/gitDir via RPC,
-    /// and constructs the <see cref="Repository"/>.
+    /// Opens a repository that lives on a remote host. Auto-deploys the server binary to
+    /// <c>~/.sourcegit-server/sourcegit</c> on the remote (probe → upload if missing → chmod),
+    /// then establishes the SSH connection, registers a <see cref="RemoteCommandRunner"/>,
+    /// probes isBare/gitDir via RPC, and constructs the <see cref="Repository"/>.
     /// <para>
-    /// Probing is done with <c>git rev-parse</c> over RPC on purpose: the local
-    /// <c>IsBareRepository</c>/<c>GetRepositoryGitDir</c> helpers short-circuit on local
-    /// <c>Directory.Exists</c>/<c>File.Exists</c> checks that are meaningless for a path
-    /// that does not exist on this machine.
+    /// Probe/upload/chmod reuse the same ssh host alias so ~/.ssh/config (ProxyJump/jump
+    /// hosts, agent, identity, passwordless auth) applies throughout.
     /// </para>
     /// </summary>
     public static class RemoteRepositoryOpener
     {
-        /// <summary>
-        /// Open <paramref name="remotePath"/> on <paramref name="host"/>. The returned
-        /// Repository owns the SSH connection; disposing it on close releases the process
-        /// and unregisters the runner.
-        /// </summary>
+        // Fixed command that launches the auto-deployed server on the remote host.
+        private const string RemoteServerCommand = "~/.sourcegit-server/sourcegit --remote-server";
+
         public static Repository Open(Models.RemoteHost host, string remotePath)
         {
-            var conn = new SshConnection(host.Host, $"{host.RemoteServerPath} --remote-server");
+            EnsureRemoteServer(host.Host);
+
+            var conn = new SshConnection(host.Host, RemoteServerCommand);
             var client = new RpcClient(conn.Input, conn.Output);
             var runner = new RemoteCommandRunner(client);
 
@@ -62,6 +60,33 @@ namespace SourceGit.Remote
             repo.RemoteWatcher = new RemoteWatcher(repo, client);
             client.Call("watch_start", new { path = remotePath });
             return repo;
+        }
+
+        /// <summary>
+        /// Ensure the server binary exists and is executable on the remote host. Probes first
+        /// so the common case (already deployed) needs no upload; uploads the bundled binary
+        /// if missing. Throws on failure.
+        /// </summary>
+        private static void EnsureRemoteServer(string host)
+        {
+            var probe = SshExec.Run(host, "test -x ~/.sourcegit-server/sourcegit && echo OK");
+            if (probe.stdout.Trim() == "OK")
+                return;
+
+            var local = Native.OS.GetBundledRemoteServerPath();
+            if (string.IsNullOrEmpty(local))
+                throw new Exception("bundled remote server binary not found; please run from the installed app");
+
+            var mkdir = SshExec.Run(host, "mkdir -p ~/.sourcegit-server");
+            if (mkdir.exitCode != 0)
+                throw new Exception($"failed to create ~/.sourcegit-server on '{host}' (exit {mkdir.exitCode})");
+
+            if (ScpUpload.Upload(host, local, "~/.sourcegit-server/sourcegit") != 0)
+                throw new Exception($"failed to upload server binary to '{host}'");
+
+            var chmod = SshExec.Run(host, "chmod +x ~/.sourcegit-server/sourcegit");
+            if (chmod.exitCode != 0)
+                throw new Exception($"failed to chmod server binary on '{host}' (exit {chmod.exitCode})");
         }
     }
 }

--- a/src/Remote/RemoteRepositoryOpener.cs
+++ b/src/Remote/RemoteRepositoryOpener.cs
@@ -66,6 +66,7 @@ namespace SourceGit.Remote
                 var repo = new Repository(isBare, remotePath, gitDir, isRemote: true)
                 {
                     FileSystem = new RemoteFileSystem(client),
+                    RemoteHost = host,
                 };
                 repo.RemoteWatcher = new RemoteWatcher(repo, client);
                 client.Call("watch_start", new { path = remotePath });

--- a/src/Remote/RemoteRepositoryOpener.cs
+++ b/src/Remote/RemoteRepositoryOpener.cs
@@ -1,5 +1,4 @@
 using System;
-using System.IO;
 
 using SourceGit.Commands;
 using SourceGit.ViewModels;
@@ -7,86 +6,63 @@ using SourceGit.ViewModels;
 namespace SourceGit.Remote
 {
     /// <summary>
-    /// Opens a repository that lives on a remote host. Auto-deploys the server binary to
-    /// <c>~/.sourcegit-server/sourcegit</c> on the remote (probe → upload if missing → chmod),
-    /// then establishes the SSH connection, registers a <see cref="RemoteCommandRunner"/>,
-    /// probes isBare/gitDir via RPC, and constructs the <see cref="Repository"/>.
+    /// Opens a repository that lives on a remote host by reusing the already-established
+    /// <see cref="RemoteHostSession"/> for that host (connected from the settings page).
     /// <para>
-    /// Probe/upload/chmod reuse the same ssh host alias so ~/.ssh/config (ProxyJump/jump
-    /// hosts, agent, identity, passwordless auth) applies throughout.
+    /// The connection is owned by the session, not by the repository, so several repositories
+    /// can share one connection and closing a repository tab never tears down the connection.
+    /// This method registers a <see cref="RemoteCommandRunner"/> for the repository path,
+    /// probes isBare/gitDir over RPC, and constructs the <see cref="Repository"/>.
     /// </para>
     /// </summary>
     public static class RemoteRepositoryOpener
     {
-        // Fixed command that launches the auto-deployed server on the remote host.
-        private const string RemoteServerCommand = "~/.sourcegit-server/sourcegit --remote-server";
-
         public static Repository Open(Models.RemoteHost host, string remotePath)
         {
-            EnsureRemoteServer(host.Host);
+            var session = RemoteHostManager.Instance.GetConnectedSession(host);
+            if (session == null)
+                throw new Exception($"Host '{host?.Name ?? host?.Host}' is not connected. Connect it from Preferences first.");
 
-            var conn = new SshConnection(host.Host, RemoteServerCommand);
-            var client = new RpcClient(conn.Input, conn.Output);
+            var client = session.Client;
             var runner = new RemoteCommandRunner(client);
-
-            // Verify the server is alive before doing anything else.
-            client.Call("ping", new { });
 
             // Register the runner so any Commands spawned with remotePath reach the remote.
             CommandRunnerRegistry.Register(remotePath, runner);
 
-            // Probe isBare + gitDir via RPC.
-            var isBareRS = runner.ReadToEnd(new Command.RunSpec
+            try
             {
-                Args = "rev-parse --is-bare-repository",
-                WorkingDirectory = remotePath,
-            });
-            var isBare = isBareRS.IsSuccess && isBareRS.StdOut.Trim() == "true";
+                // Probe isBare + gitDir via RPC.
+                var isBareRS = runner.ReadToEnd(new Command.RunSpec
+                {
+                    Args = "rev-parse --is-bare-repository",
+                    WorkingDirectory = remotePath,
+                });
+                var isBare = isBareRS.IsSuccess && isBareRS.StdOut.Trim() == "true";
 
-            var gitDirRS = runner.ReadToEnd(new Command.RunSpec
+                var gitDirRS = runner.ReadToEnd(new Command.RunSpec
+                {
+                    Args = "rev-parse --git-dir",
+                    WorkingDirectory = remotePath,
+                });
+                var gitDir = gitDirRS.IsSuccess ? gitDirRS.StdOut.Trim() : remotePath;
+                if (string.IsNullOrEmpty(gitDir) || gitDir == ".")
+                    gitDir = remotePath;
+                else if (!gitDir.StartsWith('/'))
+                    gitDir = remotePath.TrimEnd('/') + "/" + gitDir;
+
+                var repo = new Repository(isBare, remotePath, gitDir, isRemote: true)
+                {
+                    FileSystem = new RemoteFileSystem(client),
+                };
+                repo.RemoteWatcher = new RemoteWatcher(repo, client);
+                client.Call("watch_start", new { path = remotePath });
+                return repo;
+            }
+            catch
             {
-                Args = "rev-parse --git-dir",
-                WorkingDirectory = remotePath,
-            });
-            var gitDir = gitDirRS.IsSuccess ? gitDirRS.StdOut.Trim() : remotePath;
-            if (string.IsNullOrEmpty(gitDir) || gitDir == ".")
-                gitDir = remotePath;
-            else if (!gitDir.StartsWith('/'))
-                gitDir = remotePath.TrimEnd('/') + "/" + gitDir;
-
-            var repo = new Repository(isBare, remotePath, gitDir, isRemote: true);
-            repo.RemoteConnection = conn;
-            repo.FileSystem = new RemoteFileSystem(client);
-            repo.RemoteWatcher = new RemoteWatcher(repo, client);
-            client.Call("watch_start", new { path = remotePath });
-            return repo;
-        }
-
-        /// <summary>
-        /// Ensure the server binary exists and is executable on the remote host. Probes first
-        /// so the common case (already deployed) needs no upload; uploads the bundled binary
-        /// if missing. Throws on failure.
-        /// </summary>
-        private static void EnsureRemoteServer(string host)
-        {
-            var probe = SshExec.Run(host, "test -x ~/.sourcegit-server/sourcegit && echo OK");
-            if (probe.stdout.Trim() == "OK")
-                return;
-
-            var local = Native.OS.GetBundledRemoteServerPath();
-            if (string.IsNullOrEmpty(local))
-                throw new Exception("bundled remote server binary not found; please run from the installed app");
-
-            var mkdir = SshExec.Run(host, "mkdir -p ~/.sourcegit-server");
-            if (mkdir.exitCode != 0)
-                throw new Exception($"failed to create ~/.sourcegit-server on '{host}' (exit {mkdir.exitCode})");
-
-            if (ScpUpload.Upload(host, local, "~/.sourcegit-server/sourcegit") != 0)
-                throw new Exception($"failed to upload server binary to '{host}'");
-
-            var chmod = SshExec.Run(host, "chmod +x ~/.sourcegit-server/sourcegit");
-            if (chmod.exitCode != 0)
-                throw new Exception($"failed to chmod server binary on '{host}' (exit {chmod.exitCode})");
+                CommandRunnerRegistry.Unregister(remotePath);
+                throw;
+            }
         }
     }
 }

--- a/src/Remote/RemoteRepositoryOpener.cs
+++ b/src/Remote/RemoteRepositoryOpener.cs
@@ -24,10 +24,9 @@ namespace SourceGit.Remote
             if (session == null)
             {
                 // Auto-connect when opening a remote repository (restored tabs, recent repos, etc.).
-                // This makes remote SSH repositories behave like local ones: they just open.
-                var connected = Task.Run(async () => await RemoteHostManager.Instance.ConnectAsync(host).ConfigureAwait(false))
-                    .GetAwaiter()
-                    .GetResult();
+                // This is called from a background thread by the launcher, so blocking here is fine
+                // and does not stall the UI.
+                var connected = RemoteHostManager.Instance.ConnectAsync(host).GetAwaiter().GetResult();
 
                 if (!connected)
                     throw new Exception($"Host '{host?.Name ?? host?.Host}' could not be connected automatically.");

--- a/src/Remote/RemoteRepositoryOpener.cs
+++ b/src/Remote/RemoteRepositoryOpener.cs
@@ -22,10 +22,10 @@ namespace SourceGit.Remote
     {
         /// <summary>
         /// Open <paramref name="remotePath"/> on <paramref name="host"/>. The returned
-        /// <paramref name="connection"/> owns the SSH process and must be disposed when the
-        /// repository is closed.
+        /// Repository owns the SSH connection; disposing it on close releases the process
+        /// and unregisters the runner.
         /// </summary>
-        public static Repository Open(Models.RemoteHost host, string remotePath, out IDisposable connection)
+        public static Repository Open(Models.RemoteHost host, string remotePath)
         {
             var conn = new SshConnection(host.Host, $"{host.RemoteServerPath} --remote-server");
             var client = new RpcClient(conn.Input, conn.Output);
@@ -56,8 +56,9 @@ namespace SourceGit.Remote
             else if (!gitDir.StartsWith('/'))
                 gitDir = remotePath.TrimEnd('/') + "/" + gitDir;
 
-            connection = conn;
-            return new Repository(isBare, remotePath, gitDir, isRemote: true);
+            var repo = new Repository(isBare, remotePath, gitDir, isRemote: true);
+            repo.RemoteConnection = conn;
+            return repo;
         }
     }
 }

--- a/src/Remote/RemoteWatcher.cs
+++ b/src/Remote/RemoteWatcher.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Text.Json.Nodes;
+using System.Threading;
+using Avalonia.Threading;
+
+using SourceGit.ViewModels;
+
+namespace SourceGit.Remote
+{
+    /// <summary>
+    /// Subscribes to <c>watch_event</c> notifications from the remote server and refreshes
+    /// the repository on the UI thread. Events are debounced (a short quiet period must
+    /// pass before refreshing) so a burst of filesystem changes on the remote does not
+    /// trigger a refresh storm.
+    /// </summary>
+    public sealed class RemoteWatcher : IDisposable
+    {
+        public RemoteWatcher(Repository repo, RpcClient client)
+        {
+            _repo = repo;
+            _client = client;
+            _client.NotificationReceived += OnNotification;
+            _timer = new Timer(_ => Flush(), null, 500, 500);
+        }
+
+        private void OnNotification(string method, JsonNode pars)
+        {
+            if (method != "watch_event")
+                return;
+
+            var path = pars?["path"]?.GetValue<string>();
+            if (path == null || !path.Equals(_repo.FullPath, StringComparison.Ordinal))
+                return;
+
+            Interlocked.Exchange(ref _dirty, 1);
+        }
+
+        private void Flush()
+        {
+            if (Interlocked.CompareExchange(ref _dirty, 0, 1) == 0)
+                return;
+
+            try
+            {
+                Dispatcher.UIThread.Post(() => _repo.RefreshAll());
+            }
+            catch
+            {
+                // Repository may be closing; ignore.
+            }
+        }
+
+        public void Dispose()
+        {
+            _client.NotificationReceived -= OnNotification;
+            _timer.Dispose();
+        }
+
+        private readonly Repository _repo;
+        private readonly RpcClient _client;
+        private readonly Timer _timer;
+        private int _dirty; // 0 = clean, 1 = dirty
+    }
+}

--- a/src/Remote/RemoteWatcher.cs
+++ b/src/Remote/RemoteWatcher.cs
@@ -54,6 +54,11 @@ namespace SourceGit.Remote
         {
             _client.NotificationReceived -= OnNotification;
             _timer.Dispose();
+
+            // Stop the server-side watcher for this path. The connection itself is shared and
+            // owned by the host session, so it stays alive for other repositories.
+            try { _client.Call("watch_stop", new { path = _repo.FullPath }); }
+            catch { /* connection may already be gone; ignore */ }
         }
 
         private readonly Repository _repo;

--- a/src/Remote/RpcClient.cs
+++ b/src/Remote/RpcClient.cs
@@ -1,75 +1,139 @@
 using System;
+using System.Collections.Concurrent;
 using System.IO;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Nodes;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace SourceGit.Remote
 {
     /// <summary>
-    /// Client side of the JSON-RPC over stdio protocol. Sends <see cref="Request"/>s on the
-    /// connection's output stream and reads <see cref="Response"/>s back, correlating by id.
+    /// Client side of the JSON-RPC over stdio protocol.
     /// <para>
-    /// Calls are serialized (one outstanding request at a time) which matches the server's
-    /// single-threaded dispatch loop. Server-pushed notifications (for remote change watching)
-    /// require a background read loop and are tracked separately.
+    /// A dedicated background read thread consumes the stream, dispatching responses
+    /// (matched by id to outstanding <see cref="CallAsync"/> requests) and forwarding
+    /// server-pushed notifications (no id) to <see cref="NotificationReceived"/>. This lets
+    /// the remote server push events such as working-copy changes back to the client for
+    /// auto-refresh.
+    /// </para>
+    /// <para>
+    /// A dedicated thread (not a thread-pool Task) plus
+    /// <see cref="TaskCreationOptions.RunContinuationsAsynchronously"/> avoid the
+    /// continuation/thread-pool deadlock that an earlier Task.Run-based version hit.
     /// </para>
     /// </summary>
     public class RpcClient : IDisposable
     {
         private readonly StreamReader _reader;
         private readonly StreamWriter _writer;
-        private readonly object _lock = new();
-        private long _nextId = 1;
+        private readonly object _writeLock = new();
+        private readonly ConcurrentDictionary<long, TaskCompletionSource<JsonNode>> _pending = new();
+        private readonly Thread _readThread;
+        private long _nextId = 0;
+        private volatile bool _stopped = false;
 
         public RpcClient(Stream input, Stream output)
         {
             _reader = new StreamReader(input, Encoding.UTF8);
             _writer = new StreamWriter(output, new UTF8Encoding(false)) { AutoFlush = true };
+            _readThread = new Thread(ReadLoop) { IsBackground = true, Name = "RpcClient.ReadLoop" };
+            _readThread.Start();
         }
 
-        /// <summary>
-        /// Send a method call and block until the matching response arrives. Throws on a
-        /// remote error or if the connection is closed.
-        /// </summary>
-        public JsonNode Call(string method, object parameters)
+        /// <summary>Server-pushed notification (method, params).</summary>
+        public event Action<string, JsonNode> NotificationReceived;
+
+        /// <summary>Synchronous request/response. Blocks until the matching response arrives.</summary>
+        public JsonNode Call(string method, object parameters) => CallAsync(method, parameters).GetAwaiter().GetResult();
+
+        public async Task<JsonNode> CallAsync(string method, object parameters)
         {
-            long id;
-            string respLine;
+            var id = Interlocked.Increment(ref _nextId);
+            var tcs = new TaskCompletionSource<JsonNode>(TaskCreationOptions.RunContinuationsAsynchronously);
+            _pending[id] = tcs;
 
-            lock (_lock)
+            var req = new Request
             {
-                id = _nextId++;
-                var req = new Request
-                {
-                    Id = id,
-                    Method = method,
-                    Params = JsonSerializer.SerializeToNode(parameters),
-                };
+                Id = id,
+                Method = method,
+                Params = JsonSerializer.SerializeToNode(parameters),
+            };
 
-                var json = JsonSerializer.Serialize(req);
+            var json = JsonSerializer.Serialize(req);
+            lock (_writeLock)
+            {
                 _writer.WriteLine(json);
-                respLine = _reader.ReadLine();
+                _writer.Flush();
             }
 
-            if (respLine == null)
-                throw new Exception("remote server closed the connection");
+            return await tcs.Task.ConfigureAwait(false);
+        }
 
-            var resp = JsonSerializer.Deserialize<Response>(respLine);
-            if (resp == null)
-                throw new Exception("malformed response from remote server");
-            if (resp.Id != id)
-                throw new Exception($"response id mismatch (sent {id}, got {resp.Id})");
-            if (resp.Error != null)
-                throw new Exception(resp.Error.Message ?? "remote error");
+        private void ReadLoop()
+        {
+            while (!_stopped)
+            {
+                string line;
+                try
+                {
+                    line = _reader.ReadLine();
+                }
+                catch
+                {
+                    break;
+                }
 
-            return resp.Result;
+                if (line == null)
+                    break;
+
+                JsonNode msg;
+                try
+                {
+                    msg = JsonNode.Parse(line);
+                }
+                catch
+                {
+                    continue;
+                }
+
+                if (msg == null)
+                    continue;
+
+                var idNode = msg["id"];
+                if (idNode != null)
+                {
+                    var id = idNode.GetValue<long>();
+                    if (_pending.TryRemove(id, out var tcs))
+                    {
+                        var err = msg["error"];
+                        if (err != null)
+                            tcs.TrySetException(new Exception(err["message"]?.GetValue<string>() ?? "remote error"));
+                        else
+                            tcs.TrySetResult(msg["result"]);
+                    }
+                }
+                else
+                {
+                    var method = msg["method"]?.GetValue<string>();
+                    if (method != null)
+                    {
+                        try { NotificationReceived?.Invoke(method, msg["params"]); }
+                        catch { /* notification handlers must not tear down the read loop */ }
+                    }
+                }
+            }
+
+            foreach (var kv in _pending)
+                kv.Value.TrySetException(new Exception("remote server closed the connection"));
         }
 
         public void Dispose()
         {
-            _reader.Dispose();
-            _writer.Dispose();
+            _stopped = true;
+            try { _reader.Dispose(); } catch { }
+            try { _writer.Dispose(); } catch { }
         }
     }
 }

--- a/src/Remote/RpcClient.cs
+++ b/src/Remote/RpcClient.cs
@@ -46,6 +46,9 @@ namespace SourceGit.Remote
         /// <summary>Server-pushed notification (method, params).</summary>
         public event Action<string, JsonNode> NotificationReceived;
 
+        /// <summary>Raised when the read loop exits (server died / SSH channel closed).</summary>
+        public event Action ConnectionLost;
+
         /// <summary>Register a handler for a streaming exec_git stream id.</summary>
         public void RegisterStreamHandler(string streamId, Action<string, JsonNode> handler)
         {
@@ -154,6 +157,8 @@ namespace SourceGit.Remote
 
             foreach (var kv in _pending)
                 kv.Value.TrySetException(new Exception("remote server closed the connection"));
+
+            try { ConnectionLost?.Invoke(); } catch { /* best effort */ }
         }
 
         public void Dispose()

--- a/src/Remote/RpcClient.cs
+++ b/src/Remote/RpcClient.cs
@@ -30,6 +30,7 @@ namespace SourceGit.Remote
         private readonly StreamWriter _writer;
         private readonly object _writeLock = new();
         private readonly ConcurrentDictionary<long, TaskCompletionSource<JsonNode>> _pending = new();
+        private readonly ConcurrentDictionary<string, Action<string, JsonNode>> _streamHandlers = new();
         private readonly Thread _readThread;
         private long _nextId = 0;
         private volatile bool _stopped = false;
@@ -44,6 +45,19 @@ namespace SourceGit.Remote
 
         /// <summary>Server-pushed notification (method, params).</summary>
         public event Action<string, JsonNode> NotificationReceived;
+
+        /// <summary>Register a handler for a streaming exec_git stream id.</summary>
+        public void RegisterStreamHandler(string streamId, Action<string, JsonNode> handler)
+        {
+            if (!string.IsNullOrEmpty(streamId) && handler != null)
+                _streamHandlers[streamId] = handler;
+        }
+
+        public void UnregisterStreamHandler(string streamId)
+        {
+            if (!string.IsNullOrEmpty(streamId))
+                _streamHandlers.TryRemove(streamId, out _);
+        }
 
         /// <summary>Synchronous request/response. Blocks until the matching response arrives.</summary>
         public JsonNode Call(string method, object parameters) => CallAsync(method, parameters).GetAwaiter().GetResult();
@@ -119,8 +133,21 @@ namespace SourceGit.Remote
                     var method = msg["method"]?.GetValue<string>();
                     if (method != null)
                     {
-                        try { NotificationReceived?.Invoke(method, msg["params"]); }
-                        catch { /* notification handlers must not tear down the read loop */ }
+                        // Route streaming exec_git data/done notifications to the owning process.
+                        if (method == "exec_git_stream_data" || method == "exec_git_stream_done")
+                        {
+                            var streamId = msg["params"]?["stream_id"]?.GetValue<string>();
+                            if (streamId != null && _streamHandlers.TryGetValue(streamId, out var handler))
+                            {
+                                try { handler(method, msg["params"]); }
+                                catch { /* stream handlers must not tear down the read loop */ }
+                            }
+                        }
+                        else
+                        {
+                            try { NotificationReceived?.Invoke(method, msg["params"]); }
+                            catch { /* notification handlers must not tear down the read loop */ }
+                        }
                     }
                 }
             }

--- a/src/Remote/RpcClient.cs
+++ b/src/Remote/RpcClient.cs
@@ -1,0 +1,74 @@
+using System;
+using System.IO;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace SourceGit.Remote
+{
+    /// <summary>
+    /// Client side of the JSON-RPC over stdio protocol. Sends <see cref="Request"/>s on the
+    /// connection's output stream and reads <see cref="Response"/>s back, correlating by id.
+    /// <para>
+    /// Calls are serialized (one outstanding request at a time) which matches the server's
+    /// single-threaded dispatch loop. A future phase may add concurrent multiplexing.
+    /// </para>
+    /// </summary>
+    public class RpcClient : IDisposable
+    {
+        private readonly StreamReader _reader;
+        private readonly StreamWriter _writer;
+        private readonly object _lock = new();
+        private long _nextId = 1;
+
+        public RpcClient(Stream input, Stream output)
+        {
+            _reader = new StreamReader(input, Encoding.UTF8);
+            _writer = new StreamWriter(output, new UTF8Encoding(false)) { AutoFlush = true };
+        }
+
+        /// <summary>
+        /// Send a method call and block until the matching response arrives. Throws on a
+        /// remote error or if the connection is closed.
+        /// </summary>
+        public JsonNode Call(string method, object parameters)
+        {
+            long id;
+            string respLine;
+
+            lock (_lock)
+            {
+                id = _nextId++;
+                var req = new Request
+                {
+                    Id = id,
+                    Method = method,
+                    Params = JsonSerializer.SerializeToNode(parameters),
+                };
+
+                var json = JsonSerializer.Serialize(req);
+                _writer.WriteLine(json);
+                respLine = _reader.ReadLine();
+            }
+
+            if (respLine == null)
+                throw new Exception("remote server closed the connection");
+
+            var resp = JsonSerializer.Deserialize<Response>(respLine);
+            if (resp == null)
+                throw new Exception("malformed response from remote server");
+            if (resp.Id != id)
+                throw new Exception($"response id mismatch (sent {id}, got {resp.Id})");
+            if (resp.Error != null)
+                throw new Exception(resp.Error.Message ?? "remote error");
+
+            return resp.Result;
+        }
+
+        public void Dispose()
+        {
+            _reader.Dispose();
+            _writer.Dispose();
+        }
+    }
+}

--- a/src/Remote/RpcClient.cs
+++ b/src/Remote/RpcClient.cs
@@ -11,7 +11,8 @@ namespace SourceGit.Remote
     /// connection's output stream and reads <see cref="Response"/>s back, correlating by id.
     /// <para>
     /// Calls are serialized (one outstanding request at a time) which matches the server's
-    /// single-threaded dispatch loop. A future phase may add concurrent multiplexing.
+    /// single-threaded dispatch loop. Server-pushed notifications (for remote change watching)
+    /// require a background read loop and are tracked separately.
     /// </para>
     /// </summary>
     public class RpcClient : IDisposable

--- a/src/Remote/RpcServer.cs
+++ b/src/Remote/RpcServer.cs
@@ -159,6 +159,7 @@ namespace SourceGit.Remote
                 SSHKey = sshKey ?? string.Empty,
                 Editor = editor,
                 RedirectStandardInput = stdin != null,
+                Headless = true,
             };
 
             // Launch git locally (the server host *is* the repo host). The runner injects

--- a/src/Remote/RpcServer.cs
+++ b/src/Remote/RpcServer.cs
@@ -120,6 +120,9 @@ namespace SourceGit.Remote
                 case "read_file":
                     return JsonSerializer.SerializeToNode(new { content = File.ReadAllText(GetString(p, "path")) });
 
+                case "read_file_base64":
+                    return JsonSerializer.SerializeToNode(new { content = Convert.ToBase64String(File.ReadAllBytes(GetString(p, "path"))) });
+
                 case "write_file":
                     File.WriteAllText(GetString(p, "path"), GetString(p, "content"));
                     return JsonSerializer.SerializeToNode(new { });

--- a/src/Remote/RpcServer.cs
+++ b/src/Remote/RpcServer.cs
@@ -152,7 +152,7 @@ namespace SourceGit.Remote
                     return JsonSerializer.SerializeToNode(ListDir(TryGetString(p, "path")));
 
                 case "watch_start":
-                    StartWatch(GetString(p, "path"));
+                    StartWatch(GetString(p, "path"), TryGetString(p, "git_dir"));
                     return JsonSerializer.SerializeToNode(new { });
 
                 case "watch_stop":
@@ -330,7 +330,7 @@ namespace SourceGit.Remote
             }
         }
 
-        private void StartWatch(string path)
+        private void StartWatch(string path, string gitDir = null)
         {
             lock (_watchers)
             {
@@ -358,6 +358,39 @@ namespace SourceGit.Remote
                 fsw.Renamed += (_, e) => OnWatchEvent(path, e.Name);
 
                 _watchers[path] = fsw;
+
+                // Also watch the .git directory (resolved gitDir) so that ref/worktree/index
+                // changes made from another terminal or tool are detected. For worktrees the
+                // .git dir lives outside the working tree, so the working-tree watcher alone
+                // would miss them.
+                if (!string.IsNullOrEmpty(gitDir))
+                {
+                    var resolved = ResolvePath(gitDir);
+                    if (resolved != path && !_watchers.ContainsKey(resolved))
+                    {
+                        FileSystemWatcher gitFsw;
+                        try
+                        {
+                            gitFsw = new FileSystemWatcher(resolved)
+                            {
+                                IncludeSubdirectories = true,
+                                NotifyFilter = NotifyFilters.FileName | NotifyFilters.DirectoryName | NotifyFilters.LastWrite,
+                                EnableRaisingEvents = true,
+                            };
+                        }
+                        catch
+                        {
+                            return;
+                        }
+
+                        gitFsw.Changed += (_, e) => OnWatchEvent(path, e.Name);
+                        gitFsw.Created += (_, e) => OnWatchEvent(path, e.Name);
+                        gitFsw.Deleted += (_, e) => OnWatchEvent(path, e.Name);
+                        gitFsw.Renamed += (_, e) => OnWatchEvent(path, e.Name);
+
+                        _watchers[resolved] = gitFsw;
+                    }
+                }
             }
         }
 

--- a/src/Remote/RpcServer.cs
+++ b/src/Remote/RpcServer.cs
@@ -111,6 +111,9 @@ namespace SourceGit.Remote
                 case "exec_git":
                     return JsonSerializer.SerializeToNode(await ExecGitAsync(p).ConfigureAwait(false));
 
+                case "exec_git_stream":
+                    return await ExecGitStreamAsync(p).ConfigureAwait(false);
+
                 case "file_exists":
                     return JsonValue.Create(File.Exists(GetString(p, "path")));
 
@@ -163,6 +166,73 @@ namespace SourceGit.Remote
 
         private static async Task<ExecGitResult> ExecGitAsync(JsonNode p)
         {
+            var (spec, stdin) = BuildGitSpec(p);
+
+            using var proc = LocalCommandRunner.Instance.Start(spec);
+
+            var stdoutTask = proc.Stdout.ReadToEndAsync();
+            var stderrTask = proc.Stderr.ReadToEndAsync();
+
+            if (stdin != null)
+            {
+                await proc.Stdin.WriteAsync(stdin).ConfigureAwait(false);
+                proc.Stdin.Close();
+            }
+
+            var stdout = await stdoutTask.ConfigureAwait(false);
+            var stderr = await stderrTask.ConfigureAwait(false);
+            await proc.WaitForExitAsync(CancellationToken.None).ConfigureAwait(false);
+
+            return new ExecGitResult { Stdout = stdout, Stderr = stderr, ExitCode = proc.ExitCode };
+        }
+
+        /// <summary>
+        /// Streaming variant of <c>exec_git</c>. Returns a stream id immediately, then pushes
+        /// <c>exec_git_stream_data</c> notifications (base64 chunks of stdout) followed by
+        /// <c>exec_git_stream_done</c> (exit code + stderr). This lets the client process large
+        /// git log/diff outputs incrementally instead of buffering one giant JSON string.
+        /// </summary>
+        private async Task<JsonNode> ExecGitStreamAsync(JsonNode p)
+        {
+            var (spec, stdin) = BuildGitSpec(p);
+            var streamId = Interlocked.Increment(ref _nextStreamId).ToString();
+
+            _ = Task.Run(() => StreamGitAsync(streamId, spec, stdin));
+            return JsonSerializer.SerializeToNode(new { stream_id = streamId });
+        }
+
+        private async Task StreamGitAsync(string streamId, Command.RunSpec spec, string stdin)
+        {
+            try
+            {
+                using var proc = LocalCommandRunner.Instance.Start(spec);
+
+                if (stdin != null)
+                {
+                    proc.Stdin.Write(stdin);
+                    proc.Stdin.Close();
+                }
+
+                var stderrTask = proc.Stderr.ReadToEndAsync();
+                var buf = new byte[64 * 1024];
+                int read;
+
+                while ((read = await proc.StdoutStream.ReadAsync(buf, 0, buf.Length).ConfigureAwait(false)) > 0)
+                    SendNotification("exec_git_stream_data", new { stream_id = streamId, data = Convert.ToBase64String(buf, 0, read) });
+
+                var stderr = await stderrTask.ConfigureAwait(false);
+                await proc.WaitForExitAsync(CancellationToken.None).ConfigureAwait(false);
+
+                SendNotification("exec_git_stream_done", new { stream_id = streamId, exit_code = proc.ExitCode, stderr });
+            }
+            catch (Exception e)
+            {
+                SendNotification("exec_git_stream_done", new { stream_id = streamId, exit_code = -1, stderr = e.Message });
+            }
+        }
+
+        private static (Command.RunSpec spec, string stdin) BuildGitSpec(JsonNode p)
+        {
             var args = GetString(p, "args");
             var workingDir = GetString(p, "working_dir");
             var sshKey = TryGetString(p, "ssh_key");
@@ -186,22 +256,7 @@ namespace SourceGit.Remote
                 Headless = true,
             };
 
-            using var proc = LocalCommandRunner.Instance.Start(spec);
-
-            var stdoutTask = proc.Stdout.ReadToEndAsync();
-            var stderrTask = proc.Stderr.ReadToEndAsync();
-
-            if (stdin != null)
-            {
-                await proc.Stdin.WriteAsync(stdin).ConfigureAwait(false);
-                proc.Stdin.Close();
-            }
-
-            var stdout = await stdoutTask.ConfigureAwait(false);
-            var stderr = await stderrTask.ConfigureAwait(false);
-            await proc.WaitForExitAsync(CancellationToken.None).ConfigureAwait(false);
-
-            return new ExecGitResult { Stdout = stdout, Stderr = stderr, ExitCode = proc.ExitCode };
+            return (spec, stdin);
         }
 
         private static string HomeDir()
@@ -350,5 +405,6 @@ namespace SourceGit.Remote
 
         private readonly object _sendLock = new();
         private readonly Dictionary<string, FileSystemWatcher> _watchers = new();
+        private static long _nextStreamId = 0;
     }
 }

--- a/src/Remote/RpcServer.cs
+++ b/src/Remote/RpcServer.cs
@@ -1,0 +1,202 @@
+using System;
+using System.IO;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Threading;
+using System.Threading.Tasks;
+
+using SourceGit.Commands;
+
+namespace SourceGit.Remote
+{
+    /// <summary>
+    /// Headless RPC server started by <c>sourcegit --remote-server</c>. Reads JSON-RPC
+    /// requests from stdin (one per line) and writes responses to stdout. It runs on the
+    /// remote host where the repository actually lives, so git is launched as a local
+    /// child process via <see cref="LocalCommandRunner"/> and files are accessed directly.
+    /// <para>
+    /// The server owns no GUI and no Avalonia lifetime; it blocks on stdin until the SSH
+    /// channel closes, then exits.
+    /// </para>
+    /// </summary>
+    public class RpcServer
+    {
+        public int Run()
+        {
+            try
+            {
+                Console.InputEncoding = Encoding.UTF8;
+                Console.OutputEncoding = Encoding.UTF8;
+            }
+            catch
+            {
+                // Encoding may be unavailable in some environments; the loop still works
+                // for ASCII content.
+            }
+
+            // The GUI path locates git via Preferences.PrepareGit(); the headless server
+            // never starts that path, so locate git explicitly before handling exec_git.
+            if (string.IsNullOrEmpty(Native.OS.GitExecutable) || !File.Exists(Native.OS.GitExecutable))
+                Native.OS.GitExecutable = Native.OS.FindGitExecutable();
+
+            while (Console.In.ReadLine() is { } line)
+            {
+                if (string.IsNullOrWhiteSpace(line))
+                    continue;
+
+                try
+                {
+                    ProcessLineAsync(line).GetAwaiter().GetResult();
+                }
+                catch (Exception e)
+                {
+                    // Keep serving even if a single message fails.
+                    Native.OS.LogException(e);
+                }
+            }
+
+            return 0;
+        }
+
+        private async Task ProcessLineAsync(string line)
+        {
+            Request req;
+            try
+            {
+                req = JsonSerializer.Deserialize<Request>(line);
+            }
+            catch
+            {
+                // Malformed input — nothing to correlate a response with, ignore.
+                return;
+            }
+
+            if (req == null || string.IsNullOrEmpty(req.Method))
+                return;
+
+            Response resp;
+            try
+            {
+                var result = await DispatchAsync(req).ConfigureAwait(false);
+                resp = new Response { Id = req.Id, Result = result };
+            }
+            catch (Exception e)
+            {
+                resp = new Response { Id = req.Id, Error = new RpcError { Code = -1, Message = e.Message } };
+            }
+
+            // Serialize and flush on the loop thread so messages stay whole-line ordered.
+            var json = JsonSerializer.Serialize(resp);
+            Console.Out.WriteLine(json);
+            Console.Out.Flush();
+        }
+
+        private async Task<JsonNode> DispatchAsync(Request req)
+        {
+            var p = req.Params;
+
+            switch (req.Method)
+            {
+                case "ping":
+                    return JsonSerializer.SerializeToNode(new { pong = true });
+
+                case "exec_git":
+                    return JsonSerializer.SerializeToNode(await ExecGitAsync(p).ConfigureAwait(false));
+
+                case "file_exists":
+                    return JsonValue.Create(File.Exists(GetString(p, "path")));
+
+                case "dir_exists":
+                    return JsonValue.Create(Directory.Exists(GetString(p, "path")));
+
+                case "read_file":
+                    return JsonSerializer.SerializeToNode(new { content = File.ReadAllText(GetString(p, "path")) });
+
+                case "write_file":
+                    File.WriteAllText(GetString(p, "path"), GetString(p, "content"));
+                    return JsonSerializer.SerializeToNode(new { });
+
+                case "delete_file":
+                    File.Delete(GetString(p, "path"));
+                    return JsonSerializer.SerializeToNode(new { });
+
+                case "delete_dir":
+                    Directory.Delete(GetString(p, "path"), GetBool(p, "recursive"));
+                    return JsonSerializer.SerializeToNode(new { });
+
+                case "get_temp_file":
+                    {
+                        var path = Path.GetTempFileName();
+                        File.WriteAllText(path, GetString(p, "content"));
+                        return JsonSerializer.SerializeToNode(new { path });
+                    }
+
+                default:
+                    throw new Exception($"unknown method: {req.Method}");
+            }
+        }
+
+        private static async Task<ExecGitResult> ExecGitAsync(JsonNode p)
+        {
+            var args = GetString(p, "args");
+            var workingDir = GetString(p, "working_dir");
+            var sshKey = TryGetString(p, "ssh_key");
+            var editorStr = TryGetString(p, "editor");
+            var stdin = TryGetString(p, "stdin");
+
+            var editor = Command.EditorType.None;
+            if (!string.IsNullOrEmpty(editorStr) &&
+                Enum.TryParse(editorStr, ignoreCase: true, out Command.EditorType et))
+            {
+                editor = et;
+            }
+
+            var spec = new Command.RunSpec
+            {
+                Args = args,
+                WorkingDirectory = workingDir,
+                SSHKey = sshKey ?? string.Empty,
+                Editor = editor,
+                RedirectStandardInput = stdin != null,
+            };
+
+            // Launch git locally (the server host *is* the repo host). The runner injects
+            // the same SSH askpass / GIT_SSH_COMMAND / locale env as the GUI client does.
+            // Note: askpass currently needs a GUI; fetch/push over SSH from the server is
+            // addressed in a later phase via an askpass callback over this same RPC channel.
+            using var proc = LocalCommandRunner.Instance.Start(spec);
+
+            // Read stdout/stderr concurrently to avoid pipe deadlocks on large output.
+            var stdoutTask = proc.Stdout.ReadToEndAsync();
+            var stderrTask = proc.Stderr.ReadToEndAsync();
+
+            if (stdin != null)
+            {
+                await proc.Stdin.WriteAsync(stdin).ConfigureAwait(false);
+                proc.Stdin.Close();
+            }
+
+            var stdout = await stdoutTask.ConfigureAwait(false);
+            var stderr = await stderrTask.ConfigureAwait(false);
+            await proc.WaitForExitAsync(CancellationToken.None).ConfigureAwait(false);
+
+            return new ExecGitResult { Stdout = stdout, Stderr = stderr, ExitCode = proc.ExitCode };
+        }
+
+        private static string GetString(JsonNode p, string name)
+        {
+            return p?[name]?.GetValue<string>() ?? throw new Exception($"missing param: {name}");
+        }
+
+        private static string TryGetString(JsonNode p, string name)
+        {
+            return p?[name]?.GetValue<string>();
+        }
+
+        private static bool GetBool(JsonNode p, string name)
+        {
+            return p?[name]?.GetValue<bool>() ?? throw new Exception($"missing param: {name}");
+        }
+    }
+}

--- a/src/Remote/RpcServer.cs
+++ b/src/Remote/RpcServer.cs
@@ -139,6 +139,12 @@ namespace SourceGit.Remote
                         return JsonSerializer.SerializeToNode(new { path });
                     }
 
+                case "home_dir":
+                    return JsonSerializer.SerializeToNode(new { path = HomeDir() });
+
+                case "list_dir":
+                    return JsonSerializer.SerializeToNode(ListDir(TryGetString(p, "path")));
+
                 case "watch_start":
                     StartWatch(GetString(p, "path"));
                     return JsonSerializer.SerializeToNode(new { });
@@ -193,6 +199,73 @@ namespace SourceGit.Remote
             await proc.WaitForExitAsync(CancellationToken.None).ConfigureAwait(false);
 
             return new ExecGitResult { Stdout = stdout, Stderr = stderr, ExitCode = proc.ExitCode };
+        }
+
+        private static string HomeDir()
+        {
+            var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+            return string.IsNullOrEmpty(home) ? "/" : home.Replace('\\', '/');
+        }
+
+        /// <summary>
+        /// List the sub-entries of a directory on the host so the client can browse for a
+        /// repository path. Expands <c>~</c>/empty to the home directory, resolves to an
+        /// absolute path and returns directories first. Entries that cannot be stat'd are
+        /// skipped rather than aborting the whole listing.
+        /// </summary>
+        private static ListDirResult ListDir(string path)
+        {
+            var resolved = ResolvePath(path);
+            var result = new ListDirResult { Path = resolved };
+
+            try
+            {
+                foreach (var dir in Directory.EnumerateDirectories(resolved))
+                {
+                    var name = Path.GetFileName(dir.TrimEnd('/'));
+                    if (!string.IsNullOrEmpty(name))
+                        result.Entries.Add(new ListDirEntry { Name = name, IsDir = true });
+                }
+
+                foreach (var file in Directory.EnumerateFiles(resolved))
+                {
+                    var name = Path.GetFileName(file);
+                    if (!string.IsNullOrEmpty(name))
+                        result.Entries.Add(new ListDirEntry { Name = name, IsDir = false });
+                }
+            }
+            catch
+            {
+                // Return whatever we managed to collect (possibly empty) for an unreadable dir.
+            }
+
+            result.Entries.Sort((l, r) =>
+            {
+                if (l.IsDir != r.IsDir)
+                    return l.IsDir ? -1 : 1;
+                return string.Compare(l.Name, r.Name, StringComparison.OrdinalIgnoreCase);
+            });
+
+            return result;
+        }
+
+        private static string ResolvePath(string path)
+        {
+            var home = HomeDir();
+            if (string.IsNullOrWhiteSpace(path) || path == "~" || path == ".")
+                return home;
+
+            if (path.StartsWith("~/", StringComparison.Ordinal))
+                path = home.TrimEnd('/') + path.Substring(1);
+
+            try
+            {
+                return Path.GetFullPath(path).Replace('\\', '/');
+            }
+            catch
+            {
+                return path.Replace('\\', '/');
+            }
         }
 
         private void StartWatch(string path)

--- a/src/Remote/RpcServer.cs
+++ b/src/Remote/RpcServer.cs
@@ -195,7 +195,11 @@ namespace SourceGit.Remote
         private async Task<JsonNode> ExecGitStreamAsync(JsonNode p)
         {
             var (spec, stdin) = BuildGitSpec(p);
-            var streamId = Interlocked.Increment(ref _nextStreamId).ToString();
+            // The client may supply its own stream id so it can register a handler before the
+            // server starts pushing data (avoids losing the first chunks to a race).
+            var streamId = TryGetString(p, "stream_id");
+            if (string.IsNullOrEmpty(streamId))
+                streamId = Interlocked.Increment(ref _nextStreamId).ToString();
 
             _ = Task.Run(() => StreamGitAsync(streamId, spec, stdin));
             return JsonSerializer.SerializeToNode(new { stream_id = streamId });

--- a/src/Remote/RpcServer.cs
+++ b/src/Remote/RpcServer.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using System.Text.Json;
@@ -12,12 +13,13 @@ namespace SourceGit.Remote
 {
     /// <summary>
     /// Headless RPC server started by <c>sourcegit --remote-server</c>. Reads JSON-RPC
-    /// requests from stdin (one per line) and writes responses to stdout. It runs on the
-    /// remote host where the repository actually lives, so git is launched as a local
-    /// child process via <see cref="LocalCommandRunner"/> and files are accessed directly.
+    /// requests from stdin and writes responses to stdout, blocking until the SSH channel
+    /// closes. It runs on the remote host where the repository lives, so git is launched as a
+    /// local child process and files are accessed directly.
     /// <para>
-    /// The server owns no GUI and no Avalonia lifetime; it blocks on stdin until the SSH
-    /// channel closes, then exits.
+    /// Also supports <c>watch_start</c>/<c>watch_stop</c>: a <see cref="FileSystemWatcher"/> is
+    /// started on the remote working tree and change events are pushed back to the client as
+    /// <c>watch_event</c> notifications so the client can auto-refresh a remote repository.
     /// </para>
     /// </summary>
     public class RpcServer
@@ -31,12 +33,8 @@ namespace SourceGit.Remote
             }
             catch
             {
-                // Encoding may be unavailable in some environments; the loop still works
-                // for ASCII content.
             }
 
-            // The GUI path locates git via Preferences.PrepareGit(); the headless server
-            // never starts that path, so locate git explicitly before handling exec_git.
             if (string.IsNullOrEmpty(Native.OS.GitExecutable) || !File.Exists(Native.OS.GitExecutable))
                 Native.OS.GitExecutable = Native.OS.FindGitExecutable();
 
@@ -51,9 +49,17 @@ namespace SourceGit.Remote
                 }
                 catch (Exception e)
                 {
-                    // Keep serving even if a single message fails.
                     Native.OS.LogException(e);
                 }
+            }
+
+            lock (_watchers)
+            {
+                foreach (var kv in _watchers)
+                {
+                    try { kv.Value.EnableRaisingEvents = false; kv.Value.Dispose(); } catch { }
+                }
+                _watchers.Clear();
             }
 
             return 0;
@@ -68,7 +74,6 @@ namespace SourceGit.Remote
             }
             catch
             {
-                // Malformed input — nothing to correlate a response with, ignore.
                 return;
             }
 
@@ -86,10 +91,12 @@ namespace SourceGit.Remote
                 resp = new Response { Id = req.Id, Error = new RpcError { Code = -1, Message = e.Message } };
             }
 
-            // Serialize and flush on the loop thread so messages stay whole-line ordered.
             var json = JsonSerializer.Serialize(resp);
-            Console.Out.WriteLine(json);
-            Console.Out.Flush();
+            lock (_sendLock)
+            {
+                Console.Out.WriteLine(json);
+                Console.Out.Flush();
+            }
         }
 
         private async Task<JsonNode> DispatchAsync(Request req)
@@ -132,6 +139,14 @@ namespace SourceGit.Remote
                         return JsonSerializer.SerializeToNode(new { path });
                     }
 
+                case "watch_start":
+                    StartWatch(GetString(p, "path"));
+                    return JsonSerializer.SerializeToNode(new { });
+
+                case "watch_stop":
+                    StopWatch(GetString(p, "path"));
+                    return JsonSerializer.SerializeToNode(new { });
+
                 default:
                     throw new Exception($"unknown method: {req.Method}");
             }
@@ -162,13 +177,8 @@ namespace SourceGit.Remote
                 Headless = true,
             };
 
-            // Launch git locally (the server host *is* the repo host). The runner injects
-            // the same SSH askpass / GIT_SSH_COMMAND / locale env as the GUI client does.
-            // Note: askpass currently needs a GUI; fetch/push over SSH from the server is
-            // addressed in a later phase via an askpass callback over this same RPC channel.
             using var proc = LocalCommandRunner.Instance.Start(spec);
 
-            // Read stdout/stderr concurrently to avoid pipe deadlocks on large output.
             var stdoutTask = proc.Stdout.ReadToEndAsync();
             var stderrTask = proc.Stderr.ReadToEndAsync();
 
@@ -185,6 +195,68 @@ namespace SourceGit.Remote
             return new ExecGitResult { Stdout = stdout, Stderr = stderr, ExitCode = proc.ExitCode };
         }
 
+        private void StartWatch(string path)
+        {
+            lock (_watchers)
+            {
+                if (_watchers.ContainsKey(path))
+                    return;
+
+                FileSystemWatcher fsw;
+                try
+                {
+                    fsw = new FileSystemWatcher(path)
+                    {
+                        IncludeSubdirectories = true,
+                        NotifyFilter = NotifyFilters.FileName | NotifyFilters.DirectoryName | NotifyFilters.LastWrite,
+                        EnableRaisingEvents = true,
+                    };
+                }
+                catch
+                {
+                    return;
+                }
+
+                fsw.Changed += (_, e) => OnWatchEvent(path, e.Name);
+                fsw.Created += (_, e) => OnWatchEvent(path, e.Name);
+                fsw.Deleted += (_, e) => OnWatchEvent(path, e.Name);
+                fsw.Renamed += (_, e) => OnWatchEvent(path, e.Name);
+
+                _watchers[path] = fsw;
+            }
+        }
+
+        private void StopWatch(string path)
+        {
+            lock (_watchers)
+            {
+                if (_watchers.TryGetValue(path, out var fsw))
+                {
+                    try { fsw.EnableRaisingEvents = false; fsw.Dispose(); } catch { }
+                    _watchers.Remove(path);
+                }
+            }
+        }
+
+        private void OnWatchEvent(string path, string file)
+        {
+            SendNotification("watch_event", new { path, file });
+        }
+
+        private void SendNotification(string method, object parameters)
+        {
+            var notif = JsonSerializer.Serialize(new Notification
+            {
+                Method = method,
+                Params = JsonSerializer.SerializeToNode(parameters),
+            });
+
+            lock (_sendLock)
+            {
+                try { Console.Out.WriteLine(notif); Console.Out.Flush(); } catch { }
+            }
+        }
+
         private static string GetString(JsonNode p, string name)
         {
             return p?[name]?.GetValue<string>() ?? throw new Exception($"missing param: {name}");
@@ -199,5 +271,8 @@ namespace SourceGit.Remote
         {
             return p?[name]?.GetValue<bool>() ?? throw new Exception($"missing param: {name}");
         }
+
+        private readonly object _sendLock = new();
+        private readonly Dictionary<string, FileSystemWatcher> _watchers = new();
     }
 }

--- a/src/Remote/SshConfigParser.cs
+++ b/src/Remote/SshConfigParser.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace SourceGit.Remote
+{
+    /// <summary>
+    /// Reads host aliases from the user's ~/.ssh/config so the SSH Remote dialog can offer
+    /// them in a dropdown (carrying ProxyJump/identity/agent/passwordless as configured).
+    /// </summary>
+    public static class SshConfigParser
+    {
+        public static List<string> GetHosts()
+        {
+            var hosts = new List<string>();
+            var path = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".ssh", "config");
+            if (!File.Exists(path))
+                return hosts;
+
+            try
+            {
+                foreach (var raw in File.ReadAllLines(path))
+                {
+                    var line = raw.Trim();
+                    if (!line.StartsWith("Host ", StringComparison.OrdinalIgnoreCase))
+                        continue;
+
+                    foreach (var name in line.Substring(5).Split(' ', StringSplitOptions.RemoveEmptyEntries))
+                    {
+                        if (name.Contains('*') || name.Contains('?'))
+                            continue;
+                        if (!hosts.Contains(name))
+                            hosts.Add(name);
+                    }
+                }
+            }
+            catch
+            {
+                // ignore
+            }
+
+            return hosts;
+        }
+    }
+}

--- a/src/Resources/Locales/en_US.axaml
+++ b/src/Resources/Locales/en_US.axaml
@@ -628,11 +628,14 @@
   <x:String x:Key="Text.OpenLocalRepository" xml:space="preserve">Open Local Repository</x:String>
   <x:String x:Key="Text.OpenLocalRepository.Bookmark" xml:space="preserve">Bookmark:</x:String>
   <x:String x:Key="Text.OpenLocalRepository.Group" xml:space="preserve">Group:</x:String>
-  <x:String x:Key="Text.OpenLocalRepository.Path" xml:space="preserve">Folder:</x:String>
-  <x:String x:Key="Text.OpenLocalRepository.SSHRemote" xml:space="preserve">SSH Remote</x:String>
   <x:String x:Key="Text.OpenLocalRepository.Host" xml:space="preserve">Host:</x:String>
-  <x:String x:Key="Text.OpenLocalRepository.RemoteServerPath" xml:space="preserve">Remote SourceGit Path:</x:String>
-  <x:String x:Key="Text.OpenLocalRepository.RemotePath" xml:space="preserve">Remote Repository Path:</x:String>
+  <x:String x:Key="Text.OpenLocalRepository.LocalHost" xml:space="preserve">Local Machine</x:String>
+  <x:String x:Key="Text.OpenLocalRepository.Path" xml:space="preserve">Folder:</x:String>
+  <x:String x:Key="Text.OpenLocalRepository.RemotePath" xml:space="preserve">Remote Folder:</x:String>
+  <x:String x:Key="Text.OpenLocalRepository.RemotePath.Placeholder" xml:space="preserve">Path on the remote host</x:String>
+  <x:String x:Key="Text.OpenLocalRepository.Invalid.LocalPath" xml:space="preserve">The given folder can not be found.</x:String>
+  <x:String x:Key="Text.OpenLocalRepository.Invalid.RemotePath" xml:space="preserve">Remote folder is required.</x:String>
+  <x:String x:Key="Text.OpenLocalRepository.Invalid.NotConnected" xml:space="preserve">The selected remote host is not connected.</x:String>
   <x:String x:Key="Text.Optional" xml:space="preserve">Optional.</x:String>
   <x:String x:Key="Text.PageTabBar.New" xml:space="preserve">Create New Tab</x:String>
   <x:String x:Key="Text.PageTabBar.Tab.Close" xml:space="preserve">Close Tab</x:String>
@@ -722,6 +725,18 @@
   <x:String x:Key="Text.Preferences.GPG.UserKey" xml:space="preserve">User Signing Key</x:String>
   <x:String x:Key="Text.Preferences.GPG.UserKey.Placeholder" xml:space="preserve">User's gpg signing key</x:String>
   <x:String x:Key="Text.Preferences.Integration" xml:space="preserve">INTEGRATION</x:String>
+  <x:String x:Key="Text.Preferences.RemoteHosts" xml:space="preserve">REMOTE HOSTS</x:String>
+  <x:String x:Key="Text.Preferences.RemoteHosts.Add" xml:space="preserve">Add host</x:String>
+  <x:String x:Key="Text.Preferences.RemoteHosts.Connect" xml:space="preserve">Connect</x:String>
+  <x:String x:Key="Text.Preferences.RemoteHosts.Disconnect" xml:space="preserve">Disconnect</x:String>
+  <x:String x:Key="Text.Preferences.RemoteHosts.FromConfig" xml:space="preserve">From SSH config</x:String>
+  <x:String x:Key="Text.Preferences.RemoteHosts.Host" xml:space="preserve">Host (SSH)</x:String>
+  <x:String x:Key="Text.Preferences.RemoteHosts.HostPlaceholder" xml:space="preserve">user@host or a ~/.ssh/config alias</x:String>
+  <x:String x:Key="Text.Preferences.RemoteHosts.Name" xml:space="preserve">Name</x:String>
+  <x:String x:Key="Text.Preferences.RemoteHosts.Remove" xml:space="preserve">Remove host</x:String>
+  <x:String x:Key="Text.Preferences.RemoteHosts.Reset" xml:space="preserve">Reset</x:String>
+  <x:String x:Key="Text.Preferences.RemoteHosts.Status" xml:space="preserve">Status</x:String>
+  <x:String x:Key="Text.Preferences.RemoteHosts.Test" xml:space="preserve">Test</x:String>
   <x:String x:Key="Text.Preferences.Shell" xml:space="preserve">SHELL/TERMINAL</x:String>
   <x:String x:Key="Text.Preferences.Shell.Args" xml:space="preserve">Arguments</x:String>
   <x:String x:Key="Text.Preferences.Shell.Args.Tip" xml:space="preserve">Please use '.' to indicate working directory</x:String>
@@ -779,6 +794,11 @@
   <x:String x:Key="Text.RemoteCM.Fetch" xml:space="preserve">Fetch</x:String>
   <x:String x:Key="Text.RemoteCM.OpenInBrowser" xml:space="preserve">Open In Browser</x:String>
   <x:String x:Key="Text.RemoteCM.Prune" xml:space="preserve">Prune</x:String>
+  <x:String x:Key="Text.RemoteFolderPicker" xml:space="preserve">Select Remote Folder</x:String>
+  <x:String x:Key="Text.RemoteFolderPicker.Home" xml:space="preserve">Home</x:String>
+  <x:String x:Key="Text.RemoteFolderPicker.Loading" xml:space="preserve">Loading...</x:String>
+  <x:String x:Key="Text.RemoteFolderPicker.PathPlaceholder" xml:space="preserve">Remote path</x:String>
+  <x:String x:Key="Text.RemoteFolderPicker.Up" xml:space="preserve">Up</x:String>
   <x:String x:Key="Text.RemoveWorktree" xml:space="preserve">Confirm to Remove Worktree</x:String>
   <x:String x:Key="Text.RemoveWorktree.Force" xml:space="preserve">Enable `--force` Option</x:String>
   <x:String x:Key="Text.RemoveWorktree.Target" xml:space="preserve">Target:</x:String>

--- a/src/Resources/Locales/en_US.axaml
+++ b/src/Resources/Locales/en_US.axaml
@@ -582,6 +582,7 @@
   <x:String x:Key="Text.Launcher.Info" xml:space="preserve">NOTICE</x:String>
   <x:String x:Key="Text.Launcher.OpenRepository" xml:space="preserve">Open Repositories</x:String>
   <x:String x:Key="Text.Launcher.Pages" xml:space="preserve">Tabs</x:String>
+  <x:String x:Key="Text.Launcher.RemoteRepository.Loading" xml:space="preserve">Connecting to ${0}$ ...</x:String>
   <x:String x:Key="Text.Launcher.Workspaces" xml:space="preserve">Workspaces</x:String>
   <x:String x:Key="Text.Merge" xml:space="preserve">Merge Branch</x:String>
   <x:String x:Key="Text.Merge.Edit" xml:space="preserve">Customize merge message</x:String>

--- a/src/Resources/Locales/en_US.axaml
+++ b/src/Resources/Locales/en_US.axaml
@@ -629,6 +629,10 @@
   <x:String x:Key="Text.OpenLocalRepository.Bookmark" xml:space="preserve">Bookmark:</x:String>
   <x:String x:Key="Text.OpenLocalRepository.Group" xml:space="preserve">Group:</x:String>
   <x:String x:Key="Text.OpenLocalRepository.Path" xml:space="preserve">Folder:</x:String>
+  <x:String x:Key="Text.OpenLocalRepository.SSHRemote" xml:space="preserve">SSH Remote</x:String>
+  <x:String x:Key="Text.OpenLocalRepository.Host" xml:space="preserve">Host:</x:String>
+  <x:String x:Key="Text.OpenLocalRepository.RemoteServerPath" xml:space="preserve">Remote SourceGit Path:</x:String>
+  <x:String x:Key="Text.OpenLocalRepository.RemotePath" xml:space="preserve">Remote Repository Path:</x:String>
   <x:String x:Key="Text.Optional" xml:space="preserve">Optional.</x:String>
   <x:String x:Key="Text.PageTabBar.New" xml:space="preserve">Create New Tab</x:String>
   <x:String x:Key="Text.PageTabBar.Tab.Close" xml:space="preserve">Close Tab</x:String>

--- a/src/Resources/Locales/zh_CN.axaml
+++ b/src/Resources/Locales/zh_CN.axaml
@@ -632,6 +632,10 @@
   <x:String x:Key="Text.OpenLocalRepository.Bookmark" xml:space="preserve">书签 ：</x:String>
   <x:String x:Key="Text.OpenLocalRepository.Group" xml:space="preserve">分组 ：</x:String>
   <x:String x:Key="Text.OpenLocalRepository.Path" xml:space="preserve">仓库位置 ：</x:String>
+  <x:String x:Key="Text.OpenLocalRepository.SSHRemote" xml:space="preserve">SSH 远程</x:String>
+  <x:String x:Key="Text.OpenLocalRepository.Host" xml:space="preserve">主机 ：</x:String>
+  <x:String x:Key="Text.OpenLocalRepository.RemoteServerPath" xml:space="preserve">远端 SourceGit 路径 ：</x:String>
+  <x:String x:Key="Text.OpenLocalRepository.RemotePath" xml:space="preserve">远端仓库路径 ：</x:String>
   <x:String x:Key="Text.Optional" xml:space="preserve">选填。</x:String>
   <x:String x:Key="Text.PageTabBar.New" xml:space="preserve">新建空白页</x:String>
   <x:String x:Key="Text.PageTabBar.Tab.Close" xml:space="preserve">关闭标签页</x:String>

--- a/src/Resources/Locales/zh_CN.axaml
+++ b/src/Resources/Locales/zh_CN.axaml
@@ -585,6 +585,7 @@
   <x:String x:Key="Text.Launcher.Info" xml:space="preserve">系统提示</x:String>
   <x:String x:Key="Text.Launcher.OpenRepository" xml:space="preserve">打开其他仓库</x:String>
   <x:String x:Key="Text.Launcher.Pages" xml:space="preserve">页面列表</x:String>
+  <x:String x:Key="Text.Launcher.RemoteRepository.Loading" xml:space="preserve">正在连接 ${0}$ ...</x:String>
   <x:String x:Key="Text.Launcher.Workspaces" xml:space="preserve">工作区列表</x:String>
   <x:String x:Key="Text.Merge" xml:space="preserve">合并分支</x:String>
   <x:String x:Key="Text.Merge.Edit" xml:space="preserve">编辑合并信息</x:String>

--- a/src/Resources/Locales/zh_CN.axaml
+++ b/src/Resources/Locales/zh_CN.axaml
@@ -631,11 +631,14 @@
   <x:String x:Key="Text.OpenLocalRepository" xml:space="preserve">打开本地仓库</x:String>
   <x:String x:Key="Text.OpenLocalRepository.Bookmark" xml:space="preserve">书签 ：</x:String>
   <x:String x:Key="Text.OpenLocalRepository.Group" xml:space="preserve">分组 ：</x:String>
-  <x:String x:Key="Text.OpenLocalRepository.Path" xml:space="preserve">仓库位置 ：</x:String>
-  <x:String x:Key="Text.OpenLocalRepository.SSHRemote" xml:space="preserve">SSH 远程</x:String>
   <x:String x:Key="Text.OpenLocalRepository.Host" xml:space="preserve">主机 ：</x:String>
-  <x:String x:Key="Text.OpenLocalRepository.RemoteServerPath" xml:space="preserve">远端 SourceGit 路径 ：</x:String>
-  <x:String x:Key="Text.OpenLocalRepository.RemotePath" xml:space="preserve">远端仓库路径 ：</x:String>
+  <x:String x:Key="Text.OpenLocalRepository.LocalHost" xml:space="preserve">本机</x:String>
+  <x:String x:Key="Text.OpenLocalRepository.Path" xml:space="preserve">仓库位置 ：</x:String>
+  <x:String x:Key="Text.OpenLocalRepository.RemotePath" xml:space="preserve">远端文件夹 ：</x:String>
+  <x:String x:Key="Text.OpenLocalRepository.RemotePath.Placeholder" xml:space="preserve">远程主机上的路径</x:String>
+  <x:String x:Key="Text.OpenLocalRepository.Invalid.LocalPath" xml:space="preserve">找不到指定的文件夹。</x:String>
+  <x:String x:Key="Text.OpenLocalRepository.Invalid.RemotePath" xml:space="preserve">请填写远端文件夹路径。</x:String>
+  <x:String x:Key="Text.OpenLocalRepository.Invalid.NotConnected" xml:space="preserve">所选远程主机尚未连接。</x:String>
   <x:String x:Key="Text.Optional" xml:space="preserve">选填。</x:String>
   <x:String x:Key="Text.PageTabBar.New" xml:space="preserve">新建空白页</x:String>
   <x:String x:Key="Text.PageTabBar.Tab.Close" xml:space="preserve">关闭标签页</x:String>
@@ -725,6 +728,18 @@
   <x:String x:Key="Text.Preferences.GPG.UserKey" xml:space="preserve">用户签名KEY</x:String>
   <x:String x:Key="Text.Preferences.GPG.UserKey.Placeholder" xml:space="preserve">输入签名提交所使用的KEY</x:String>
   <x:String x:Key="Text.Preferences.Integration" xml:space="preserve">第三方工具集成</x:String>
+  <x:String x:Key="Text.Preferences.RemoteHosts" xml:space="preserve">远程主机</x:String>
+  <x:String x:Key="Text.Preferences.RemoteHosts.Add" xml:space="preserve">添加主机</x:String>
+  <x:String x:Key="Text.Preferences.RemoteHosts.Connect" xml:space="preserve">连接</x:String>
+  <x:String x:Key="Text.Preferences.RemoteHosts.Disconnect" xml:space="preserve">断开连接</x:String>
+  <x:String x:Key="Text.Preferences.RemoteHosts.FromConfig" xml:space="preserve">从 SSH 配置选择</x:String>
+  <x:String x:Key="Text.Preferences.RemoteHosts.Host" xml:space="preserve">主机 (SSH)</x:String>
+  <x:String x:Key="Text.Preferences.RemoteHosts.HostPlaceholder" xml:space="preserve">user@host 或 ~/.ssh/config 中的别名</x:String>
+  <x:String x:Key="Text.Preferences.RemoteHosts.Name" xml:space="preserve">名称</x:String>
+  <x:String x:Key="Text.Preferences.RemoteHosts.Remove" xml:space="preserve">删除主机</x:String>
+  <x:String x:Key="Text.Preferences.RemoteHosts.Reset" xml:space="preserve">重置</x:String>
+  <x:String x:Key="Text.Preferences.RemoteHosts.Status" xml:space="preserve">状态</x:String>
+  <x:String x:Key="Text.Preferences.RemoteHosts.Test" xml:space="preserve">测试</x:String>
   <x:String x:Key="Text.Preferences.Shell" xml:space="preserve">终端/SHELL</x:String>
   <x:String x:Key="Text.Preferences.Shell.Args" xml:space="preserve">启动参数</x:String>
   <x:String x:Key="Text.Preferences.Shell.Args.Tip" xml:space="preserve">请使用 '.' 来指定工作目录</x:String>
@@ -782,6 +797,11 @@
   <x:String x:Key="Text.RemoteCM.Fetch" xml:space="preserve">拉取(fetch)更新</x:String>
   <x:String x:Key="Text.RemoteCM.OpenInBrowser" xml:space="preserve">在浏览器中打开</x:String>
   <x:String x:Key="Text.RemoteCM.Prune" xml:space="preserve">清理远程已删除分支</x:String>
+  <x:String x:Key="Text.RemoteFolderPicker" xml:space="preserve">选择远程文件夹</x:String>
+  <x:String x:Key="Text.RemoteFolderPicker.Home" xml:space="preserve">主目录</x:String>
+  <x:String x:Key="Text.RemoteFolderPicker.Loading" xml:space="preserve">加载中...</x:String>
+  <x:String x:Key="Text.RemoteFolderPicker.PathPlaceholder" xml:space="preserve">远程路径</x:String>
+  <x:String x:Key="Text.RemoteFolderPicker.Up" xml:space="preserve">上一级</x:String>
   <x:String x:Key="Text.RemoveWorktree" xml:space="preserve">移除工作树操作确认</x:String>
   <x:String x:Key="Text.RemoveWorktree.Force" xml:space="preserve">启用`--force`选项</x:String>
   <x:String x:Key="Text.RemoveWorktree.Target" xml:space="preserve">目标工作树 ：</x:String>

--- a/src/ViewModels/Apply.cs
+++ b/src/ViewModels/Apply.cs
@@ -98,7 +98,7 @@ namespace SourceGit.ViewModels
             Use(log);
 
             var extra = ThreeWayMerge ? "--3way" : string.Empty;
-            var succ = await new Commands.Apply(_repo.FullPath, finalPatchFile, _ignoreWhiteSpace, SelectedWhiteSpaceMode.Arg, extra)
+            var succ = await new Commands.Apply(_repo.FullPath, File.ReadAllText(finalPatchFile), _ignoreWhiteSpace, SelectedWhiteSpaceMode.Arg, extra)
                 .Use(log)
                 .ExecAsync();
 

--- a/src/ViewModels/CommitDetail.cs
+++ b/src/ViewModels/CommitDetail.cs
@@ -263,7 +263,7 @@ namespace SourceGit.ViewModels
             if (change.Index == Models.ChangeState.Deleted)
             {
                 var fullpath = Native.OS.GetAbsPath(_repo.FullPath, change.Path);
-                if (File.Exists(fullpath))
+                if (_repo.FileSystem.FileExists(fullpath))
                     await new Commands.Remove(_repo.FullPath, [change.Path])
                         .Use(log)
                         .ExecAsync();
@@ -271,7 +271,7 @@ namespace SourceGit.ViewModels
             else if (change.Index == Models.ChangeState.Renamed)
             {
                 var old = Native.OS.GetAbsPath(_repo.FullPath, change.OriginalPath);
-                if (File.Exists(old))
+                if (_repo.FileSystem.FileExists(old))
                     await new Commands.Remove(_repo.FullPath, [change.OriginalPath])
                         .Use(log)
                         .ExecAsync();
@@ -297,7 +297,7 @@ namespace SourceGit.ViewModels
             if (change.Index == Models.ChangeState.Added)
             {
                 var fullpath = Native.OS.GetAbsPath(_repo.FullPath, change.Path);
-                if (File.Exists(fullpath))
+                if (_repo.FileSystem.FileExists(fullpath))
                     await new Commands.Remove(_repo.FullPath, [change.Path])
                         .Use(log)
                         .ExecAsync();
@@ -305,7 +305,7 @@ namespace SourceGit.ViewModels
             else if (change.Index == Models.ChangeState.Renamed)
             {
                 var renamed = Native.OS.GetAbsPath(_repo.FullPath, change.Path);
-                if (File.Exists(renamed))
+                if (_repo.FileSystem.FileExists(renamed))
                     await new Commands.Remove(_repo.FullPath, [change.Path])
                         .Use(log)
                         .ExecAsync();
@@ -334,13 +334,13 @@ namespace SourceGit.ViewModels
                 if (c.Index == Models.ChangeState.Deleted)
                 {
                     var fullpath = Native.OS.GetAbsPath(_repo.FullPath, c.Path);
-                    if (File.Exists(fullpath))
+                    if (_repo.FileSystem.FileExists(fullpath))
                         removes.Add(c.Path);
                 }
                 else if (c.Index == Models.ChangeState.Renamed)
                 {
                     var old = Native.OS.GetAbsPath(_repo.FullPath, c.OriginalPath);
-                    if (File.Exists(old))
+                    if (_repo.FileSystem.FileExists(old))
                         removes.Add(c.OriginalPath);
 
                     checkouts.Add(c.Path);
@@ -376,13 +376,13 @@ namespace SourceGit.ViewModels
                 if (c.Index == Models.ChangeState.Added)
                 {
                     var fullpath = Native.OS.GetAbsPath(_repo.FullPath, c.Path);
-                    if (File.Exists(fullpath))
+                    if (_repo.FileSystem.FileExists(fullpath))
                         removes.Add(c.Path);
                 }
                 else if (c.Index == Models.ChangeState.Renamed)
                 {
                     var renamed = Native.OS.GetAbsPath(_repo.FullPath, c.Path);
-                    if (File.Exists(renamed))
+                    if (_repo.FileSystem.FileExists(renamed))
                         removes.Add(c.Path);
 
                     checkouts.Add(c.OriginalPath);

--- a/src/ViewModels/Compare.cs
+++ b/src/ViewModels/Compare.cs
@@ -164,13 +164,13 @@ namespace SourceGit.ViewModels
             if (change.Index == Models.ChangeState.Added)
             {
                 var fullpath = Native.OS.GetAbsPath(_repo.FullPath, change.Path);
-                if (File.Exists(fullpath))
+                if (_repo.FileSystem.FileExists(fullpath))
                     await new Commands.Remove(_repo.FullPath, [change.Path]).ExecAsync();
             }
             else if (change.Index == Models.ChangeState.Renamed)
             {
                 var renamed = Native.OS.GetAbsPath(_repo.FullPath, change.Path);
-                if (File.Exists(renamed))
+                if (_repo.FileSystem.FileExists(renamed))
                     await new Commands.Remove(_repo.FullPath, [change.Path]).ExecAsync();
 
                 await new Commands.Checkout(_repo.FullPath).FileWithRevisionAsync(change.OriginalPath, _baseHead.SHA);
@@ -186,13 +186,13 @@ namespace SourceGit.ViewModels
             if (change.Index == Models.ChangeState.Deleted)
             {
                 var fullpath = Native.OS.GetAbsPath(_repo.FullPath, change.Path);
-                if (File.Exists(fullpath))
+                if (_repo.FileSystem.FileExists(fullpath))
                     await new Commands.Remove(_repo.FullPath, [change.Path]).ExecAsync();
             }
             else if (change.Index == Models.ChangeState.Renamed)
             {
                 var old = Native.OS.GetAbsPath(_repo.FullPath, change.OriginalPath);
-                if (File.Exists(old))
+                if (_repo.FileSystem.FileExists(old))
                     await new Commands.Remove(_repo.FullPath, [change.OriginalPath]).ExecAsync();
 
                 await new Commands.Checkout(_repo.FullPath).FileWithRevisionAsync(change.Path, ToHead.SHA);
@@ -213,13 +213,13 @@ namespace SourceGit.ViewModels
                 if (c.Index == Models.ChangeState.Added)
                 {
                     var fullpath = Native.OS.GetAbsPath(_repo.FullPath, c.Path);
-                    if (File.Exists(fullpath))
+                    if (_repo.FileSystem.FileExists(fullpath))
                         removes.Add(c.Path);
                 }
                 else if (c.Index == Models.ChangeState.Renamed)
                 {
                     var old = Native.OS.GetAbsPath(_repo.FullPath, c.Path);
-                    if (File.Exists(old))
+                    if (_repo.FileSystem.FileExists(old))
                         removes.Add(c.Path);
 
                     checkouts.Add(c.OriginalPath);
@@ -247,13 +247,13 @@ namespace SourceGit.ViewModels
                 if (c.Index == Models.ChangeState.Deleted)
                 {
                     var fullpath = Native.OS.GetAbsPath(_repo.FullPath, c.Path);
-                    if (File.Exists(fullpath))
+                    if (_repo.FileSystem.FileExists(fullpath))
                         removes.Add(c.Path);
                 }
                 else if (c.Index == Models.ChangeState.Renamed)
                 {
                     var renamed = Native.OS.GetAbsPath(_repo.FullPath, c.OriginalPath);
-                    if (File.Exists(renamed))
+                    if (_repo.FileSystem.FileExists(renamed))
                         removes.Add(c.OriginalPath);
 
                     checkouts.Add(c.Path);

--- a/src/ViewModels/InProgressContexts.cs
+++ b/src/ViewModels/InProgressContexts.cs
@@ -78,7 +78,7 @@ namespace SourceGit.ViewModels
                 Args = "cherry-pick --abort",
             };
 
-            var headSHA = File.ReadAllText(Path.Combine(repo.GitDir, "CHERRY_PICK_HEAD")).Trim();
+            var headSHA = repo.FileSystem.ReadAllText(Path.Combine(repo.GitDir, "CHERRY_PICK_HEAD")).Trim();
             Head = new Commands.QuerySingleCommit(repo.FullPath, headSHA).GetResult() ?? new Models.Commit() { SHA = headSHA };
             HeadName = Head.GetFriendlyName();
         }
@@ -109,6 +109,7 @@ namespace SourceGit.ViewModels
         public RebaseInProgress(Repository repo)
         {
             _gitDir = repo.GitDir;
+            _fs = repo.FileSystem;
             Name = "Rebase";
 
             _continueCmd = new Commands.Command
@@ -134,21 +135,21 @@ namespace SourceGit.ViewModels
                 RaiseError = false,
             };
 
-            HeadName = File.ReadAllText(Path.Combine(repo.GitDir, "rebase-merge", "head-name")).Trim();
+            HeadName = repo.FileSystem.ReadAllText(Path.Combine(repo.GitDir, "rebase-merge", "head-name")).Trim();
             if (HeadName.StartsWith("refs/heads/"))
                 HeadName = HeadName.Substring(11);
             else if (HeadName.StartsWith("refs/tags/"))
                 HeadName = HeadName.Substring(10);
 
             var stoppedSHAPath = Path.Combine(repo.GitDir, "rebase-merge", "stopped-sha");
-            var stoppedSHA = File.Exists(stoppedSHAPath)
-                ? File.ReadAllText(stoppedSHAPath).Trim()
+            var stoppedSHA = repo.FileSystem.FileExists(stoppedSHAPath)
+                ? repo.FileSystem.ReadAllText(stoppedSHAPath).Trim()
                 : new Commands.QueryRevisionByRefName(repo.FullPath, HeadName).GetResult();
 
             if (!string.IsNullOrEmpty(stoppedSHA))
                 StoppedAt = new Commands.QuerySingleCommit(repo.FullPath, stoppedSHA).GetResult() ?? new Models.Commit() { SHA = stoppedSHA };
 
-            var ontoSHA = File.ReadAllText(Path.Combine(repo.GitDir, "rebase-merge", "onto")).Trim();
+            var ontoSHA = repo.FileSystem.ReadAllText(Path.Combine(repo.GitDir, "rebase-merge", "onto")).Trim();
             Onto = new Commands.QuerySingleCommit(repo.FullPath, ontoSHA).GetResult() ?? new Models.Commit() { SHA = ontoSHA };
             BaseName = Onto.GetFriendlyName();
         }
@@ -156,19 +157,20 @@ namespace SourceGit.ViewModels
         protected override void OnAborted()
         {
             var rebaseMergeDir = Path.Combine(_gitDir, "rebase-merge");
-            if (Directory.Exists(rebaseMergeDir))
-                Directory.Delete(rebaseMergeDir, true);
+            if (_fs.DirectoryExists(rebaseMergeDir))
+                _fs.DeleteDirectory(rebaseMergeDir, true);
 
             var rebaseApplyDir = Path.Combine(_gitDir, "rebase-apply");
-            if (Directory.Exists(rebaseApplyDir))
-                Directory.Delete(rebaseApplyDir, true);
+            if (_fs.DirectoryExists(rebaseApplyDir))
+                _fs.DeleteDirectory(rebaseApplyDir, true);
 
             var jobFile = Path.Combine(_gitDir, "sourcegit.interactive_rebase");
-            if (File.Exists(jobFile))
-                File.Delete(jobFile);
+            if (_fs.FileExists(jobFile))
+                _fs.DeleteFile(jobFile);
         }
 
         private readonly string _gitDir;
+        private readonly Models.IFileSystem _fs;
     }
 
     public class RevertInProgress : InProgressContext
@@ -204,7 +206,7 @@ namespace SourceGit.ViewModels
                 Args = "revert --abort",
             };
 
-            var headSHA = File.ReadAllText(Path.Combine(repo.GitDir, "REVERT_HEAD")).Trim();
+            var headSHA = repo.FileSystem.ReadAllText(Path.Combine(repo.GitDir, "REVERT_HEAD")).Trim();
             Head = new Commands.QuerySingleCommit(repo.FullPath, headSHA).GetResult() ?? new Models.Commit() { SHA = headSHA };
         }
     }
@@ -247,7 +249,7 @@ namespace SourceGit.ViewModels
 
             Current = new Commands.QueryCurrentBranch(repo.FullPath).GetResult();
 
-            var sourceSHA = File.ReadAllText(Path.Combine(repo.GitDir, "MERGE_HEAD")).Trim();
+            var sourceSHA = repo.FileSystem.ReadAllText(Path.Combine(repo.GitDir, "MERGE_HEAD")).Trim();
             Source = new Commands.QuerySingleCommit(repo.FullPath, sourceSHA).GetResult() ?? new Models.Commit() { SHA = sourceSHA };
             SourceName = Source.GetFriendlyName();
         }

--- a/src/ViewModels/Launcher.cs
+++ b/src/ViewModels/Launcher.cs
@@ -304,34 +304,56 @@ namespace SourceGit.ViewModels
                 }
             }
 
-            if (!Directory.Exists(node.Id))
+            Repository repo;
+            if (node.IsRemote)
             {
-                ActivePage.Notifications.Add(new Models.Notification
+                try
                 {
-                    Group = node.Id,
-                    Message = "Repository does NOT exist any more. Please remove it.",
-                    IsError = true,
-                });
-                return;
+                    repo = Remote.RemoteRepositoryOpener.Open(node.RemoteHost, node.Id);
+                }
+                catch (Exception ex)
+                {
+                    ActivePage.Notifications.Add(new Models.Notification
+                    {
+                        Group = node.Id,
+                        Message = $"Failed to open remote repository: {ex.Message}",
+                        IsError = true,
+                    });
+                    return;
+                }
+            }
+            else
+            {
+                if (!Directory.Exists(node.Id))
+                {
+                    ActivePage.Notifications.Add(new Models.Notification
+                    {
+                        Group = node.Id,
+                        Message = "Repository does NOT exist any more. Please remove it.",
+                        IsError = true,
+                    });
+                    return;
+                }
+
+                var isBare = new Commands.IsBareRepository(node.Id).GetResult();
+                var gitDir = isBare ? node.Id : GetRepositoryGitDir(node.Id);
+                if (string.IsNullOrEmpty(gitDir))
+                {
+                    ActivePage.Notifications.Add(new Models.Notification
+                    {
+                        Group = node.Id,
+                        Message = "Given path is not a valid git repository!",
+                        IsError = true,
+                    });
+                    return;
+                }
+
+                if (node.IsUnmanaged)
+                    node.LoadMinimalInfo(gitDir);
+
+                repo = new Repository(isBare, node.Id, gitDir);
             }
 
-            var isBare = new Commands.IsBareRepository(node.Id).GetResult();
-            var gitDir = isBare ? node.Id : GetRepositoryGitDir(node.Id);
-            if (string.IsNullOrEmpty(gitDir))
-            {
-                ActivePage.Notifications.Add(new Models.Notification
-                {
-                    Group = node.Id,
-                    Message = "Given path is not a valid git repository!",
-                    IsError = true,
-                });
-                return;
-            }
-
-            if (node.IsUnmanaged)
-                node.LoadMinimalInfo(gitDir);
-
-            var repo = new Repository(isBare, node.Id, gitDir);
             repo.Open();
 
             if (page == null)

--- a/src/ViewModels/Launcher.cs
+++ b/src/ViewModels/Launcher.cs
@@ -293,12 +293,21 @@ namespace SourceGit.ViewModels
         {
             foreach (var one in Pages)
             {
-                // Skip the page being re-opened (e.g. Reset reuses the same page); otherwise
-                // the duplicate check would short-circuit and leave it stuck in loading state.
+                // Skip the page being re-opened (e.g. Reset reuses the same page).
                 if (one.Node.Id == node.Id && !ReferenceEquals(one, page))
                 {
-                    ActivePage = one;
-                    return;
+                    // If the existing page is a live repository, just activate it.
+                    // If it's in a broken/loading state (Welcome/LoadingRemoteRepository after
+                    // a failed auto-connect), fall through and reuse that page for re-opening
+                    // so the user can retry from the sidebar without a dead tab.
+                    if (one.Data is Repository)
+                    {
+                        ActivePage = one;
+                        return;
+                    }
+
+                    page = one;
+                    break;
                 }
             }
 

--- a/src/ViewModels/Launcher.cs
+++ b/src/ViewModels/Launcher.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Text;
+using System.Threading.Tasks;
 
 using Avalonia.Collections;
 using Avalonia.Threading;
@@ -167,12 +168,7 @@ namespace SourceGit.ViewModels
             var toIdx = Pages.IndexOf(to);
             Pages.Move(fromIdx, toIdx);
 
-            _activeWorkspace.Repositories.Clear();
-            foreach (var p in Pages)
-            {
-                if (p.Data is Repository r)
-                    _activeWorkspace.Repositories.Add(r.FullPath);
-            }
+            RebuildWorkspaceRepositoryList();
 
             _ignoreIndexChange = false;
             ActivePage = from;
@@ -304,56 +300,40 @@ namespace SourceGit.ViewModels
                 }
             }
 
-            Repository repo;
             if (node.IsRemote)
             {
-                try
-                {
-                    repo = Remote.RemoteRepositoryOpener.Open(node.RemoteHost, node.Id);
-                }
-                catch (Exception ex)
-                {
-                    ActivePage.Notifications.Add(new Models.Notification
-                    {
-                        Group = node.Id,
-                        Message = $"Failed to open remote repository: {ex.Message}",
-                        IsError = true,
-                    });
-                    return;
-                }
+                OpenRemoteRepositoryInTab(node, page);
+                return;
             }
-            else
+
+            if (!Directory.Exists(node.Id))
             {
-                if (!Directory.Exists(node.Id))
+                ActivePage.Notifications.Add(new Models.Notification
                 {
-                    ActivePage.Notifications.Add(new Models.Notification
-                    {
-                        Group = node.Id,
-                        Message = "Repository does NOT exist any more. Please remove it.",
-                        IsError = true,
-                    });
-                    return;
-                }
-
-                var isBare = new Commands.IsBareRepository(node.Id).GetResult();
-                var gitDir = isBare ? node.Id : GetRepositoryGitDir(node.Id);
-                if (string.IsNullOrEmpty(gitDir))
-                {
-                    ActivePage.Notifications.Add(new Models.Notification
-                    {
-                        Group = node.Id,
-                        Message = "Given path is not a valid git repository!",
-                        IsError = true,
-                    });
-                    return;
-                }
-
-                if (node.IsUnmanaged)
-                    node.LoadMinimalInfo(gitDir);
-
-                repo = new Repository(isBare, node.Id, gitDir);
+                    Group = node.Id,
+                    Message = "Repository does NOT exist any more. Please remove it.",
+                    IsError = true,
+                });
+                return;
             }
 
+            var isBare = new Commands.IsBareRepository(node.Id).GetResult();
+            var gitDir = isBare ? node.Id : GetRepositoryGitDir(node.Id);
+            if (string.IsNullOrEmpty(gitDir))
+            {
+                ActivePage.Notifications.Add(new Models.Notification
+                {
+                    Group = node.Id,
+                    Message = "Given path is not a valid git repository!",
+                    IsError = true,
+                });
+                return;
+            }
+
+            if (node.IsUnmanaged)
+                node.LoadMinimalInfo(gitDir);
+
+            var repo = new Repository(isBare, node.Id, gitDir);
             repo.Open();
 
             if (page == null)
@@ -376,17 +356,109 @@ namespace SourceGit.ViewModels
                 page.Data = repo;
             }
 
-            _activeWorkspace.Repositories.Clear();
-            foreach (var p in Pages)
-            {
-                if (p.Data is Repository r)
-                    _activeWorkspace.Repositories.Add(r.FullPath);
-            }
+            RebuildWorkspaceRepositoryList();
 
             if (_activePage == page)
                 PostActivePageChanged();
             else
                 ActivePage = page;
+        }
+
+        /// <summary>
+        /// Open a remote SSH repository without blocking the UI. A loading page is shown
+        /// immediately (so the tab strip keeps working and the window stays responsive),
+        /// and the real <see cref="Repository"/> replaces it once the SSH connection and
+        /// probes finish on a background thread.
+        /// </summary>
+        private void OpenRemoteRepositoryInTab(RepositoryNode node, LauncherPage page)
+        {
+            var hostDisplay = node.RemoteHost?.Name ?? node.RemoteHost?.Host ?? string.Empty;
+            var loading = new LoadingRemoteRepository
+            {
+                Host = hostDisplay,
+                Path = node.Id,
+                Message = App.Text("Launcher.RemoteRepository.Loading", hostDisplay),
+            };
+
+            if (page == null)
+            {
+                if (_activePage == null || _activePage.Node.IsRepository || _activePage.Data is LoadingRemoteRepository)
+                {
+                    page = new LauncherPage(node, loading);
+                    Pages.Add(page);
+                }
+                else
+                {
+                    page = _activePage;
+                    page.Node = node;
+                    page.Data = loading;
+                }
+            }
+            else
+            {
+                page.Node = node;
+                page.Data = loading;
+            }
+
+            RebuildWorkspaceRepositoryList();
+
+            if (_activePage == page)
+                PostActivePageChanged();
+            else
+                ActivePage = page;
+
+            var capturedPage = page;
+            Task.Run(() =>
+            {
+                Repository repo;
+                try
+                {
+                    repo = Remote.RemoteRepositoryOpener.Open(node.RemoteHost, node.Id);
+                }
+                catch (Exception ex)
+                {
+                    Dispatcher.UIThread.Post(() =>
+                    {
+                        capturedPage.Notifications.Add(new Models.Notification
+                        {
+                            Group = node.Id,
+                            Message = $"Failed to open remote repository: {ex.Message}",
+                            IsError = true,
+                        });
+
+                        capturedPage.Data = Welcome.Instance;
+                        RebuildWorkspaceRepositoryList();
+                    });
+                    return;
+                }
+
+                Dispatcher.UIThread.Post(() =>
+                {
+                    // The user may have closed the tab or navigated away; only swap in the
+                    // repository if the page is still showing our loading state.
+                    if (!ReferenceEquals(capturedPage.Data, loading))
+                        return;
+
+                    repo.Open();
+                    capturedPage.Data = repo;
+                    RebuildWorkspaceRepositoryList();
+
+                    if (_activePage == capturedPage)
+                        PostActivePageChanged();
+                });
+            });
+        }
+
+        private void RebuildWorkspaceRepositoryList()
+        {
+            _activeWorkspace.Repositories.Clear();
+            foreach (var p in Pages)
+            {
+                if (p.Data is Repository r)
+                    _activeWorkspace.Repositories.Add(r.FullPath);
+                else if (p.Data is LoadingRemoteRepository loading)
+                    _activeWorkspace.Repositories.Add(loading.Path);
+            }
         }
 
         private void DispatchNotification(Models.Notification notification)
@@ -458,6 +530,10 @@ namespace SourceGit.ViewModels
                     page.Node.SaveMinimalInfo(repo.GitDir);
 
                 repo.Close();
+            }
+            else if (removeFromWorkspace && page.Data is LoadingRemoteRepository loading)
+            {
+                _activeWorkspace.Repositories.Remove(loading.Path);
             }
 
             page.Popup?.Cleanup();

--- a/src/ViewModels/Launcher.cs
+++ b/src/ViewModels/Launcher.cs
@@ -372,6 +372,60 @@ namespace SourceGit.ViewModels
         /// </summary>
         private void OpenRemoteRepositoryInTab(RepositoryNode node, LauncherPage page)
         {
+            // Fast path: the host is already connected, so opening is just a couple of quick
+            // RPC probes. Do it synchronously to avoid the loading-page flash; the UI stays
+            // responsive enough because no SSH connect is needed.
+            if (Remote.RemoteHostManager.Instance.GetConnectedSession(node.RemoteHost) != null)
+            {
+                Repository repo;
+                try
+                {
+                    repo = Remote.RemoteRepositoryOpener.Open(node.RemoteHost, node.Id);
+                }
+                catch (Exception ex)
+                {
+                    ActivePage.Notifications.Add(new Models.Notification
+                    {
+                        Group = node.Id,
+                        Message = $"Failed to open remote repository: {ex.Message}",
+                        IsError = true,
+                    });
+                    return;
+                }
+
+                repo.Open();
+
+                if (page == null)
+                {
+                    if (_activePage == null || _activePage.Node.IsRepository || _activePage.Data is LoadingRemoteRepository)
+                    {
+                        page = new LauncherPage(node, repo);
+                        Pages.Add(page);
+                    }
+                    else
+                    {
+                        page = _activePage;
+                        page.Node = node;
+                        page.Data = repo;
+                    }
+                }
+                else
+                {
+                    page.Node = node;
+                    page.Data = repo;
+                }
+
+                RebuildWorkspaceRepositoryList();
+
+                if (_activePage == page)
+                    PostActivePageChanged();
+                else
+                    ActivePage = page;
+                return;
+            }
+
+            // Slow path: need to establish SSH connection. Show a loading page immediately and
+            // do the connect/probe on a background thread so the UI never blocks.
             var hostDisplay = node.RemoteHost?.Name ?? node.RemoteHost?.Host ?? string.Empty;
             var loading = new LoadingRemoteRepository
             {

--- a/src/ViewModels/Launcher.cs
+++ b/src/ViewModels/Launcher.cs
@@ -293,7 +293,9 @@ namespace SourceGit.ViewModels
         {
             foreach (var one in Pages)
             {
-                if (one.Node.Id == node.Id)
+                // Skip the page being re-opened (e.g. Reset reuses the same page); otherwise
+                // the duplicate check would short-circuit and leave it stuck in loading state.
+                if (one.Node.Id == node.Id && !ReferenceEquals(one, page))
                 {
                     ActivePage = one;
                     return;

--- a/src/ViewModels/LauncherPage.cs
+++ b/src/ViewModels/LauncherPage.cs
@@ -52,6 +52,12 @@ namespace SourceGit.ViewModels
             _data = repo;
         }
 
+        public LauncherPage(RepositoryNode node, object data)
+        {
+            _node = node;
+            _data = data;
+        }
+
         public void ClearNotifications()
         {
             Notifications.Clear();

--- a/src/ViewModels/LoadingRemoteRepository.cs
+++ b/src/ViewModels/LoadingRemoteRepository.cs
@@ -1,0 +1,34 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace SourceGit.ViewModels
+{
+    /// <summary>
+    /// Shown in a launcher page while a remote SSH repository is being connected/opened.
+    /// Keeps the UI responsive: the tab is created immediately with this loading state, and
+    /// the real <see cref="Repository"/> replaces it once the SSH connection and probes finish.
+    /// </summary>
+    public class LoadingRemoteRepository : ObservableObject
+    {
+        public string Host
+        {
+            get => _host;
+            set => SetProperty(ref _host, value);
+        }
+
+        public string Path
+        {
+            get => _path;
+            set => SetProperty(ref _path, value);
+        }
+
+        public string Message
+        {
+            get => _message;
+            set => SetProperty(ref _message, value);
+        }
+
+        private string _host = string.Empty;
+        private string _path = string.Empty;
+        private string _message = string.Empty;
+    }
+}

--- a/src/ViewModels/OpenLocalRepository.cs
+++ b/src/ViewModels/OpenLocalRepository.cs
@@ -16,9 +16,11 @@ namespace SourceGit.ViewModels
             set => SetProperty(ref _repoPath, value, true);
         }
 
+        private bool _isSSHRemote;
         public bool IsSSHRemote
         {
-            get; set;
+            get => _isSSHRemote;
+            set => SetProperty(ref _isSSHRemote, value);
         }
 
         public string SSHHost

--- a/src/ViewModels/OpenLocalRepository.cs
+++ b/src/ViewModels/OpenLocalRepository.cs
@@ -1,59 +1,57 @@
 using System;
 using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
 using System.IO;
 using System.Threading.Tasks;
-using Avalonia.Controls.ApplicationLifetimes;
-using Avalonia.Media;
-using Avalonia.Threading;
 
-using SourceGit.Remote;
+using Avalonia.Controls.ApplicationLifetimes;
+using Avalonia.Threading;
 
 namespace SourceGit.ViewModels
 {
+    /// <summary>
+    /// One entry in the "Open Local Repository" host dropdown. <see cref="Host"/> is
+    /// <c>null</c> for the local machine; otherwise it is a connected remote host.
+    /// </summary>
+    public class RepositoryHostChoice
+    {
+        public string Display { get; init; } = string.Empty;
+        public Models.RemoteHost Host { get; init; }
+        public bool IsRemote => Host != null;
+    }
+
+    /// <summary>
+    /// "Open Local Repository" dialog. A host dropdown at the top selects where the
+    /// repository lives: the local machine, or any currently-connected remote host
+    /// (connected from Preferences → Remote Hosts). Apart from the machine, the workflow is
+    /// identical — folder, group and bookmark — and for remote hosts the folder is chosen
+    /// with a browser that runs over the host's existing connection.
+    /// </summary>
     public class OpenLocalRepository : Popup
     {
-        [Required(ErrorMessage = "Repository folder is required")]
-        [CustomValidation(typeof(OpenLocalRepository), nameof(ValidateRepoPath))]
-        public string RepoPath
-        {
-            get => _repoPath;
-            set => SetProperty(ref _repoPath, value, true);
-        }
+        public List<RepositoryHostChoice> AvailableHosts { get; }
 
-        private bool _isSSHRemote;
-        public bool IsSSHRemote
+        public RepositoryHostChoice SelectedHost
         {
-            get => _isSSHRemote;
-            set => SetProperty(ref _isSSHRemote, value);
-        }
-
-        private string _sshHost = string.Empty;
-        public string SSHHost
-        {
-            get => _sshHost;
+            get => _selectedHost;
             set
             {
-                if (SetProperty(ref _sshHost, value))
-                    _ = TestConnectionAsync();
+                if (SetProperty(ref _selectedHost, value))
+                    OnPropertyChanged(nameof(IsRemote));
             }
         }
 
-        private string _remotePath = string.Empty;
+        public bool IsRemote => _selectedHost?.IsRemote ?? false;
+
+        public string RepoPath
+        {
+            get => _repoPath;
+            set => SetProperty(ref _repoPath, value);
+        }
+
         public string RemotePath
         {
             get => _remotePath;
             set => SetProperty(ref _remotePath, value);
-        }
-
-        /// <summary>Host aliases parsed from ~/.ssh/config.</summary>
-        public List<string> SshHosts { get; } = SshConfigParser.GetHosts();
-
-        private IBrush _connectionStatusBrush = Brushes.Gray;
-        public IBrush ConnectionStatusBrush
-        {
-            get => _connectionStatusBrush;
-            set => SetProperty(ref _connectionStatusBrush, value);
         }
 
         public List<RepositoryNode> Groups
@@ -77,23 +75,37 @@ namespace SourceGit.ViewModels
         {
             _pageId = pageId;
 
+            AvailableHosts = new List<RepositoryHostChoice>
+            {
+                new RepositoryHostChoice { Display = App.Text("OpenLocalRepository.LocalHost"), Host = null },
+            };
+
+            foreach (var host in Preferences.Instance.RemoteHosts)
+            {
+                if (host.IsConnected)
+                    AvailableHosts.Add(new RepositoryHostChoice { Display = string.IsNullOrEmpty(host.Name) ? host.Host : host.Name, Host = host });
+            }
+
+            _selectedHost = AvailableHosts[0];
+
             Groups = new List<RepositoryNode>();
             Groups.Add(new RepositoryNode { Name = "No Group (Uncategorized)", Id = string.Empty });
             Group = group ?? Groups[0];
             CollectGroups(Groups, Preferences.Instance.RepositoryNodes);
         }
 
-        public static ValidationResult ValidateRepoPath(string folder, ValidationContext _)
-        {
-            if (!Directory.Exists(folder))
-                return new ValidationResult("Given path can NOT be found");
-            return ValidationResult.Success;
-        }
-
         public override async Task<bool> Sure()
         {
-            if (IsSSHRemote)
-                return await OpenRemoteAsync();
+            return IsRemote ? await OpenRemoteAsync() : await OpenLocalAsync();
+        }
+
+        private async Task<bool> OpenLocalAsync()
+        {
+            if (string.IsNullOrWhiteSpace(_repoPath) || !Directory.Exists(_repoPath))
+            {
+                Models.Notification.Send(null, App.Text("OpenLocalRepository.Invalid.LocalPath"), true);
+                return false;
+            }
 
             var isBare = await new Commands.IsBareRepository(_repoPath).GetResultAsync();
             var parent = _group is { Id: not "" } ? _group : null;
@@ -129,61 +141,59 @@ namespace SourceGit.ViewModels
             return true;
         }
 
-        private async Task<bool> OpenRemoteAsync()
+        private Task<bool> OpenRemoteAsync()
         {
-            var host = new Models.RemoteHost
+            var host = _selectedHost?.Host;
+            if (host == null || !host.IsConnected)
             {
-                Name = SSHHost,
-                Host = SSHHost,
-            };
+                Models.Notification.Send(null, App.Text("OpenLocalRepository.Invalid.NotConnected"), true);
+                return Task.FromResult(false);
+            }
+
+            if (string.IsNullOrWhiteSpace(_remotePath))
+            {
+                Models.Notification.Send(null, App.Text("OpenLocalRepository.Invalid.RemotePath"), true);
+                return Task.FromResult(false);
+            }
 
             var parent = _group is { Id: not "" } ? _group : null;
-            var node = Preferences.Instance.FindOrAddNodeByRepositoryPath(RemotePath, parent, true);
+            var node = Preferences.Instance.FindOrAddNodeByRepositoryPath(_remotePath.Trim(), parent, true, save: false);
             node.IsRemote = true;
             node.RemoteHost = host;
             node.Bookmark = _bookmark;
-            await node.UpdateStatusAsync(false, null);
+
+            // Persist after IsRemote/RemoteHost are set so the node reopens as remote next time.
+            Preferences.Instance.Save();
+
             Welcome.Instance.Refresh();
             node.Open();
-            return true;
+            return Task.FromResult(true);
         }
 
         /// <summary>
-        /// Open the remote folder picker so the user can browse directories on the SSH host
-        /// and pick the repository path instead of typing it.
+        /// Open the remote folder browser so the user can navigate directories on the host
+        /// (over its existing connection) and pick the repository path.
         /// </summary>
         public void BrowseRemotePath()
         {
-            if (string.IsNullOrEmpty(SSHHost))
+            var host = _selectedHost?.Host;
+            var session = Remote.RemoteHostManager.Instance.GetConnectedSession(host);
+            if (session == null)
+            {
+                Models.Notification.Send(null, App.Text("OpenLocalRepository.Invalid.NotConnected"), true);
                 return;
+            }
 
             var owner = (App.Current.ApplicationLifetime as IClassicDesktopStyleApplicationLifetime)?.MainWindow;
             if (owner == null)
                 return;
 
-            var picker = new Views.RemoteFolderPicker(SSHHost, RemotePath);
+            var picker = new Views.RemoteFolderPicker(host, session.Client, _remotePath);
             picker.ShowDialog<bool>(owner).ContinueWith(t =>
             {
-                if (t.IsCompletedSuccessfully && t.Result)
+                if (t.IsCompletedSuccessfully && t.Result && !string.IsNullOrEmpty(picker.SelectedPath))
                     Dispatcher.UIThread.Post(() => RemotePath = picker.SelectedPath);
             });
-        }
-
-        private async Task TestConnectionAsync()
-        {
-            if (string.IsNullOrEmpty(SSHHost))
-            {
-                ConnectionStatusBrush = Brushes.Gray;
-                return;
-            }
-
-            ConnectionStatusBrush = Brushes.Yellow;
-            var host = SSHHost;
-            var (stdout, exit) = await Task.Run(() => SshExec.Run(host, "echo OK")).ConfigureAwait(true);
-            if (host != SSHHost)
-                return; // selection changed meanwhile
-
-            ConnectionStatusBrush = (exit == 0 && stdout.Trim() == "OK") ? Brushes.Green : Brushes.Red;
         }
 
         private void CollectGroups(List<RepositoryNode> outs, List<RepositoryNode> collections)
@@ -200,6 +210,8 @@ namespace SourceGit.ViewModels
 
         private string _pageId = string.Empty;
         private string _repoPath = string.Empty;
+        private string _remotePath = string.Empty;
+        private RepositoryHostChoice _selectedHost = null;
         private RepositoryNode _group = null;
         private int _bookmark = 0;
     }

--- a/src/ViewModels/OpenLocalRepository.cs
+++ b/src/ViewModels/OpenLocalRepository.cs
@@ -1,8 +1,13 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.IO;
 using System.Threading.Tasks;
+using Avalonia.Controls.ApplicationLifetimes;
+using Avalonia.Media;
+using Avalonia.Threading;
+
+using SourceGit.Remote;
 
 namespace SourceGit.ViewModels
 {
@@ -23,15 +28,33 @@ namespace SourceGit.ViewModels
             set => SetProperty(ref _isSSHRemote, value);
         }
 
+        private string _sshHost = string.Empty;
         public string SSHHost
         {
-            get; set;
-        } = string.Empty;
+            get => _sshHost;
+            set
+            {
+                if (SetProperty(ref _sshHost, value))
+                    _ = TestConnectionAsync();
+            }
+        }
 
+        private string _remotePath = string.Empty;
         public string RemotePath
         {
-            get; set;
-        } = string.Empty;
+            get => _remotePath;
+            set => SetProperty(ref _remotePath, value);
+        }
+
+        /// <summary>Host aliases parsed from ~/.ssh/config.</summary>
+        public List<string> SshHosts { get; } = SshConfigParser.GetHosts();
+
+        private IBrush _connectionStatusBrush = Brushes.Gray;
+        public IBrush ConnectionStatusBrush
+        {
+            get => _connectionStatusBrush;
+            set => SetProperty(ref _connectionStatusBrush, value);
+        }
 
         public List<RepositoryNode> Groups
         {
@@ -123,6 +146,44 @@ namespace SourceGit.ViewModels
             Welcome.Instance.Refresh();
             node.Open();
             return true;
+        }
+
+        /// <summary>
+        /// Open the remote folder picker so the user can browse directories on the SSH host
+        /// and pick the repository path instead of typing it.
+        /// </summary>
+        public void BrowseRemotePath()
+        {
+            if (string.IsNullOrEmpty(SSHHost))
+                return;
+
+            var owner = (App.Current.ApplicationLifetime as IClassicDesktopStyleApplicationLifetime)?.MainWindow;
+            if (owner == null)
+                return;
+
+            var picker = new Views.RemoteFolderPicker(SSHHost, RemotePath);
+            picker.ShowDialog<bool>(owner).ContinueWith(t =>
+            {
+                if (t.IsCompletedSuccessfully && t.Result)
+                    Dispatcher.UIThread.Post(() => RemotePath = picker.SelectedPath);
+            });
+        }
+
+        private async Task TestConnectionAsync()
+        {
+            if (string.IsNullOrEmpty(SSHHost))
+            {
+                ConnectionStatusBrush = Brushes.Gray;
+                return;
+            }
+
+            ConnectionStatusBrush = Brushes.Yellow;
+            var host = SSHHost;
+            var (stdout, exit) = await Task.Run(() => SshExec.Run(host, "echo OK")).ConfigureAwait(true);
+            if (host != SSHHost)
+                return; // selection changed meanwhile
+
+            ConnectionStatusBrush = (exit == 0 && stdout.Trim() == "OK") ? Brushes.Green : Brushes.Red;
         }
 
         private void CollectGroups(List<RepositoryNode> outs, List<RepositoryNode> collections)

--- a/src/ViewModels/OpenLocalRepository.cs
+++ b/src/ViewModels/OpenLocalRepository.cs
@@ -16,6 +16,26 @@ namespace SourceGit.ViewModels
             set => SetProperty(ref _repoPath, value, true);
         }
 
+        public bool IsSSHRemote
+        {
+            get; set;
+        }
+
+        public string SSHHost
+        {
+            get; set;
+        } = string.Empty;
+
+        public string RemoteServerPath
+        {
+            get; set;
+        } = "sourcegit";
+
+        public string RemotePath
+        {
+            get; set;
+        } = string.Empty;
+
         public List<RepositoryNode> Groups
         {
             get;
@@ -52,6 +72,9 @@ namespace SourceGit.ViewModels
 
         public override async Task<bool> Sure()
         {
+            if (IsSSHRemote)
+                return await OpenRemoteAsync();
+
             var isBare = await new Commands.IsBareRepository(_repoPath).GetResultAsync();
             var parent = _group is { Id: not "" } ? _group : null;
             var repoRoot = _repoPath;
@@ -79,6 +102,26 @@ namespace SourceGit.ViewModels
             }
 
             var node = Preferences.Instance.FindOrAddNodeByRepositoryPath(repoRoot, parent, true);
+            node.Bookmark = _bookmark;
+            await node.UpdateStatusAsync(false, null);
+            Welcome.Instance.Refresh();
+            node.Open();
+            return true;
+        }
+
+        private async Task<bool> OpenRemoteAsync()
+        {
+            var host = new Models.RemoteHost
+            {
+                Name = SSHHost,
+                Host = SSHHost,
+                RemoteServerPath = string.IsNullOrEmpty(RemoteServerPath) ? "sourcegit" : RemoteServerPath,
+            };
+
+            var parent = _group is { Id: not "" } ? _group : null;
+            var node = Preferences.Instance.FindOrAddNodeByRepositoryPath(RemotePath, parent, true);
+            node.IsRemote = true;
+            node.RemoteHost = host;
             node.Bookmark = _bookmark;
             await node.UpdateStatusAsync(false, null);
             Welcome.Instance.Refresh();

--- a/src/ViewModels/OpenLocalRepository.cs
+++ b/src/ViewModels/OpenLocalRepository.cs
@@ -26,11 +26,6 @@ namespace SourceGit.ViewModels
             get; set;
         } = string.Empty;
 
-        public string RemoteServerPath
-        {
-            get; set;
-        } = "sourcegit";
-
         public string RemotePath
         {
             get; set;
@@ -115,7 +110,6 @@ namespace SourceGit.ViewModels
             {
                 Name = SSHHost,
                 Host = SSHHost,
-                RemoteServerPath = string.IsNullOrEmpty(RemoteServerPath) ? "sourcegit" : RemoteServerPath,
             };
 
             var parent = _group is { Id: not "" } ? _group : null;

--- a/src/ViewModels/Preferences.cs
+++ b/src/ViewModels/Preferences.cs
@@ -492,6 +492,12 @@ namespace SourceGit.ViewModels
             set;
         } = [];
 
+        public AvaloniaList<Models.RemoteHost> RemoteHosts
+        {
+            get;
+            set;
+        } = [];
+
         public double LastCheckUpdateTime
         {
             get => _lastCheckUpdateTime;

--- a/src/ViewModels/Repository.cs
+++ b/src/ViewModels/Repository.cs
@@ -430,6 +430,13 @@ namespace SourceGit.ViewModels
 
         public bool IsRemote { get; } = false;
 
+        /// <summary>
+        /// For remote repositories, the SSH host used to open this repository. Needed so that
+        /// worktrees/submodules opened from a remote repo are opened on the same host instead
+        /// of being treated as local paths.
+        /// </summary>
+        internal Models.RemoteHost RemoteHost { get; set; } = null;
+
         // The live SSH connection is owned by Remote.RemoteHostSession (shared across repos),
         // so the repository only owns its per-repo change watcher and never tears the
         // connection down on close.
@@ -1567,8 +1574,7 @@ namespace SourceGit.ViewModels
                 return;
 
             var root = Path.GetFullPath(Path.Combine(FullPath, submodule));
-            var normalizedPath = root.Replace('\\', '/').TrimEnd('/');
-            App.GetLauncher().OpenRepositoryInTab(normalizedPath, null);
+            OpenOwnedPathAsRepository(root);
         }
 
         public void AddWorktree()
@@ -1588,8 +1594,29 @@ namespace SourceGit.ViewModels
             if (worktree.IsCurrent)
                 return;
 
-            var normalizedPath = worktree.FullPath.Replace('\\', '/').TrimEnd('/');
-            App.GetLauncher().OpenRepositoryInTab(normalizedPath, null);
+            OpenOwnedPathAsRepository(worktree.FullPath);
+        }
+
+        /// <summary>
+        /// Open a path that belongs to this repository (worktree/submodule). For a remote
+        /// repository the path lives on the remote host, so it must be opened as a remote
+        /// repository on the same host — not as a local path (which would fail with
+        /// "Repository does NOT exist").
+        /// </summary>
+        private void OpenOwnedPathAsRepository(string path)
+        {
+            var normalizedPath = path.Replace('\\', '/').TrimEnd('/');
+            if (!IsRemote)
+            {
+                App.GetLauncher().OpenRepositoryInTab(normalizedPath, null);
+                return;
+            }
+
+            var node = Preferences.Instance.FindOrAddNodeByRepositoryPath(normalizedPath, null, false, save: false);
+            node.IsRemote = true;
+            node.RemoteHost = RemoteHost;
+            Preferences.Instance.Save();
+            App.GetLauncher().OpenRepositoryInTab(node, null);
         }
 
         public async Task LockWorktreeAsync(Worktree worktree)

--- a/src/ViewModels/Repository.cs
+++ b/src/ViewModels/Repository.cs
@@ -430,6 +430,8 @@ namespace SourceGit.ViewModels
 
         public bool IsRemote { get; } = false;
 
+        internal IDisposable RemoteConnection { get; set; } = null;
+
         public Repository(bool isBare, string path, string gitDir)
             : this(isBare, path, gitDir, false)
         {
@@ -512,6 +514,12 @@ namespace SourceGit.ViewModels
 
             _watcher?.Dispose();
             _autoFetchTimer.Dispose();
+
+            if (IsRemote)
+            {
+                Commands.CommandRunnerRegistry.Unregister(FullPath);
+                RemoteConnection?.Dispose();
+            }
         }
 
         public void SendNotification(string message, bool isError = false)

--- a/src/ViewModels/Repository.cs
+++ b/src/ViewModels/Repository.cs
@@ -430,8 +430,9 @@ namespace SourceGit.ViewModels
 
         public bool IsRemote { get; } = false;
 
-        internal IDisposable RemoteConnection { get; set; } = null;
-
+        // The live SSH connection is owned by Remote.RemoteHostSession (shared across repos),
+        // so the repository only owns its per-repo change watcher and never tears the
+        // connection down on close.
         internal IDisposable RemoteWatcher { get; set; } = null;
 
         /// <summary>
@@ -528,7 +529,6 @@ namespace SourceGit.ViewModels
             {
                 Commands.CommandRunnerRegistry.Unregister(FullPath);
                 RemoteWatcher?.Dispose();
-                RemoteConnection?.Dispose();
             }
         }
 

--- a/src/ViewModels/Repository.cs
+++ b/src/ViewModels/Repository.cs
@@ -428,9 +428,17 @@ namespace SourceGit.ViewModels
             get;
         } = [];
 
+        public bool IsRemote { get; } = false;
+
         public Repository(bool isBare, string path, string gitDir)
+            : this(isBare, path, gitDir, false)
+        {
+        }
+
+        public Repository(bool isBare, string path, string gitDir, bool isRemote)
         {
             IsBare = isBare;
+            IsRemote = isRemote;
             FullPath = path.Replace('\\', '/').TrimEnd('/');
             GitDir = gitDir.Replace('\\', '/').TrimEnd('/');
 
@@ -459,13 +467,16 @@ namespace SourceGit.ViewModels
 
         public void Open()
         {
-            try
+            if (!IsRemote)
             {
-                _watcher = new Models.Watcher(this, FullPath, _gitCommonDir);
-            }
-            catch (Exception ex)
-            {
-                SendNotification($"Failed to start watcher for repository: '{FullPath}'. You may need to press 'F5' to refresh repository manually!\n\nReason: {ex.Message}", true);
+                try
+                {
+                    _watcher = new Models.Watcher(this, FullPath, _gitCommonDir);
+                }
+                catch (Exception ex)
+                {
+                    SendNotification($"Failed to start watcher for repository: '{FullPath}'. You may need to press 'F5' to refresh repository manually!\n\nReason: {ex.Message}", true);
+                }
             }
 
             _historyFilterMode = _uiStates.GetHistoryFilterMode();

--- a/src/ViewModels/Repository.cs
+++ b/src/ViewModels/Repository.cs
@@ -789,7 +789,32 @@ namespace SourceGit.ViewModels
 
         public IDisposable LockWatcher()
         {
-            return _watcher?.Lock();
+            if (_watcher != null)
+                return _watcher.Lock();
+
+            // For remote repos there is no local FileSystemWatcher. Return a context that
+            // triggers a full refresh on dispose, so any operation that wraps its work in
+            // `using var lock = repo.LockWatcher()` (tag/push/commit/merge/…) auto-refreshes
+            // the UI once the command finishes — matching the local behavior.
+            if (IsRemote)
+                return new RemoteRefreshContext(this);
+
+            return null;
+        }
+
+        /// <summary>
+        /// Returned by <see cref="LockWatcher"/> for remote repositories. Disposing it
+        /// (i.e. when the `using` block exits after a git command completes) posts a
+        /// <see cref="RefreshAll"/> to the UI thread.
+        /// </summary>
+        private sealed class RemoteRefreshContext : IDisposable
+        {
+            private readonly Repository _repo;
+            public RemoteRefreshContext(Repository repo) { _repo = repo; }
+            public void Dispose()
+            {
+                Dispatcher.UIThread.Post(() => _repo.RefreshAll());
+            }
         }
 
         public void RefreshAfterCreateBranch(Models.Branch created, bool checkout)

--- a/src/ViewModels/Repository.cs
+++ b/src/ViewModels/Repository.cs
@@ -432,6 +432,8 @@ namespace SourceGit.ViewModels
 
         internal IDisposable RemoteConnection { get; set; } = null;
 
+        internal IDisposable RemoteWatcher { get; set; } = null;
+
         /// <summary>
         /// Filesystem accessor for the working tree and .git internals. Local repos use
         /// <see cref="LocalFileSystem"/> (direct File./Directory.); remote repos use a
@@ -525,6 +527,7 @@ namespace SourceGit.ViewModels
             if (IsRemote)
             {
                 Commands.CommandRunnerRegistry.Unregister(FullPath);
+                RemoteWatcher?.Dispose();
                 RemoteConnection?.Dispose();
             }
         }

--- a/src/ViewModels/Repository.cs
+++ b/src/ViewModels/Repository.cs
@@ -432,6 +432,13 @@ namespace SourceGit.ViewModels
 
         internal IDisposable RemoteConnection { get; set; } = null;
 
+        /// <summary>
+        /// Filesystem accessor for the working tree and .git internals. Local repos use
+        /// <see cref="LocalFileSystem"/> (direct File./Directory.); remote repos use a
+        /// <see cref="Remote.RemoteFileSystem"/> that routes over RPC.
+        /// </summary>
+        public Models.IFileSystem FileSystem { get; internal set; } = Models.LocalFileSystem.Instance;
+
         public Repository(bool isBare, string path, string gitDir)
             : this(isBare, path, gitDir, false)
         {

--- a/src/ViewModels/RepositoryNode.cs
+++ b/src/ViewModels/RepositoryNode.cs
@@ -45,6 +45,16 @@ namespace SourceGit.ViewModels
             set => SetProperty(ref _isRepository, value);
         }
 
+        public bool IsRemote
+        {
+            get; set;
+        }
+
+        public Models.RemoteHost RemoteHost
+        {
+            get; set;
+        }
+
         public bool IsExpanded
         {
             get => _isExpanded;
@@ -61,7 +71,7 @@ namespace SourceGit.ViewModels
         [JsonIgnore]
         public bool IsInvalid
         {
-            get => _isRepository && !Directory.Exists(_id);
+            get => _isRepository && !IsRemote && !Directory.Exists(_id);
         }
 
         [JsonIgnore]

--- a/src/ViewModels/RepositoryNode.cs
+++ b/src/ViewModels/RepositoryNode.cs
@@ -135,14 +135,14 @@ namespace SourceGit.ViewModels
 
         public void OpenInFileManager()
         {
-            if (!IsRepository)
+            if (!IsRepository || IsRemote)
                 return;
             Native.OS.OpenInFileManager(_id);
         }
 
         public void OpenTerminal()
         {
-            if (!IsRepository)
+            if (!IsRepository || IsRemote)
                 return;
             Native.OS.OpenTerminal(_id);
         }

--- a/src/ViewModels/RevisionCompare.cs
+++ b/src/ViewModels/RevisionCompare.cs
@@ -164,7 +164,7 @@ namespace SourceGit.ViewModels
             if (change.Index == Models.ChangeState.Added)
             {
                 var fullpath = Native.OS.GetAbsPath(_repo.FullPath, change.Path);
-                if (File.Exists(fullpath))
+                if (_repo.FileSystem.FileExists(fullpath))
                     await new Commands.Remove(_repo.FullPath, [change.Path])
                         .Use(log)
                         .ExecAsync();
@@ -172,7 +172,7 @@ namespace SourceGit.ViewModels
             else if (change.Index == Models.ChangeState.Renamed)
             {
                 var renamed = Native.OS.GetAbsPath(_repo.FullPath, change.Path);
-                if (File.Exists(renamed))
+                if (_repo.FileSystem.FileExists(renamed))
                     await new Commands.Remove(_repo.FullPath, [change.Path])
                         .Use(log)
                         .ExecAsync();
@@ -199,7 +199,7 @@ namespace SourceGit.ViewModels
             if (change.Index == Models.ChangeState.Deleted)
             {
                 var fullpath = Native.OS.GetAbsPath(_repo.FullPath, change.Path);
-                if (File.Exists(fullpath))
+                if (_repo.FileSystem.FileExists(fullpath))
                     await new Commands.Remove(_repo.FullPath, [change.Path])
                         .Use(log)
                         .ExecAsync();
@@ -207,7 +207,7 @@ namespace SourceGit.ViewModels
             else if (change.Index == Models.ChangeState.Renamed)
             {
                 var old = Native.OS.GetAbsPath(_repo.FullPath, change.OriginalPath);
-                if (File.Exists(old))
+                if (_repo.FileSystem.FileExists(old))
                     await new Commands.Remove(_repo.FullPath, [change.OriginalPath])
                         .Use(log)
                         .ExecAsync();
@@ -237,13 +237,13 @@ namespace SourceGit.ViewModels
                 if (c.Index == Models.ChangeState.Added)
                 {
                     var fullpath = Native.OS.GetAbsPath(_repo.FullPath, c.Path);
-                    if (File.Exists(fullpath))
+                    if (_repo.FileSystem.FileExists(fullpath))
                         removes.Add(c.Path);
                 }
                 else if (c.Index == Models.ChangeState.Renamed)
                 {
                     var old = Native.OS.GetAbsPath(_repo.FullPath, c.Path);
-                    if (File.Exists(old))
+                    if (_repo.FileSystem.FileExists(old))
                         removes.Add(c.Path);
 
                     checkouts.Add(c.OriginalPath);
@@ -280,13 +280,13 @@ namespace SourceGit.ViewModels
                 if (c.Index == Models.ChangeState.Deleted)
                 {
                     var fullpath = Native.OS.GetAbsPath(_repo.FullPath, c.Path);
-                    if (File.Exists(fullpath))
+                    if (_repo.FileSystem.FileExists(fullpath))
                         removes.Add(c.Path);
                 }
                 else if (c.Index == Models.ChangeState.Renamed)
                 {
                     var renamed = Native.OS.GetAbsPath(_repo.FullPath, c.OriginalPath);
-                    if (File.Exists(renamed))
+                    if (_repo.FileSystem.FileExists(renamed))
                         removes.Add(c.OriginalPath);
 
                     checkouts.Add(c.Path);

--- a/src/ViewModels/StashesPage.cs
+++ b/src/ViewModels/StashesPage.cs
@@ -244,15 +244,20 @@ namespace SourceGit.ViewModels
             var saveTo = Path.GetTempFileName();
             var succ = await Commands.SaveChangesAsPatch.ProcessStashChangesAsync(_repo.FullPath, opts, saveTo);
             if (!succ)
+            {
+                File.Delete(saveTo);
                 return;
+            }
+
+            var patch = File.ReadAllText(saveTo);
+            File.Delete(saveTo);
 
             var log = _repo.CreateLog($"Apply changes from '{_selectedStash.Name}'");
-            await new Commands.Apply(_repo.FullPath, saveTo, true, string.Empty, string.Empty)
+            await new Commands.Apply(_repo.FullPath, patch, true, string.Empty, string.Empty)
                 .Use(log)
                 .ExecAsync();
 
             log.Complete();
-            File.Delete(saveTo);
         }
 
         private void RefreshVisible()

--- a/src/ViewModels/WorkingCopy.cs
+++ b/src/ViewModels/WorkingCopy.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Text;
 using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.ComponentModel;
 
@@ -327,15 +328,11 @@ namespace SourceGit.ViewModels
             using var lockWatcher = _repo.LockWatcher();
 
             var log = _repo.CreateLog("Stage");
-            var pathSpecFile = Path.GetTempFileName();
-            await using (var writer = new StreamWriter(pathSpecFile))
-            {
-                foreach (var c in canStaged)
-                    await writer.WriteLineAsync(c.Path);
-            }
+            var pathspec = new StringBuilder();
+            foreach (var c in canStaged)
+                pathspec.Append(c.Path).Append('\n');
 
-            await new Commands.Add(_repo.FullPath, pathSpecFile).Use(log).ExecAsync();
-            File.Delete(pathSpecFile);
+            await new Commands.Add(_repo.FullPath, pathspec.ToString()).Use(log).ExecAsync();
             log.Complete();
 
             _repo.MarkWorkingCopyDirtyManually();
@@ -361,19 +358,15 @@ namespace SourceGit.ViewModels
             }
             else
             {
-                var pathSpecFile = Path.GetTempFileName();
-                await using (var writer = new StreamWriter(pathSpecFile))
+                var pathspec = new StringBuilder();
+                foreach (var c in changes)
                 {
-                    foreach (var c in changes)
-                    {
-                        await writer.WriteLineAsync(c.Path);
-                        if (c.Index == Models.ChangeState.Renamed)
-                            await writer.WriteLineAsync(c.OriginalPath);
-                    }
+                    pathspec.Append(c.Path).Append('\n');
+                    if (c.Index == Models.ChangeState.Renamed)
+                        pathspec.Append(c.OriginalPath).Append('\n');
                 }
 
-                await new Commands.Reset(_repo.FullPath, pathSpecFile).Use(log).ExecAsync();
-                File.Delete(pathSpecFile);
+                await new Commands.Reset(_repo.FullPath, pathspec.ToString()).Use(log).ExecAsync();
             }
             log.Complete();
 
@@ -415,8 +408,8 @@ namespace SourceGit.ViewModels
                 if (change.ConflictReason is Models.ConflictReason.BothDeleted or Models.ConflictReason.DeletedByThem or Models.ConflictReason.AddedByUs)
                 {
                     var fullpath = Path.Combine(_repo.FullPath, change.Path);
-                    if (File.Exists(fullpath))
-                        File.Delete(fullpath);
+                    if (_repo.FileSystem.FileExists(fullpath))
+                        _repo.FileSystem.DeleteFile(fullpath);
 
                     needStage.Add(change.Path);
                 }
@@ -435,10 +428,10 @@ namespace SourceGit.ViewModels
 
             if (needStage.Count > 0)
             {
-                var pathSpecFile = Path.GetTempFileName();
-                await File.WriteAllLinesAsync(pathSpecFile, needStage);
-                await new Commands.Add(_repo.FullPath, pathSpecFile).Use(log).ExecAsync();
-                File.Delete(pathSpecFile);
+                var pathspec = new StringBuilder();
+                foreach (var p in needStage)
+                    pathspec.Append(p).Append('\n');
+                await new Commands.Add(_repo.FullPath, pathspec.ToString()).Use(log).ExecAsync();
             }
 
             log.Complete();
@@ -461,8 +454,8 @@ namespace SourceGit.ViewModels
                 if (change.ConflictReason is Models.ConflictReason.BothDeleted or Models.ConflictReason.DeletedByUs or Models.ConflictReason.AddedByThem)
                 {
                     var fullpath = Path.Combine(_repo.FullPath, change.Path);
-                    if (File.Exists(fullpath))
-                        File.Delete(fullpath);
+                    if (_repo.FileSystem.FileExists(fullpath))
+                        _repo.FileSystem.DeleteFile(fullpath);
 
                     needStage.Add(change.Path);
                 }
@@ -481,10 +474,10 @@ namespace SourceGit.ViewModels
 
             if (needStage.Count > 0)
             {
-                var pathSpecFile = Path.GetTempFileName();
-                await File.WriteAllLinesAsync(pathSpecFile, needStage);
-                await new Commands.Add(_repo.FullPath, pathSpecFile).Use(log).ExecAsync();
-                File.Delete(pathSpecFile);
+                var pathspec = new StringBuilder();
+                foreach (var p in needStage)
+                    pathspec.Append(p).Append('\n');
+                await new Commands.Add(_repo.FullPath, pathspec.ToString()).Use(log).ExecAsync();
             }
 
             log.Complete();

--- a/src/ViewModels/WorkingCopy.cs
+++ b/src/ViewModels/WorkingCopy.cs
@@ -502,8 +502,8 @@ namespace SourceGit.ViewModels
                 IsCommitting = true;
 
                 var mergeMsgFile = Path.Combine(_repo.GitDir, "MERGE_MSG");
-                if (File.Exists(mergeMsgFile) && !string.IsNullOrWhiteSpace(_commitMessage))
-                    await File.WriteAllTextAsync(mergeMsgFile, _commitMessage);
+                if (_repo.FileSystem.FileExists(mergeMsgFile) && !string.IsNullOrWhiteSpace(_commitMessage))
+                    await _repo.FileSystem.WriteAllTextAsync(mergeMsgFile, _commitMessage);
 
                 var log = _repo.CreateLog($"Continue {_inProgressContext.Name}");
                 await _inProgressContext.ContinueAsync(log);
@@ -731,13 +731,13 @@ namespace SourceGit.ViewModels
         {
             var oldType = _inProgressContext != null ? _inProgressContext.GetType() : null;
 
-            if (File.Exists(Path.Combine(_repo.GitDir, "CHERRY_PICK_HEAD")))
+            if (_repo.FileSystem.FileExists(Path.Combine(_repo.GitDir, "CHERRY_PICK_HEAD")))
                 InProgressContext = new CherryPickInProgress(_repo);
-            else if (Directory.Exists(Path.Combine(_repo.GitDir, "rebase-merge")) || Directory.Exists(Path.Combine(_repo.GitDir, "rebase-apply")))
+            else if (_repo.FileSystem.DirectoryExists(Path.Combine(_repo.GitDir, "rebase-merge")) || _repo.FileSystem.DirectoryExists(Path.Combine(_repo.GitDir, "rebase-apply")))
                 InProgressContext = new RebaseInProgress(_repo);
-            else if (File.Exists(Path.Combine(_repo.GitDir, "REVERT_HEAD")))
+            else if (_repo.FileSystem.FileExists(Path.Combine(_repo.GitDir, "REVERT_HEAD")))
                 InProgressContext = new RevertInProgress(_repo);
-            else if (File.Exists(Path.Combine(_repo.GitDir, "MERGE_HEAD")))
+            else if (_repo.FileSystem.FileExists(Path.Combine(_repo.GitDir, "MERGE_HEAD")))
                 InProgressContext = new MergeInProgress(_repo);
             else
                 InProgressContext = null;
@@ -759,10 +759,10 @@ namespace SourceGit.ViewModels
 
         private bool LoadCommitMessageFromFile(string file)
         {
-            if (!File.Exists(file))
+            if (!_repo.FileSystem.FileExists(file))
                 return false;
 
-            var msg = File.ReadAllText(file).Trim();
+            var msg = _repo.FileSystem.ReadAllText(file).Trim();
             if (string.IsNullOrEmpty(msg))
                 return false;
 

--- a/src/Views/LauncherPage.axaml
+++ b/src/Views/LauncherPage.axaml
@@ -22,6 +22,10 @@
             <v:WelcomeToolbar/>
           </DataTemplate>
 
+          <DataTemplate DataType="vm:LoadingRemoteRepository">
+            <TextBlock Margin="12,0" VerticalAlignment="Center" Text="{Binding Message}"/>
+          </DataTemplate>
+
           <DataTemplate DataType="vm:Repository">
             <v:RepositoryToolbar/>
           </DataTemplate>
@@ -31,10 +35,17 @@
 
     <!-- Body -->
     <Border Grid.Row="1">
-      <ContentControl Content="{Binding Data}">        
+      <ContentControl Content="{Binding Data}">
         <ContentControl.DataTemplates>
           <DataTemplate DataType="vm:Welcome">
             <v:Welcome/>
+          </DataTemplate>
+
+          <DataTemplate DataType="vm:LoadingRemoteRepository">
+            <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Spacing="12">
+              <ProgressBar IsIndeterminate="True" Width="240" Height="4"/>
+              <TextBlock HorizontalAlignment="Center" Text="{Binding Message}"/>
+            </StackPanel>
           </DataTemplate>
 
           <DataTemplate DataType="vm:Repository">

--- a/src/Views/OpenLocalRepository.axaml
+++ b/src/Views/OpenLocalRepository.axaml
@@ -20,7 +20,13 @@
                  Text="{DynamicResource Text.OpenLocalRepository}"/>
     </StackPanel>
 
-    <Grid Margin="8,16,0,0" RowDefinitions="32,32,32" ColumnDefinitions="Auto,*">
+    <ToggleButton Margin="8,12,0,0"
+                  Height="28"
+                  Content="{DynamicResource Text.OpenLocalRepository.SSHRemote}"
+                  IsChecked="{Binding IsSSHRemote, Mode=TwoWay}"/>
+
+    <Grid Margin="8,8,0,0" RowDefinitions="32,32,32" ColumnDefinitions="Auto,*"
+          IsVisible="{Binding !IsSSHRemote}">
       <TextBlock Grid.Row="0" Grid.Column="0"
                  HorizontalAlignment="Right"
                  Margin="0,0,8,0"
@@ -57,6 +63,60 @@
                  Margin="0,0,8,0"
                  Text="{DynamicResource Text.OpenLocalRepository.Bookmark}"/>
       <v:BookmarkSelector Grid.Row="2" Grid.Column="1"
+                          HorizontalAlignment="Left" VerticalAlignment="Center"
+                          Bookmark="{Binding Bookmark, Mode=TwoWay}"/>
+    </Grid>
+
+    <Grid Margin="8,8,0,0" RowDefinitions="32,32,32,32,32" ColumnDefinitions="Auto,*"
+          IsVisible="{Binding IsSSHRemote}">
+      <TextBlock Grid.Row="0" Grid.Column="0"
+                 HorizontalAlignment="Right"
+                 Margin="0,0,8,0"
+                 Text="{DynamicResource Text.OpenLocalRepository.Host}"/>
+      <TextBox Grid.Row="0" Grid.Column="1"
+               Height="28"
+               CornerRadius="3"
+               Text="{Binding SSHHost, Mode=TwoWay}"/>
+
+      <TextBlock Grid.Row="1" Grid.Column="0"
+                 HorizontalAlignment="Right"
+                 Margin="0,0,8,0"
+                 Text="{DynamicResource Text.OpenLocalRepository.RemoteServerPath}"/>
+      <TextBox Grid.Row="1" Grid.Column="1"
+               Height="28"
+               CornerRadius="3"
+               Text="{Binding RemoteServerPath, Mode=TwoWay}"/>
+
+      <TextBlock Grid.Row="2" Grid.Column="0"
+                 HorizontalAlignment="Right"
+                 Margin="0,0,8,0"
+                 Text="{DynamicResource Text.OpenLocalRepository.RemotePath}"/>
+      <TextBox Grid.Row="2" Grid.Column="1"
+               Height="28"
+               CornerRadius="3"
+               Text="{Binding RemotePath, Mode=TwoWay}"/>
+
+      <TextBlock Grid.Row="3" Grid.Column="0"
+                 HorizontalAlignment="Right"
+                 Margin="0,0,8,0"
+                 Text="{DynamicResource Text.OpenLocalRepository.Group}"/>
+      <ComboBox Grid.Row="3" Grid.Column="1"
+                Height="28" Padding="8,0"
+                VerticalAlignment="Center" HorizontalAlignment="Stretch"
+                ItemsSource="{Binding Groups}"
+                SelectedItem="{Binding Group, Mode=TwoWay}">
+        <ComboBox.ItemTemplate>
+          <DataTemplate DataType="vm:RepositoryNode">
+            <TextBlock Text="{Binding Name, Mode=OneWay}"/>
+          </DataTemplate>
+        </ComboBox.ItemTemplate>
+      </ComboBox>
+
+      <TextBlock Grid.Row="4" Grid.Column="0"
+                 HorizontalAlignment="Right"
+                 Margin="0,0,8,0"
+                 Text="{DynamicResource Text.OpenLocalRepository.Bookmark}"/>
+      <v:BookmarkSelector Grid.Row="4" Grid.Column="1"
                           HorizontalAlignment="Left" VerticalAlignment="Center"
                           Bookmark="{Binding Bookmark, Mode=TwoWay}"/>
     </Grid>

--- a/src/Views/OpenLocalRepository.axaml
+++ b/src/Views/OpenLocalRepository.axaml
@@ -5,10 +5,10 @@
              xmlns:vm="using:SourceGit.ViewModels"
              xmlns:v="using:SourceGit.Views"
              xmlns:c="using:SourceGit.Converters"
-             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+             mc:Ignorable="d" d:DesignWidth="500" d:DesignHeight="260"
              x:Class="SourceGit.Views.OpenLocalRepository"
              x:DataType="vm:OpenLocalRepository">
-  <StackPanel Orientation="Vertical" Margin="8,0,0,0">
+  <StackPanel Orientation="Vertical" Margin="8,0,0,0" MinWidth="450">
     <StackPanel Orientation="Horizontal">
       <Path Width="16" Height="16"
             Margin="0,2,0,0"
@@ -20,21 +20,34 @@
                  Text="{DynamicResource Text.OpenLocalRepository}"/>
     </StackPanel>
 
-    <ToggleButton Margin="8,12,0,0"
-                  Height="28"
-                  Focusable="False"
-                  Content="{DynamicResource Text.OpenLocalRepository.SSHRemote}"
-                  IsChecked="{Binding IsSSHRemote, Mode=TwoWay}"/>
-
-    <Grid Margin="8,8,0,0" RowDefinitions="32,32,32" ColumnDefinitions="Auto,*"
-          IsVisible="{Binding !IsSSHRemote}">
+    <Grid Margin="8,16,0,0" RowDefinitions="32,32,32,32" ColumnDefinitions="120,*">
+      <!-- Host selector (Local + connected remote hosts) -->
       <TextBlock Grid.Row="0" Grid.Column="0"
-                 HorizontalAlignment="Right"
+                 HorizontalAlignment="Right" VerticalAlignment="Center"
                  Margin="0,0,8,0"
+                 Text="{DynamicResource Text.OpenLocalRepository.Host}"/>
+      <ComboBox Grid.Row="0" Grid.Column="1"
+                Height="28" Padding="8,0"
+                VerticalAlignment="Center" HorizontalAlignment="Stretch"
+                ItemsSource="{Binding AvailableHosts}"
+                SelectedItem="{Binding SelectedHost, Mode=TwoWay}">
+        <ComboBox.ItemTemplate>
+          <DataTemplate DataType="vm:RepositoryHostChoice">
+            <TextBlock VerticalAlignment="Center" Text="{Binding Display}"/>
+          </DataTemplate>
+        </ComboBox.ItemTemplate>
+      </ComboBox>
+
+      <!-- Local folder -->
+      <TextBlock Grid.Row="1" Grid.Column="0"
+                 HorizontalAlignment="Right" VerticalAlignment="Center"
+                 Margin="0,0,8,0"
+                 IsVisible="{Binding !IsRemote}"
                  Text="{DynamicResource Text.OpenLocalRepository.Path}"/>
-      <TextBox Grid.Row="0" Grid.Column="1"
+      <TextBox Grid.Row="1" Grid.Column="1"
                Height="28"
                CornerRadius="3"
+               IsVisible="{Binding !IsRemote}"
                Text="{Binding RepoPath, Mode=TwoWay}">
         <TextBox.InnerRightContent>
           <Button Classes="icon_button" Width="28" Height="28" Margin="4,0,0,0" Click="OnSelectRepositoryFolder">
@@ -43,57 +56,31 @@
         </TextBox.InnerRightContent>
       </TextBox>
 
+      <!-- Remote folder -->
       <TextBlock Grid.Row="1" Grid.Column="0"
-                 HorizontalAlignment="Right"
+                 HorizontalAlignment="Right" VerticalAlignment="Center"
                  Margin="0,0,8,0"
-                 Text="{DynamicResource Text.OpenLocalRepository.Group}"/>
-      <ComboBox Grid.Row="1" Grid.Column="1"
-                Height="28" Padding="8,0"
-                VerticalAlignment="Center" HorizontalAlignment="Stretch"
-                ItemsSource="{Binding Groups}"
-                SelectedItem="{Binding Group, Mode=TwoWay}">
-        <ComboBox.ItemTemplate>
-          <DataTemplate DataType="vm:RepositoryNode">
-            <TextBlock Text="{Binding Name, Mode=OneWay}"/>
-          </DataTemplate>
-        </ComboBox.ItemTemplate>
-      </ComboBox>
-
-      <TextBlock Grid.Row="2" Grid.Column="0"
-                 HorizontalAlignment="Right"
-                 Margin="0,0,8,0"
-                 Text="{DynamicResource Text.OpenLocalRepository.Bookmark}"/>
-      <v:BookmarkSelector Grid.Row="2" Grid.Column="1"
-                          HorizontalAlignment="Left" VerticalAlignment="Center"
-                          Bookmark="{Binding Bookmark, Mode=TwoWay}"/>
-    </Grid>
-
-    <Grid Margin="8,8,0,0" RowDefinitions="32,32,32,32" ColumnDefinitions="*,Auto"
-          IsVisible="{Binding IsSSHRemote}">
-      <ComboBox Grid.Row="0" Grid.Column="0"
-                Height="28" Padding="8,0"
-                VerticalAlignment="Center" HorizontalAlignment="Stretch"
-                ItemsSource="{Binding SshHosts}"
-                SelectedItem="{Binding SSHHost, Mode=TwoWay}"
-                PlaceholderText="select ssh host"/>
-      <Ellipse Grid.Row="0" Grid.Column="1"
-               Width="12" Height="12"
-               Margin="8,0,0,0"
-               VerticalAlignment="Center"
-               Fill="{Binding ConnectionStatusBrush}"/>
-
-      <TextBox Grid.Row="1" Grid.Column="0"
+                 IsVisible="{Binding IsRemote}"
+                 Text="{DynamicResource Text.OpenLocalRepository.RemotePath}"/>
+      <TextBox Grid.Row="1" Grid.Column="1"
                Height="28"
                CornerRadius="3"
-               Margin="0,0,4,0"
-               Text="{Binding RemotePath, Mode=TwoWay}"/>
-      <Button Grid.Row="1" Grid.Column="1"
-              Classes="icon_button" Width="28" Height="28"
-              Click="OnBrowseRemotePath">
-        <Path Data="{StaticResource Icons.Folder.Open}" Fill="{DynamicResource Brush.FG1}"/>
-      </Button>
+               IsVisible="{Binding IsRemote}"
+               Watermark="{DynamicResource Text.OpenLocalRepository.RemotePath.Placeholder}"
+               Text="{Binding RemotePath, Mode=TwoWay}">
+        <TextBox.InnerRightContent>
+          <Button Classes="icon_button" Width="28" Height="28" Margin="4,0,0,0" Click="OnBrowseRemotePath">
+            <Path Data="{StaticResource Icons.Folder.Open}" Fill="{DynamicResource Brush.FG1}"/>
+          </Button>
+        </TextBox.InnerRightContent>
+      </TextBox>
 
-      <ComboBox Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2"
+      <!-- Group -->
+      <TextBlock Grid.Row="2" Grid.Column="0"
+                 HorizontalAlignment="Right" VerticalAlignment="Center"
+                 Margin="0,0,8,0"
+                 Text="{DynamicResource Text.OpenLocalRepository.Group}"/>
+      <ComboBox Grid.Row="2" Grid.Column="1"
                 Height="28" Padding="8,0"
                 VerticalAlignment="Center" HorizontalAlignment="Stretch"
                 ItemsSource="{Binding Groups}"
@@ -105,7 +92,12 @@
         </ComboBox.ItemTemplate>
       </ComboBox>
 
-      <v:BookmarkSelector Grid.Row="3" Grid.Column="0"
+      <!-- Bookmark -->
+      <TextBlock Grid.Row="3" Grid.Column="0"
+                 HorizontalAlignment="Right" VerticalAlignment="Center"
+                 Margin="0,0,8,0"
+                 Text="{DynamicResource Text.OpenLocalRepository.Bookmark}"/>
+      <v:BookmarkSelector Grid.Row="3" Grid.Column="1"
                           HorizontalAlignment="Left" VerticalAlignment="Center"
                           Bookmark="{Binding Bookmark, Mode=TwoWay}"/>
     </Grid>

--- a/src/Views/OpenLocalRepository.axaml
+++ b/src/Views/OpenLocalRepository.axaml
@@ -22,6 +22,7 @@
 
     <ToggleButton Margin="8,12,0,0"
                   Height="28"
+                  Focusable="False"
                   Content="{DynamicResource Text.OpenLocalRepository.SSHRemote}"
                   IsChecked="{Binding IsSSHRemote, Mode=TwoWay}"/>
 
@@ -67,31 +68,32 @@
                           Bookmark="{Binding Bookmark, Mode=TwoWay}"/>
     </Grid>
 
-    <Grid Margin="8,8,0,0" RowDefinitions="32,32,32,32" ColumnDefinitions="Auto,*"
+    <Grid Margin="8,8,0,0" RowDefinitions="32,32,32,32" ColumnDefinitions="*,Auto"
           IsVisible="{Binding IsSSHRemote}">
-      <TextBlock Grid.Row="0" Grid.Column="0"
-                 HorizontalAlignment="Right"
-                 Margin="0,0,8,0"
-                 Text="{DynamicResource Text.OpenLocalRepository.Host}"/>
-      <TextBox Grid.Row="0" Grid.Column="1"
-               Height="28"
-               CornerRadius="3"
-               Text="{Binding SSHHost, Mode=TwoWay}"/>
+      <ComboBox Grid.Row="0" Grid.Column="0"
+                Height="28" Padding="8,0"
+                VerticalAlignment="Center" HorizontalAlignment="Stretch"
+                ItemsSource="{Binding SshHosts}"
+                SelectedItem="{Binding SSHHost, Mode=TwoWay}"
+                PlaceholderText="select ssh host"/>
+      <Ellipse Grid.Row="0" Grid.Column="1"
+               Width="12" Height="12"
+               Margin="8,0,0,0"
+               VerticalAlignment="Center"
+               Fill="{Binding ConnectionStatusBrush}"/>
 
-      <TextBlock Grid.Row="1" Grid.Column="0"
-                 HorizontalAlignment="Right"
-                 Margin="0,0,8,0"
-                 Text="{DynamicResource Text.OpenLocalRepository.RemotePath}"/>
-      <TextBox Grid.Row="1" Grid.Column="1"
+      <TextBox Grid.Row="1" Grid.Column="0"
                Height="28"
                CornerRadius="3"
+               Margin="0,0,4,0"
                Text="{Binding RemotePath, Mode=TwoWay}"/>
+      <Button Grid.Row="1" Grid.Column="1"
+              Classes="icon_button" Width="28" Height="28"
+              Click="OnBrowseRemotePath">
+        <Path Data="{StaticResource Icons.Folder.Open}" Fill="{DynamicResource Brush.FG1}"/>
+      </Button>
 
-      <TextBlock Grid.Row="2" Grid.Column="0"
-                 HorizontalAlignment="Right"
-                 Margin="0,0,8,0"
-                 Text="{DynamicResource Text.OpenLocalRepository.Group}"/>
-      <ComboBox Grid.Row="2" Grid.Column="1"
+      <ComboBox Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2"
                 Height="28" Padding="8,0"
                 VerticalAlignment="Center" HorizontalAlignment="Stretch"
                 ItemsSource="{Binding Groups}"
@@ -103,11 +105,7 @@
         </ComboBox.ItemTemplate>
       </ComboBox>
 
-      <TextBlock Grid.Row="3" Grid.Column="0"
-                 HorizontalAlignment="Right"
-                 Margin="0,0,8,0"
-                 Text="{DynamicResource Text.OpenLocalRepository.Bookmark}"/>
-      <v:BookmarkSelector Grid.Row="3" Grid.Column="1"
+      <v:BookmarkSelector Grid.Row="3" Grid.Column="0"
                           HorizontalAlignment="Left" VerticalAlignment="Center"
                           Bookmark="{Binding Bookmark, Mode=TwoWay}"/>
     </Grid>

--- a/src/Views/OpenLocalRepository.axaml
+++ b/src/Views/OpenLocalRepository.axaml
@@ -67,7 +67,7 @@
                           Bookmark="{Binding Bookmark, Mode=TwoWay}"/>
     </Grid>
 
-    <Grid Margin="8,8,0,0" RowDefinitions="32,32,32,32,32" ColumnDefinitions="Auto,*"
+    <Grid Margin="8,8,0,0" RowDefinitions="32,32,32,32" ColumnDefinitions="Auto,*"
           IsVisible="{Binding IsSSHRemote}">
       <TextBlock Grid.Row="0" Grid.Column="0"
                  HorizontalAlignment="Right"
@@ -81,26 +81,17 @@
       <TextBlock Grid.Row="1" Grid.Column="0"
                  HorizontalAlignment="Right"
                  Margin="0,0,8,0"
-                 Text="{DynamicResource Text.OpenLocalRepository.RemoteServerPath}"/>
-      <TextBox Grid.Row="1" Grid.Column="1"
-               Height="28"
-               CornerRadius="3"
-               Text="{Binding RemoteServerPath, Mode=TwoWay}"/>
-
-      <TextBlock Grid.Row="2" Grid.Column="0"
-                 HorizontalAlignment="Right"
-                 Margin="0,0,8,0"
                  Text="{DynamicResource Text.OpenLocalRepository.RemotePath}"/>
-      <TextBox Grid.Row="2" Grid.Column="1"
+      <TextBox Grid.Row="1" Grid.Column="1"
                Height="28"
                CornerRadius="3"
                Text="{Binding RemotePath, Mode=TwoWay}"/>
 
-      <TextBlock Grid.Row="3" Grid.Column="0"
+      <TextBlock Grid.Row="2" Grid.Column="0"
                  HorizontalAlignment="Right"
                  Margin="0,0,8,0"
                  Text="{DynamicResource Text.OpenLocalRepository.Group}"/>
-      <ComboBox Grid.Row="3" Grid.Column="1"
+      <ComboBox Grid.Row="2" Grid.Column="1"
                 Height="28" Padding="8,0"
                 VerticalAlignment="Center" HorizontalAlignment="Stretch"
                 ItemsSource="{Binding Groups}"
@@ -112,11 +103,11 @@
         </ComboBox.ItemTemplate>
       </ComboBox>
 
-      <TextBlock Grid.Row="4" Grid.Column="0"
+      <TextBlock Grid.Row="3" Grid.Column="0"
                  HorizontalAlignment="Right"
                  Margin="0,0,8,0"
                  Text="{DynamicResource Text.OpenLocalRepository.Bookmark}"/>
-      <v:BookmarkSelector Grid.Row="4" Grid.Column="1"
+      <v:BookmarkSelector Grid.Row="3" Grid.Column="1"
                           HorizontalAlignment="Left" VerticalAlignment="Center"
                           Bookmark="{Binding Bookmark, Mode=TwoWay}"/>
     </Grid>

--- a/src/Views/OpenLocalRepository.axaml.cs
+++ b/src/Views/OpenLocalRepository.axaml.cs
@@ -52,5 +52,12 @@ namespace SourceGit.Views
 
             e.Handled = true;
         }
+
+        private void OnBrowseRemotePath(object _1, RoutedEventArgs e)
+        {
+            if (DataContext is ViewModels.OpenLocalRepository vm)
+                vm.BrowseRemotePath();
+            e.Handled = true;
+        }
     }
 }

--- a/src/Views/Preferences.axaml
+++ b/src/Views/Preferences.axaml
@@ -1097,10 +1097,12 @@
                                TextWrapping="NoWrap"
                                FontFamily="{StaticResource Fonts.Monospace}"
                                FontSize="11"
-                               Foreground="{DynamicResource Brush.FG2}"
+                               Foreground="{DynamicResource Brush.FG1}"
                                Background="Transparent"
                                BorderThickness="0"
-                               CaretBrush="{DynamicResource Brush.FG2}"
+                               CaretBrush="{DynamicResource Brush.FG1}"
+                               SelectionBrush="{DynamicResource Brush.Accent}"
+                               SelectionForegroundBrush="White"
                                ScrollViewer.VerticalScrollBarVisibility="Auto"
                                ScrollViewer.HorizontalScrollBarVisibility="Auto"/>
                     </Border>

--- a/src/Views/Preferences.axaml
+++ b/src/Views/Preferences.axaml
@@ -14,7 +14,8 @@
                     x:Name="ThisControl"
                     Icon="/App.ico"
                     Title="{DynamicResource Text.Preferences}"
-                    SizeToContent="WidthAndHeight"
+                    Width="720" Height="640"
+                    SizeToContent="Manual"
                     CanResize="False"
                     WindowStartupLocation="CenterScreen">
   <Grid RowDefinitions="Auto,Auto" MinWidth="600">
@@ -1087,16 +1088,20 @@
                     <Border Grid.Row="6" Margin="0,8,0,0"
                             BorderThickness="1" BorderBrush="{DynamicResource Brush.Border1}"
                             CornerRadius="3" Background="{DynamicResource Brush.Contents}"
-                            IsVisible="{Binding StatusLog.Count, Converter={x:Static c:IntConverters.IsGreaterThanZero}}">
-                      <ScrollViewer Padding="4" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
-                        <ItemsControl ItemsSource="{Binding StatusLog}">
-                          <ItemsControl.ItemTemplate>
-                            <DataTemplate DataType="x:String">
-                              <TextBlock Text="{Binding}" FontFamily="{StaticResource Fonts.Monospace}" FontSize="11" Foreground="{DynamicResource Brush.FG2}" TextWrapping="NoWrap" TextTrimming="CharacterEllipsis"/>
-                            </DataTemplate>
-                          </ItemsControl.ItemTemplate>
-                        </ItemsControl>
-                      </ScrollViewer>
+                            IsVisible="{Binding StatusLogText, Converter={x:Static StringConverters.IsNotNullOrEmpty}}">
+                      <TextBox Margin="0" Padding="4"
+                               Text="{Binding StatusLogText, Mode=OneWay}"
+                               IsReadOnly="True"
+                               AcceptsReturn="True"
+                               TextWrapping="NoWrap"
+                               FontFamily="{StaticResource Fonts.Monospace}"
+                               FontSize="11"
+                               Foreground="{DynamicResource Brush.FG2}"
+                               Background="Transparent"
+                               BorderThickness="0"
+                               CaretBrush="{DynamicResource Brush.FG2}"
+                               ScrollViewer.VerticalScrollBarVisibility="Auto"
+                               ScrollViewer.HorizontalScrollBarVisibility="Auto"/>
                     </Border>
                   </Grid>
                 </DataTemplate>

--- a/src/Views/Preferences.axaml
+++ b/src/Views/Preferences.axaml
@@ -1031,32 +1031,34 @@
                                 PlaceholderText="{DynamicResource Text.Preferences.RemoteHosts.FromConfig}"/>
                     </Grid>
 
-                    <StackPanel Orientation="Horizontal" Margin="0,16,0,0" Spacing="8">
-                      <!-- Reset on the far left so the destructive/long action is hardest to hit by accident -->
-                      <Button Classes="flat" Height="28" MinWidth="76"
+                    <Grid Margin="0,16,0,0" ColumnDefinitions="Auto,Auto,*,Auto,Auto">
+                      <!-- Destructive/long actions on the far left to avoid misclicks -->
+                      <Button Grid.Column="0" Classes="flat" Height="28" MinWidth="76"
                               Click="OnResetRemoteHost"
                               IsVisible="{Binding IsConnected}"
                               IsEnabled="{Binding !IsBusy}"
                               Content="{DynamicResource Text.Preferences.RemoteHosts.Reset}"/>
 
-                      <Button Classes="flat" Height="28" MinWidth="76"
+                      <Button Grid.Column="1" Classes="flat" Height="28" MinWidth="76"
+                              Margin="8,0,0,0"
                               Click="OnDisconnectRemoteHost"
                               IsVisible="{Binding IsConnected}"
                               IsEnabled="{Binding !IsBusy}"
                               Content="{DynamicResource Text.Preferences.RemoteHosts.Disconnect}"/>
 
-                      <!-- Test is always available so the user can check liveness even when connected -->
-                      <Button Classes="flat" Height="28" MinWidth="76"
+                      <!-- Test is always available so the user can check liveness/latency even when connected -->
+                      <Button Grid.Column="3" Classes="flat" Height="28" MinWidth="76"
                               Click="OnTestRemoteHost"
                               IsEnabled="{Binding !IsBusy}"
                               Content="{DynamicResource Text.Preferences.RemoteHosts.Test}"/>
 
-                      <Button Classes="flat primary" Height="28" MinWidth="76"
+                      <Button Grid.Column="4" Classes="flat primary" Height="28" MinWidth="76"
+                              Margin="8,0,0,0"
                               Click="OnConnectRemoteHost"
                               IsVisible="{Binding !IsConnected}"
                               IsEnabled="{Binding !IsBusy}"
                               Content="{DynamicResource Text.Preferences.RemoteHosts.Connect}"/>
-                    </StackPanel>
+                    </Grid>
 
                     <TextBlock Margin="0,8,0,0"
                                Text="{Binding StatusMessage}"

--- a/src/Views/Preferences.axaml
+++ b/src/Views/Preferences.axaml
@@ -1031,18 +1031,6 @@
                                 PlaceholderText="{DynamicResource Text.Preferences.RemoteHosts.FromConfig}"/>
                     </Grid>
 
-                    <TextBlock Margin="0,12,0,0" Text="{DynamicResource Text.Preferences.RemoteHosts.Status}"/>
-                    <Border Margin="0,4,0,0" Height="28"
-                            BorderThickness="1" BorderBrush="{DynamicResource Brush.Border1}"
-                            CornerRadius="3" Background="{DynamicResource Brush.Contents}">
-                      <StackPanel Orientation="Horizontal" Margin="8,0" VerticalAlignment="Center">
-                        <Ellipse Width="9" Height="9" VerticalAlignment="Center" Fill="{Binding StatusBrush}"/>
-                        <TextBlock Margin="8,0,0,0" VerticalAlignment="Center"
-                                   Text="{Binding StatusMessage}" Foreground="{DynamicResource Brush.FG2}"
-                                   TextTrimming="CharacterEllipsis"/>
-                      </StackPanel>
-                    </Border>
-
                     <StackPanel Orientation="Horizontal" Margin="0,16,0,0" Spacing="8">
                       <Button Classes="flat" Height="28" MinWidth="76"
                               Click="OnTestRemoteHost"
@@ -1066,6 +1054,12 @@
                               IsVisible="{Binding IsConnected}"
                               Content="{DynamicResource Text.Preferences.RemoteHosts.Disconnect}"/>
                     </StackPanel>
+
+                    <TextBlock Margin="0,8,0,0"
+                               Text="{Binding StatusMessage}"
+                               Foreground="{DynamicResource Brush.FG2}"
+                               TextTrimming="CharacterEllipsis"
+                               IsVisible="{Binding StatusMessage, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"/>
                   </StackPanel>
                 </DataTemplate>
               </ContentControl.DataTemplates>

--- a/src/Views/Preferences.axaml
+++ b/src/Views/Preferences.axaml
@@ -936,6 +936,142 @@
             </ContentControl>
           </Grid>
         </TabItem>
+
+        <TabItem>
+          <TabItem.Header>
+            <TextBlock Classes="tab_header" Text="{DynamicResource Text.Preferences.RemoteHosts}"/>
+          </TabItem.Header>
+
+          <Grid Margin="0,8,0,16" MinHeight="400">
+            <Grid.ColumnDefinitions>
+              <ColumnDefinition Width="220"/>
+              <ColumnDefinition Width="*" MaxWidth="420"/>
+            </Grid.ColumnDefinitions>
+
+            <Border Grid.Column="0"
+                    BorderThickness="1" BorderBrush="{DynamicResource Brush.Border2}"
+                    Background="{DynamicResource Brush.Contents}">
+              <Grid RowDefinitions="*,1,Auto">
+                <ListBox Grid.Row="0"
+                         Background="Transparent"
+                         ItemsSource="{Binding RemoteHosts}"
+                         SelectedItem="{Binding #ThisControl.SelectedRemoteHost, Mode=TwoWay}"
+                         SelectionMode="Single">
+                  <ListBox.Styles>
+                    <Style Selector="ListBoxItem">
+                      <Setter Property="MinHeight" Value="0"/>
+                      <Setter Property="Height" Value="30"/>
+                      <Setter Property="Padding" Value="4,2"/>
+                    </Style>
+                  </ListBox.Styles>
+
+                  <ListBox.ItemsPanel>
+                    <ItemsPanelTemplate>
+                      <StackPanel Orientation="Vertical"/>
+                    </ItemsPanelTemplate>
+                  </ListBox.ItemsPanel>
+
+                  <ListBox.ItemTemplate>
+                    <DataTemplate DataType="m:RemoteHost">
+                      <Grid ColumnDefinitions="Auto,*" VerticalAlignment="Center">
+                        <Ellipse Grid.Column="0" Width="9" Height="9" VerticalAlignment="Center" Fill="{Binding StatusBrush}"/>
+                        <StackPanel Grid.Column="1" Margin="8,0,0,0" Orientation="Vertical" VerticalAlignment="Center">
+                          <TextBlock Text="{Binding Name}" TextTrimming="CharacterEllipsis" FontWeight="{Binding IsConnected, Converter={x:Static c:BoolConverters.IsBoldToFontWeight}}"/>
+                          <TextBlock Text="{Binding Host}" FontSize="10" Foreground="{DynamicResource Brush.FG2}" TextTrimming="CharacterEllipsis"/>
+                        </StackPanel>
+                      </Grid>
+                    </DataTemplate>
+                  </ListBox.ItemTemplate>
+                </ListBox>
+
+                <Rectangle Grid.Row="1" Height="1" Fill="{DynamicResource Brush.Border2}" HorizontalAlignment="Stretch" VerticalAlignment="Bottom"/>
+
+                <StackPanel Grid.Row="2" Orientation="Horizontal" Background="{DynamicResource Brush.ToolBar}">
+                  <Button Classes="icon_button" Width="28" Height="28" Click="OnAddRemoteHost" ToolTip.Tip="{DynamicResource Text.Preferences.RemoteHosts.Add}">
+                    <Path Width="14" Height="14" Data="{StaticResource Icons.Plus}"/>
+                  </Button>
+
+                  <Button Classes="icon_button" Width="28" Height="28" Click="OnRemoveSelectedRemoteHost" ToolTip.Tip="{DynamicResource Text.Preferences.RemoteHosts.Remove}">
+                    <Path Width="14" Height="14" Data="{StaticResource Icons.Minus}"/>
+                  </Button>
+                </StackPanel>
+              </Grid>
+            </Border>
+
+            <ContentControl Grid.Column="1" Margin="16,0,0,0">
+              <ContentControl.Content>
+                <Binding Path="#ThisControl.SelectedRemoteHost">
+                  <Binding.TargetNullValue>
+                    <Path Width="64" Height="64"
+                          HorizontalAlignment="Center"
+                          VerticalAlignment="Center"
+                          Fill="{DynamicResource Brush.FG2}"
+                          Data="{StaticResource Icons.Remote}"/>
+                  </Binding.TargetNullValue>
+                </Binding>
+              </ContentControl.Content>
+
+              <ContentControl.DataTemplates>
+                <DataTemplate DataType="m:RemoteHost">
+                  <StackPanel Orientation="Vertical">
+                    <TextBlock Text="{DynamicResource Text.Preferences.RemoteHosts.Name}"/>
+                    <TextBox Margin="0,4,0,0" CornerRadius="3" Height="28" Text="{Binding Name, Mode=TwoWay}"/>
+
+                    <TextBlock Margin="0,12,0,0" Text="{DynamicResource Text.Preferences.RemoteHosts.Host}"/>
+                    <Grid Margin="0,4,0,0" ColumnDefinitions="*,8,150">
+                      <TextBox Grid.Column="0"
+                               CornerRadius="3" Height="28"
+                               Text="{Binding Host, Mode=TwoWay}"
+                               Watermark="{DynamicResource Text.Preferences.RemoteHosts.HostPlaceholder}"/>
+                      <ComboBox Grid.Column="2"
+                                Height="28" Padding="8,0"
+                                HorizontalAlignment="Stretch"
+                                ItemsSource="{Binding #ThisControl.SshConfigHosts}"
+                                SelectionChanged="OnPickSshConfigHost"
+                                PlaceholderText="{DynamicResource Text.Preferences.RemoteHosts.FromConfig}"/>
+                    </Grid>
+
+                    <TextBlock Margin="0,12,0,0" Text="{DynamicResource Text.Preferences.RemoteHosts.Status}"/>
+                    <Border Margin="0,4,0,0" Height="28"
+                            BorderThickness="1" BorderBrush="{DynamicResource Brush.Border1}"
+                            CornerRadius="3" Background="{DynamicResource Brush.Contents}">
+                      <StackPanel Orientation="Horizontal" Margin="8,0" VerticalAlignment="Center">
+                        <Ellipse Width="9" Height="9" VerticalAlignment="Center" Fill="{Binding StatusBrush}"/>
+                        <TextBlock Margin="8,0,0,0" VerticalAlignment="Center"
+                                   Text="{Binding StatusMessage}" Foreground="{DynamicResource Brush.FG2}"
+                                   TextTrimming="CharacterEllipsis"/>
+                      </StackPanel>
+                    </Border>
+
+                    <StackPanel Orientation="Horizontal" Margin="0,16,0,0" Spacing="8">
+                      <Button Classes="flat" Height="28" MinWidth="76"
+                              Click="OnTestRemoteHost"
+                              IsVisible="{Binding !IsConnected}"
+                              IsEnabled="{Binding !IsBusy}"
+                              Content="{DynamicResource Text.Preferences.RemoteHosts.Test}"/>
+
+                      <Button Classes="flat primary" Height="28" MinWidth="76"
+                              Click="OnConnectRemoteHost"
+                              IsVisible="{Binding !IsConnected}"
+                              IsEnabled="{Binding !IsBusy}"
+                              Content="{DynamicResource Text.Preferences.RemoteHosts.Connect}"/>
+
+                      <Button Classes="flat" Height="28" MinWidth="76"
+                              Click="OnResetRemoteHost"
+                              IsVisible="{Binding IsConnected}"
+                              Content="{DynamicResource Text.Preferences.RemoteHosts.Reset}"/>
+
+                      <Button Classes="flat" Height="28" MinWidth="76"
+                              Click="OnDisconnectRemoteHost"
+                              IsVisible="{Binding IsConnected}"
+                              Content="{DynamicResource Text.Preferences.RemoteHosts.Disconnect}"/>
+                    </StackPanel>
+                  </StackPanel>
+                </DataTemplate>
+              </ContentControl.DataTemplates>
+            </ContentControl>
+          </Grid>
+        </TabItem>
       </TabControl>
     </Border>
   </Grid>

--- a/src/Views/Preferences.axaml
+++ b/src/Views/Preferences.axaml
@@ -1013,12 +1013,12 @@
 
               <ContentControl.DataTemplates>
                 <DataTemplate DataType="m:RemoteHost">
-                  <StackPanel Orientation="Vertical">
-                    <TextBlock Text="{DynamicResource Text.Preferences.RemoteHosts.Name}"/>
-                    <TextBox Margin="0,4,0,0" CornerRadius="3" Height="28" Text="{Binding Name, Mode=TwoWay}"/>
+                  <Grid RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,*">
+                    <TextBlock Grid.Row="0" Text="{DynamicResource Text.Preferences.RemoteHosts.Name}"/>
+                    <TextBox Grid.Row="1" Margin="0,4,0,0" CornerRadius="3" Height="28" Text="{Binding Name, Mode=TwoWay}"/>
 
-                    <TextBlock Margin="0,12,0,0" Text="{DynamicResource Text.Preferences.RemoteHosts.Host}"/>
-                    <Grid Margin="0,4,0,0" ColumnDefinitions="*,8,150">
+                    <TextBlock Grid.Row="2" Margin="0,12,0,0" Text="{DynamicResource Text.Preferences.RemoteHosts.Host}"/>
+                    <Grid Grid.Row="3" Margin="0,4,0,0" ColumnDefinitions="*,8,150">
                       <TextBox Grid.Column="0"
                                CornerRadius="3" Height="28"
                                Text="{Binding Host, Mode=TwoWay}"
@@ -1031,20 +1031,32 @@
                                 PlaceholderText="{DynamicResource Text.Preferences.RemoteHosts.FromConfig}"/>
                     </Grid>
 
-                    <Grid Margin="0,16,0,0" ColumnDefinitions="Auto,Auto,*,Auto,Auto">
-                      <!-- Destructive/long actions on the far left to avoid misclicks -->
+                    <Grid Grid.Row="4" Margin="0,16,0,0" ColumnDefinitions="Auto,Auto,*,Auto,Auto">
+                      <!-- Destructive/long actions on the far left to avoid misclicks.
+                           Buttons stay in place (always visible) and just gray out when not
+                           applicable, so testing/refreshing doesn't shift the layout. -->
                       <Button Grid.Column="0" Classes="flat" Height="28" MinWidth="76"
                               Click="OnResetRemoteHost"
-                              IsVisible="{Binding IsConnected}"
-                              IsEnabled="{Binding !IsBusy}"
-                              Content="{DynamicResource Text.Preferences.RemoteHosts.Reset}"/>
+                              Content="{DynamicResource Text.Preferences.RemoteHosts.Reset}">
+                        <Button.IsEnabled>
+                          <MultiBinding Converter="{x:Static BoolConverters.And}">
+                            <Binding Path="IsConnected"/>
+                            <Binding Path="IsBusy" Converter="{x:Static BoolConverters.Not}"/>
+                          </MultiBinding>
+                        </Button.IsEnabled>
+                      </Button>
 
                       <Button Grid.Column="1" Classes="flat" Height="28" MinWidth="76"
                               Margin="8,0,0,0"
                               Click="OnDisconnectRemoteHost"
-                              IsVisible="{Binding IsConnected}"
-                              IsEnabled="{Binding !IsBusy}"
-                              Content="{DynamicResource Text.Preferences.RemoteHosts.Disconnect}"/>
+                              Content="{DynamicResource Text.Preferences.RemoteHosts.Disconnect}">
+                        <Button.IsEnabled>
+                          <MultiBinding Converter="{x:Static BoolConverters.And}">
+                            <Binding Path="IsConnected"/>
+                            <Binding Path="IsBusy" Converter="{x:Static BoolConverters.Not}"/>
+                          </MultiBinding>
+                        </Button.IsEnabled>
+                      </Button>
 
                       <!-- Test is always available so the user can check liveness/latency even when connected -->
                       <Button Grid.Column="3" Classes="flat" Height="28" MinWidth="76"
@@ -1055,22 +1067,28 @@
                       <Button Grid.Column="4" Classes="flat primary" Height="28" MinWidth="76"
                               Margin="8,0,0,0"
                               Click="OnConnectRemoteHost"
-                              IsVisible="{Binding !IsConnected}"
-                              IsEnabled="{Binding !IsBusy}"
-                              Content="{DynamicResource Text.Preferences.RemoteHosts.Connect}"/>
+                              Content="{DynamicResource Text.Preferences.RemoteHosts.Connect}">
+                        <Button.IsEnabled>
+                          <MultiBinding Converter="{x:Static BoolConverters.And}">
+                            <Binding Path="IsConnected" Converter="{x:Static BoolConverters.Not}"/>
+                            <Binding Path="IsBusy" Converter="{x:Static BoolConverters.Not}"/>
+                          </MultiBinding>
+                        </Button.IsEnabled>
+                      </Button>
                     </Grid>
 
-                    <TextBlock Margin="0,8,0,0"
+                    <TextBlock Grid.Row="5" Margin="0,8,0,0"
                                Text="{Binding StatusMessage}"
                                Foreground="{Binding StatusBrush}"
                                TextTrimming="CharacterEllipsis"
+                               VerticalAlignment="Top"
                                IsVisible="{Binding StatusMessage, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"/>
 
-                    <Border Margin="0,8,0,0"
+                    <Border Grid.Row="6" Margin="0,8,0,0"
                             BorderThickness="1" BorderBrush="{DynamicResource Brush.Border1}"
                             CornerRadius="3" Background="{DynamicResource Brush.Contents}"
-                            IsVisible="{Binding IsBusy}">
-                      <ScrollViewer MaxHeight="140" Padding="4" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
+                            IsVisible="{Binding StatusLog.Count, Converter={x:Static c:IntConverters.IsGreaterThanZero}}">
+                      <ScrollViewer Padding="4" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
                         <ItemsControl ItemsSource="{Binding StatusLog}">
                           <ItemsControl.ItemTemplate>
                             <DataTemplate DataType="x:String">
@@ -1080,7 +1098,7 @@
                         </ItemsControl>
                       </ScrollViewer>
                     </Border>
-                  </StackPanel>
+                  </Grid>
                 </DataTemplate>
               </ContentControl.DataTemplates>
             </ContentControl>

--- a/src/Views/Preferences.axaml
+++ b/src/Views/Preferences.axaml
@@ -1063,14 +1063,13 @@
                     <TextBlock Margin="0,8,0,0"
                                Text="{Binding StatusMessage}"
                                Foreground="{Binding StatusBrush}"
-                               FontWeight="Bold"
                                TextTrimming="CharacterEllipsis"
                                IsVisible="{Binding StatusMessage, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"/>
 
                     <Border Margin="0,8,0,0"
                             BorderThickness="1" BorderBrush="{DynamicResource Brush.Border1}"
                             CornerRadius="3" Background="{DynamicResource Brush.Contents}"
-                            IsVisible="{Binding StatusLog.Count, Converter={x:Static c:IntConverters.IsGreaterThanZero}}">
+                            IsVisible="{Binding IsBusy}">
                       <ScrollViewer MaxHeight="140" Padding="4" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
                         <ItemsControl ItemsSource="{Binding StatusLog}">
                           <ItemsControl.ItemTemplate>

--- a/src/Views/Preferences.axaml
+++ b/src/Views/Preferences.axaml
@@ -14,8 +14,7 @@
                     x:Name="ThisControl"
                     Icon="/App.ico"
                     Title="{DynamicResource Text.Preferences}"
-                    Width="720" Height="640"
-                    SizeToContent="Manual"
+                    SizeToContent="WidthAndHeight"
                     CanResize="False"
                     WindowStartupLocation="CenterScreen">
   <Grid RowDefinitions="Auto,Auto" MinWidth="600">
@@ -1014,7 +1013,7 @@
 
               <ContentControl.DataTemplates>
                 <DataTemplate DataType="m:RemoteHost">
-                  <Grid RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,*">
+                  <Grid RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto">
                     <TextBlock Grid.Row="0" Text="{DynamicResource Text.Preferences.RemoteHosts.Name}"/>
                     <TextBox Grid.Row="1" Margin="0,4,0,0" CornerRadius="3" Height="28" Text="{Binding Name, Mode=TwoWay}"/>
 
@@ -1086,9 +1085,11 @@
                                IsVisible="{Binding StatusMessage, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"/>
 
                     <Border Grid.Row="6" Margin="0,8,0,0"
+                            Height="160"
                             BorderThickness="1" BorderBrush="{DynamicResource Brush.Border1}"
                             CornerRadius="3" Background="{DynamicResource Brush.Contents}"
-                            IsVisible="{Binding StatusLogText, Converter={x:Static StringConverters.IsNotNullOrEmpty}}">
+                            IsVisible="{Binding StatusLogText, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"
+                            ClipToBounds="True">
                       <TextBox Margin="0" Padding="4"
                                Text="{Binding StatusLogText, Mode=OneWay}"
                                IsReadOnly="True"

--- a/src/Views/Preferences.axaml
+++ b/src/Views/Preferences.axaml
@@ -1032,9 +1032,22 @@
                     </Grid>
 
                     <StackPanel Orientation="Horizontal" Margin="0,16,0,0" Spacing="8">
+                      <!-- Reset on the far left so the destructive/long action is hardest to hit by accident -->
+                      <Button Classes="flat" Height="28" MinWidth="76"
+                              Click="OnResetRemoteHost"
+                              IsVisible="{Binding IsConnected}"
+                              IsEnabled="{Binding !IsBusy}"
+                              Content="{DynamicResource Text.Preferences.RemoteHosts.Reset}"/>
+
+                      <Button Classes="flat" Height="28" MinWidth="76"
+                              Click="OnDisconnectRemoteHost"
+                              IsVisible="{Binding IsConnected}"
+                              IsEnabled="{Binding !IsBusy}"
+                              Content="{DynamicResource Text.Preferences.RemoteHosts.Disconnect}"/>
+
+                      <!-- Test is always available so the user can check liveness even when connected -->
                       <Button Classes="flat" Height="28" MinWidth="76"
                               Click="OnTestRemoteHost"
-                              IsVisible="{Binding !IsConnected}"
                               IsEnabled="{Binding !IsBusy}"
                               Content="{DynamicResource Text.Preferences.RemoteHosts.Test}"/>
 
@@ -1043,23 +1056,29 @@
                               IsVisible="{Binding !IsConnected}"
                               IsEnabled="{Binding !IsBusy}"
                               Content="{DynamicResource Text.Preferences.RemoteHosts.Connect}"/>
-
-                      <Button Classes="flat" Height="28" MinWidth="76"
-                              Click="OnResetRemoteHost"
-                              IsVisible="{Binding IsConnected}"
-                              Content="{DynamicResource Text.Preferences.RemoteHosts.Reset}"/>
-
-                      <Button Classes="flat" Height="28" MinWidth="76"
-                              Click="OnDisconnectRemoteHost"
-                              IsVisible="{Binding IsConnected}"
-                              Content="{DynamicResource Text.Preferences.RemoteHosts.Disconnect}"/>
                     </StackPanel>
 
                     <TextBlock Margin="0,8,0,0"
                                Text="{Binding StatusMessage}"
-                               Foreground="{DynamicResource Brush.FG2}"
+                               Foreground="{Binding StatusBrush}"
+                               FontWeight="Bold"
                                TextTrimming="CharacterEllipsis"
                                IsVisible="{Binding StatusMessage, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"/>
+
+                    <Border Margin="0,8,0,0"
+                            BorderThickness="1" BorderBrush="{DynamicResource Brush.Border1}"
+                            CornerRadius="3" Background="{DynamicResource Brush.Contents}"
+                            IsVisible="{Binding StatusLog.Count, Converter={x:Static c:IntConverters.IsGreaterThanZero}}">
+                      <ScrollViewer MaxHeight="140" Padding="4" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
+                        <ItemsControl ItemsSource="{Binding StatusLog}">
+                          <ItemsControl.ItemTemplate>
+                            <DataTemplate DataType="x:String">
+                              <TextBlock Text="{Binding}" FontFamily="{StaticResource Fonts.Monospace}" FontSize="11" Foreground="{DynamicResource Brush.FG2}" TextWrapping="NoWrap" TextTrimming="CharacterEllipsis"/>
+                            </DataTemplate>
+                          </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+                      </ScrollViewer>
+                    </Border>
                   </StackPanel>
                 </DataTemplate>
               </ContentControl.DataTemplates>

--- a/src/Views/Preferences.axaml
+++ b/src/Views/Preferences.axaml
@@ -1090,21 +1090,13 @@
                             CornerRadius="3" Background="{DynamicResource Brush.Contents}"
                             IsVisible="{Binding StatusLogText, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"
                             ClipToBounds="True">
-                      <TextBox Margin="0" Padding="4"
-                               Text="{Binding StatusLogText, Mode=OneWay}"
-                               IsReadOnly="True"
-                               AcceptsReturn="True"
-                               TextWrapping="NoWrap"
-                               FontFamily="{StaticResource Fonts.Monospace}"
-                               FontSize="11"
-                               Foreground="{DynamicResource Brush.FG1}"
-                               Background="Transparent"
-                               BorderThickness="0"
-                               CaretBrush="{DynamicResource Brush.FG1}"
-                               SelectionBrush="{DynamicResource Brush.Accent}"
-                               SelectionForegroundBrush="White"
-                               ScrollViewer.VerticalScrollBarVisibility="Auto"
-                               ScrollViewer.HorizontalScrollBarVisibility="Auto"/>
+                      <ScrollViewer Padding="4" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto">
+                        <SelectableTextBlock Text="{Binding StatusLogText, Mode=OneWay}"
+                                             FontFamily="{StaticResource Fonts.Monospace}"
+                                             FontSize="10"
+                                             Foreground="{DynamicResource Brush.FG1}"
+                                             TextWrapping="NoWrap"/>
+                      </ScrollViewer>
                     </Border>
                   </Grid>
                 </DataTemplate>

--- a/src/Views/Preferences.axaml.cs
+++ b/src/Views/Preferences.axaml.cs
@@ -153,6 +153,11 @@ namespace SourceGit.Views
             DataContext = pref;
             CloseOnESC = true;
 
+            // Clear stale remote host logs from a previous settings session so the log box
+            // starts hidden and only shows content after a fresh test/connect/reset.
+            foreach (var host in pref.RemoteHosts)
+                Remote.RemoteHostManager.Instance.ClearLog(host);
+
             if (pref.IsGitConfigured())
             {
                 var config = new Commands.Config(null).ReadAll();

--- a/src/Views/Preferences.axaml.cs
+++ b/src/Views/Preferences.axaml.cs
@@ -129,6 +129,24 @@ namespace SourceGit.Views
             set => SetAndRaise(SelectedCustomActionProperty, ref _selectedCustomAction, value);
         }
 
+        public static readonly DirectProperty<Preferences, Models.RemoteHost> SelectedRemoteHostProperty =
+            AvaloniaProperty.RegisterDirect<Preferences, Models.RemoteHost>(
+                nameof(SelectedRemoteHost),
+                static o => o.SelectedRemoteHost,
+                static (o, v) => o.SelectedRemoteHost = v);
+
+        public Models.RemoteHost SelectedRemoteHost
+        {
+            get => _selectedRemoteHost;
+            set => SetAndRaise(SelectedRemoteHostProperty, ref _selectedRemoteHost, value);
+        }
+
+        /// <summary>Host aliases parsed from ~/.ssh/config, offered as suggestions.</summary>
+        public List<string> SshConfigHosts
+        {
+            get;
+        } = Remote.SshConfigParser.GetHosts();
+
         public Preferences()
         {
             var pref = ViewModels.Preferences.Instance;
@@ -518,11 +536,76 @@ namespace SourceGit.Views
             ShowGitVersionWarning = !string.IsNullOrEmpty(GitVersion) && Native.OS.GitVersion < Models.GitVersions.MINIMAL;
         }
 
+        private void OnAddRemoteHost(object sender, RoutedEventArgs e)
+        {
+            var host = new Models.RemoteHost { Name = "Unnamed Host", Host = string.Empty };
+            ViewModels.Preferences.Instance.RemoteHosts.Add(host);
+            SelectedRemoteHost = host;
+            ViewModels.Preferences.Instance.Save();
+            e.Handled = true;
+        }
+
+        private void OnRemoveSelectedRemoteHost(object sender, RoutedEventArgs e)
+        {
+            if (SelectedRemoteHost == null)
+                return;
+
+            Remote.RemoteHostManager.Instance.Disconnect(SelectedRemoteHost);
+            ViewModels.Preferences.Instance.RemoteHosts.Remove(SelectedRemoteHost);
+            SelectedRemoteHost = null;
+            ViewModels.Preferences.Instance.Save();
+            e.Handled = true;
+        }
+
+        private void OnPickSshConfigHost(object sender, SelectionChangedEventArgs e)
+        {
+            if (sender is ComboBox { SelectedItem: string alias, DataContext: Models.RemoteHost host } combo &&
+                !string.IsNullOrEmpty(alias))
+            {
+                host.Host = alias;
+                if (string.IsNullOrWhiteSpace(host.Name) || host.Name == "Unnamed Host")
+                    host.Name = alias;
+
+                combo.SelectedItem = null;
+            }
+
+            e.Handled = true;
+        }
+
+        private void OnTestRemoteHost(object sender, RoutedEventArgs e)
+        {
+            if (sender is Button { DataContext: Models.RemoteHost host })
+                _ = Remote.RemoteHostManager.Instance.TestAsync(host);
+            e.Handled = true;
+        }
+
+        private void OnConnectRemoteHost(object sender, RoutedEventArgs e)
+        {
+            if (sender is Button { DataContext: Models.RemoteHost host })
+                _ = Remote.RemoteHostManager.Instance.ConnectAsync(host);
+            e.Handled = true;
+        }
+
+        private void OnDisconnectRemoteHost(object sender, RoutedEventArgs e)
+        {
+            if (sender is Button { DataContext: Models.RemoteHost host })
+                Remote.RemoteHostManager.Instance.Disconnect(host);
+            e.Handled = true;
+        }
+
+        private void OnResetRemoteHost(object sender, RoutedEventArgs e)
+        {
+            if (sender is Button { DataContext: Models.RemoteHost host })
+                _ = Remote.RemoteHostManager.Instance.ResetAsync(host);
+            e.Handled = true;
+        }
+
         private string _gitVersion = string.Empty;
         private bool _showGitVersionWarning = false;
         private Models.GPGFormat _gpgFormat = Models.GPGFormat.Supported[0];
         private string _gpgExecutableFile = string.Empty;
         private AI.Service _selectedOpenAIService = null;
         private Models.CustomAction _selectedCustomAction = null;
+        private Models.RemoteHost _selectedRemoteHost = null;
     }
 }

--- a/src/Views/RemoteFolderPicker.axaml
+++ b/src/Views/RemoteFolderPicker.axaml
@@ -1,23 +1,114 @@
-<Window xmlns="https://github.com/avaloniaui"
-        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        x:Class="SourceGit.Views.RemoteFolderPicker"
-        Title="Select Remote Folder"
-        Width="560" Height="440"
-        WindowStartupLocation="CenterOwner"
-        CanResize="True">
-  <Grid RowDefinitions="Auto,Auto,*,Auto" Margin="10">
-    <Grid Grid.Row="0" ColumnDefinitions="*,Auto">
-      <TextBox Grid.Column="0" x:Name="txtPath" Margin="0,0,6,0" Watermark="remote path"/>
-      <Button Grid.Column="1" Click="OnGo">Go</Button>
+<v:ChromelessWindow xmlns="https://github.com/avaloniaui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+                    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+                    xmlns:v="using:SourceGit.Views"
+                    mc:Ignorable="d" d:DesignWidth="560" d:DesignHeight="460"
+                    x:Class="SourceGit.Views.RemoteFolderPicker"
+                    x:Name="ThisControl"
+                    Icon="/App.ico"
+                    Title="{DynamicResource Text.RemoteFolderPicker}"
+                    Width="560" Height="460"
+                    CanResize="True"
+                    WindowStartupLocation="CenterOwner">
+  <Grid RowDefinitions="Auto,*">
+    <!-- TitleBar -->
+    <Grid Grid.Row="0" Height="28" IsVisible="{Binding !#ThisControl.UseSystemWindowFrame}">
+      <Border Background="{DynamicResource Brush.TitleBar}"
+              BorderThickness="0,0,0,1" BorderBrush="{DynamicResource Brush.Border0}"
+              PointerPressed="BeginMoveWindow"/>
+
+      <Path Width="14" Height="14"
+            Margin="10,0,0,0"
+            HorizontalAlignment="Left"
+            Data="{StaticResource Icons.Folder.Open}"
+            IsVisible="{OnPlatform True, macOS=False}"/>
+
+      <TextBlock Classes="bold"
+                 Text="{DynamicResource Text.RemoteFolderPicker}"
+                 HorizontalAlignment="Center" VerticalAlignment="Center"
+                 IsHitTestVisible="False"/>
+
+      <v:CaptionButtons HorizontalAlignment="Right"
+                        IsCloseButtonOnly="True"
+                        IsVisible="{OnPlatform True, macOS=False}"/>
     </Grid>
-    <StackPanel Grid.Row="1" Orientation="Horizontal" Margin="0,6" Spacing="6">
-      <Button Click="OnUp">↑ Up</Button>
-      <Button Click="OnHome">Home</Button>
-    </StackPanel>
-    <ListBox Grid.Row="2" x:Name="lstEntries" DoubleTapped="OnDoubleTapped"/>
-    <StackPanel Grid.Row="3" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,10,0,0" Spacing="8">
-      <Button Click="OnConfirm" IsDefault="True">OK</Button>
-      <Button Click="OnCancel" IsCancel="True">Cancel</Button>
-    </StackPanel>
+
+    <!-- Body -->
+    <Grid Grid.Row="1" Margin="12" RowDefinitions="Auto,8,*,12,Auto">
+      <!-- Path bar -->
+      <Grid Grid.Row="0" ColumnDefinitions="Auto,Auto,*">
+        <Button Grid.Column="0"
+                Classes="icon_button" Width="28" Height="28"
+                Click="OnGoUp"
+                ToolTip.Tip="{DynamicResource Text.RemoteFolderPicker.Up}">
+          <Path Width="14" Height="14" Data="{StaticResource Icons.Up}"/>
+        </Button>
+
+        <Button Grid.Column="1"
+                Classes="icon_button" Width="28" Height="28" Margin="2,0,6,0"
+                Click="OnGoHome"
+                ToolTip.Tip="{DynamicResource Text.RemoteFolderPicker.Home}">
+          <Path Width="14" Height="14" Data="{StaticResource Icons.Folder}"/>
+        </Button>
+
+        <TextBox Grid.Column="2"
+                 x:Name="TxtPath"
+                 Height="28" CornerRadius="3"
+                 VerticalContentAlignment="Center"
+                 Watermark="{DynamicResource Text.RemoteFolderPicker.PathPlaceholder}"
+                 KeyDown="OnPathKeyDown"/>
+      </Grid>
+
+      <!-- Entries -->
+      <Border Grid.Row="2"
+              BorderThickness="1" BorderBrush="{DynamicResource Brush.Border1}"
+              CornerRadius="3" Background="{DynamicResource Brush.Contents}">
+        <Grid>
+          <ListBox x:Name="LstEntries"
+                   Background="Transparent"
+                   SelectionMode="Single"
+                   DoubleTapped="OnEntryDoubleTapped">
+            <ListBox.Styles>
+              <Style Selector="ListBoxItem">
+                <Setter Property="MinHeight" Value="0"/>
+                <Setter Property="Height" Value="26"/>
+                <Setter Property="Padding" Value="6,2"/>
+              </Style>
+            </ListBox.Styles>
+            <ListBox.ItemTemplate>
+              <DataTemplate DataType="v:RemoteFolderEntry">
+                <Grid ColumnDefinitions="Auto,*">
+                  <Path Grid.Column="0" Width="14" Height="14" VerticalAlignment="Center"
+                        Data="{StaticResource Icons.Folder}" Fill="{DynamicResource Brush.FG1}"
+                        IsVisible="{Binding IsDir}"/>
+                  <Path Grid.Column="0" Width="13" Height="13" VerticalAlignment="Center"
+                        Data="{StaticResource Icons.File}" Fill="{DynamicResource Brush.FG2}"
+                        IsVisible="{Binding !IsDir}"/>
+                  <TextBlock Grid.Column="1" Margin="8,0,0,0" VerticalAlignment="Center"
+                             Text="{Binding Name}"/>
+                </Grid>
+              </DataTemplate>
+            </ListBox.ItemTemplate>
+          </ListBox>
+
+          <TextBlock x:Name="LoadingTip"
+                     HorizontalAlignment="Center" VerticalAlignment="Center"
+                     Foreground="{DynamicResource Brush.FG2}"
+                     IsVisible="False"
+                     Text="{DynamicResource Text.RemoteFolderPicker.Loading}"/>
+        </Grid>
+      </Border>
+
+      <!-- Buttons -->
+      <StackPanel Grid.Row="4" Orientation="Horizontal" HorizontalAlignment="Right" Spacing="8">
+        <Button Classes="flat primary" Width="80" Height="30"
+                Click="OnConfirm" IsDefault="True"
+                Content="{DynamicResource Text.Sure}"/>
+        <Button Classes="flat" Width="80" Height="30"
+                Click="OnCancel" IsCancel="True"
+                Content="{DynamicResource Text.Cancel}"/>
+      </StackPanel>
+    </Grid>
   </Grid>
-</Window>
+</v:ChromelessWindow>

--- a/src/Views/RemoteFolderPicker.axaml
+++ b/src/Views/RemoteFolderPicker.axaml
@@ -1,0 +1,23 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:Class="SourceGit.Views.RemoteFolderPicker"
+        Title="Select Remote Folder"
+        Width="560" Height="440"
+        WindowStartupLocation="CenterOwner"
+        CanResize="True">
+  <Grid RowDefinitions="Auto,Auto,*,Auto" Margin="10">
+    <Grid Grid.Row="0" ColumnDefinitions="*,Auto">
+      <TextBox Grid.Column="0" x:Name="txtPath" Margin="0,0,6,0" Watermark="remote path"/>
+      <Button Grid.Column="1" Click="OnGo">Go</Button>
+    </Grid>
+    <StackPanel Grid.Row="1" Orientation="Horizontal" Margin="0,6" Spacing="6">
+      <Button Click="OnUp">↑ Up</Button>
+      <Button Click="OnHome">Home</Button>
+    </StackPanel>
+    <ListBox Grid.Row="2" x:Name="lstEntries" DoubleTapped="OnDoubleTapped"/>
+    <StackPanel Grid.Row="3" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,10,0,0" Spacing="8">
+      <Button Click="OnConfirm" IsDefault="True">OK</Button>
+      <Button Click="OnCancel" IsCancel="True">Cancel</Button>
+    </StackPanel>
+  </Grid>
+</Window>

--- a/src/Views/RemoteFolderPicker.axaml.cs
+++ b/src/Views/RemoteFolderPicker.axaml.cs
@@ -1,26 +1,32 @@
 using System;
 using System.Collections.ObjectModel;
+using System.Text.Json;
 using System.Threading.Tasks;
+
 using Avalonia.Controls;
+using Avalonia.Input;
 using Avalonia.Interactivity;
-using Avalonia.Markup.Xaml;
 
 using SourceGit.Remote;
 
 namespace SourceGit.Views
 {
+    /// <summary>One row in the remote folder browser.</summary>
+    public class RemoteFolderEntry
+    {
+        public string Name { get; init; } = string.Empty;
+        public bool IsDir { get; init; }
+    }
+
     /// <summary>
-    /// A lightweight remote folder browser: lists sub-directories of a path on the SSH host
-    /// (via `ssh host ls -1p`), lets the user navigate up/into/Go, and returns the chosen
-    /// path via <see cref="SelectedPath"/>. Reuses the host alias so ssh config applies.
+    /// Themed remote folder browser. Lists directories on the host over its existing RPC
+    /// connection (<c>list_dir</c>), lets the user navigate up / into / type a path, and
+    /// returns the chosen folder via <see cref="SelectedPath"/>. Because it reuses the live
+    /// connection, navigation is fast and does not re-authenticate per step.
     /// </summary>
-    public partial class RemoteFolderPicker : Window
+    public partial class RemoteFolderPicker : ChromelessWindow
     {
         public string SelectedPath { get; private set; } = string.Empty;
-
-        private readonly string _host;
-        private string _current = ".";
-        private readonly ObservableCollection<string> _entries = new();
 
         public RemoteFolderPicker()
         {
@@ -28,90 +34,111 @@ namespace SourceGit.Views
             InitializeComponent();
         }
 
-        public RemoteFolderPicker(string host, string initialPath)
+        public RemoteFolderPicker(Models.RemoteHost host, RpcClient client, string initialPath)
         {
             _host = host;
-            _current = string.IsNullOrEmpty(initialPath) ? "." : initialPath;
+            _client = client;
+            _current = initialPath ?? string.Empty;
 
             InitializeComponent();
 
-
-            var txt = this.FindControl<TextBox>("txtPath");
-            if (txt != null)
-                txt.Text = _current;
-
-            var lst = this.FindControl<ListBox>("lstEntries");
-            if (lst != null)
-                lst.ItemsSource = _entries;
-
-            _ = LoadAsync();
+            LstEntries.ItemsSource = _entries;
+            _ = LoadAsync(_current);
         }
 
-        public void OnGo(object _, RoutedEventArgs e)
+        private void OnGoUp(object _, RoutedEventArgs e)
         {
-            var txt = this.FindControl<TextBox>("txtPath");
-            if (txt != null)
-                _current = txt.Text ?? ".";
-            _ = LoadAsync();
+            if (string.IsNullOrEmpty(_current) || _current == "/")
+                return;
+
+            var idx = _current.TrimEnd('/').LastIndexOf('/');
+            var parent = idx <= 0 ? "/" : _current.Substring(0, idx);
+            _ = LoadAsync(parent);
+            e.Handled = true;
         }
 
-        public void OnUp(object _, RoutedEventArgs e) => GoUp();
-
-        public void OnHome(object _, RoutedEventArgs e)
+        private void OnGoHome(object _, RoutedEventArgs e)
         {
-            _current = ".";
-            UpdatePathText();
-            _ = LoadAsync();
+            _ = LoadAsync("~");
+            e.Handled = true;
         }
 
-        public async void OnDoubleTapped(object _, RoutedEventArgs e)
+        private void OnPathKeyDown(object sender, KeyEventArgs e)
         {
-            var lst = this.FindControl<ListBox>("lstEntries");
-            if (lst?.SelectedItem is string sel)
+            if (e.Key == Key.Enter && sender is TextBox tb)
             {
-                _current = _current == "." ? sel : (_current == "/" ? "/" + sel : _current + "/" + sel);
-                UpdatePathText();
-                await LoadAsync();
+                _ = LoadAsync(tb.Text ?? string.Empty);
+                e.Handled = true;
             }
         }
 
-        public void OnConfirm(object _, RoutedEventArgs e)
+        private void OnEntryDoubleTapped(object _, RoutedEventArgs e)
         {
-            var txt = this.FindControl<TextBox>("txtPath");
-            SelectedPath = txt?.Text ?? _current;
+            if (LstEntries.SelectedItem is RemoteFolderEntry { IsDir: true } entry)
+            {
+                var next = _current.TrimEnd('/');
+                next = string.IsNullOrEmpty(next) ? entry.Name : $"{next}/{entry.Name}";
+                _ = LoadAsync(next);
+            }
+
+            e.Handled = true;
+        }
+
+        private void OnConfirm(object _, RoutedEventArgs e)
+        {
+            // Prefer an explicitly selected sub-directory; otherwise use the current folder.
+            if (LstEntries.SelectedItem is RemoteFolderEntry { IsDir: true } entry)
+            {
+                var sel = _current.TrimEnd('/');
+                SelectedPath = string.IsNullOrEmpty(sel) ? entry.Name : $"{sel}/{entry.Name}";
+            }
+            else
+            {
+                SelectedPath = _current;
+            }
+
             Close(true);
         }
 
-        public void OnCancel(object _, RoutedEventArgs e) => Close(false);
+        private void OnCancel(object _, RoutedEventArgs e) => Close(false);
 
-        private void GoUp()
+        private async Task LoadAsync(string path)
         {
-            if (string.IsNullOrEmpty(_current) || _current == "." || _current == "/" )
+            if (_client == null)
                 return;
 
-            var idx = _current.LastIndexOf('/');
-            _current = idx <= 0 ? "/" : _current.Substring(0, idx);
-            UpdatePathText();
-            _ = LoadAsync();
-        }
+            LoadingTip.IsVisible = true;
 
-        private void UpdatePathText()
-        {
-            var txt = this.FindControl<TextBox>("txtPath");
-            if (txt != null)
-                txt.Text = _current;
-        }
-
-        private async Task LoadAsync()
-        {
-            _entries.Clear();
-            var cmd = $"ls -1p '{_current.Replace("'", "'\\''")}' 2>/dev/null";
-            var (stdout, _) = await Task.Run(() => SshExec.Run(_host, cmd)).ConfigureAwait(true);
-            foreach (var line in stdout.Split('\n', StringSplitOptions.RemoveEmptyEntries))
+            ListDirResult result = null;
+            try
             {
-                if (line.EndsWith('/'))
-                    _entries.Add(line.TrimEnd('/'));
+                result = await Task.Run(() =>
+                {
+                    var node = _client.Call("list_dir", new { path });
+                    return node == null ? null : JsonSerializer.Deserialize<ListDirResult>(node.ToJsonString());
+                }).ConfigureAwait(true);
             }
+            catch (Exception ex)
+            {
+                Models.Notification.Send(_host?.Host, $"Failed to list remote folder: {ex.Message}", true);
+            }
+
+            LoadingTip.IsVisible = false;
+
+            if (result == null)
+                return;
+
+            _current = string.IsNullOrEmpty(result.Path) ? path : result.Path;
+            TxtPath.Text = _current;
+
+            _entries.Clear();
+            foreach (var entry in result.Entries)
+                _entries.Add(new RemoteFolderEntry { Name = entry.Name, IsDir = entry.IsDir });
         }
+
+        private readonly Models.RemoteHost _host;
+        private readonly RpcClient _client;
+        private string _current = string.Empty;
+        private readonly ObservableCollection<RemoteFolderEntry> _entries = new();
     }
 }

--- a/src/Views/RemoteFolderPicker.axaml.cs
+++ b/src/Views/RemoteFolderPicker.axaml.cs
@@ -77,7 +77,7 @@ namespace SourceGit.Views
             if (LstEntries.SelectedItem is RemoteFolderEntry { IsDir: true } entry)
             {
                 var next = _current.TrimEnd('/');
-                next = string.IsNullOrEmpty(next) ? entry.Name : $"{next}/{entry.Name}";
+                next = string.IsNullOrEmpty(next) ? "/" + entry.Name : $"{next}/{entry.Name}";
                 _ = LoadAsync(next);
             }
 
@@ -90,7 +90,7 @@ namespace SourceGit.Views
             if (LstEntries.SelectedItem is RemoteFolderEntry { IsDir: true } entry)
             {
                 var sel = _current.TrimEnd('/');
-                SelectedPath = string.IsNullOrEmpty(sel) ? entry.Name : $"{sel}/{entry.Name}";
+                SelectedPath = string.IsNullOrEmpty(sel) ? "/" + entry.Name : $"{sel}/{entry.Name}";
             }
             else
             {

--- a/src/Views/RemoteFolderPicker.axaml.cs
+++ b/src/Views/RemoteFolderPicker.axaml.cs
@@ -1,0 +1,117 @@
+using System;
+using System.Collections.ObjectModel;
+using System.Threading.Tasks;
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Avalonia.Markup.Xaml;
+
+using SourceGit.Remote;
+
+namespace SourceGit.Views
+{
+    /// <summary>
+    /// A lightweight remote folder browser: lists sub-directories of a path on the SSH host
+    /// (via `ssh host ls -1p`), lets the user navigate up/into/Go, and returns the chosen
+    /// path via <see cref="SelectedPath"/>. Reuses the host alias so ssh config applies.
+    /// </summary>
+    public partial class RemoteFolderPicker : Window
+    {
+        public string SelectedPath { get; private set; } = string.Empty;
+
+        private readonly string _host;
+        private string _current = ".";
+        private readonly ObservableCollection<string> _entries = new();
+
+        public RemoteFolderPicker()
+        {
+            // for design-time / xaml loader
+            InitializeComponent();
+        }
+
+        public RemoteFolderPicker(string host, string initialPath)
+        {
+            _host = host;
+            _current = string.IsNullOrEmpty(initialPath) ? "." : initialPath;
+
+            InitializeComponent();
+
+
+            var txt = this.FindControl<TextBox>("txtPath");
+            if (txt != null)
+                txt.Text = _current;
+
+            var lst = this.FindControl<ListBox>("lstEntries");
+            if (lst != null)
+                lst.ItemsSource = _entries;
+
+            _ = LoadAsync();
+        }
+
+        public void OnGo(object _, RoutedEventArgs e)
+        {
+            var txt = this.FindControl<TextBox>("txtPath");
+            if (txt != null)
+                _current = txt.Text ?? ".";
+            _ = LoadAsync();
+        }
+
+        public void OnUp(object _, RoutedEventArgs e) => GoUp();
+
+        public void OnHome(object _, RoutedEventArgs e)
+        {
+            _current = ".";
+            UpdatePathText();
+            _ = LoadAsync();
+        }
+
+        public async void OnDoubleTapped(object _, RoutedEventArgs e)
+        {
+            var lst = this.FindControl<ListBox>("lstEntries");
+            if (lst?.SelectedItem is string sel)
+            {
+                _current = _current == "." ? sel : (_current == "/" ? "/" + sel : _current + "/" + sel);
+                UpdatePathText();
+                await LoadAsync();
+            }
+        }
+
+        public void OnConfirm(object _, RoutedEventArgs e)
+        {
+            var txt = this.FindControl<TextBox>("txtPath");
+            SelectedPath = txt?.Text ?? _current;
+            Close(true);
+        }
+
+        public void OnCancel(object _, RoutedEventArgs e) => Close(false);
+
+        private void GoUp()
+        {
+            if (string.IsNullOrEmpty(_current) || _current == "." || _current == "/" )
+                return;
+
+            var idx = _current.LastIndexOf('/');
+            _current = idx <= 0 ? "/" : _current.Substring(0, idx);
+            UpdatePathText();
+            _ = LoadAsync();
+        }
+
+        private void UpdatePathText()
+        {
+            var txt = this.FindControl<TextBox>("txtPath");
+            if (txt != null)
+                txt.Text = _current;
+        }
+
+        private async Task LoadAsync()
+        {
+            _entries.Clear();
+            var cmd = $"ls -1p '{_current.Replace("'", "'\\''")}' 2>/dev/null";
+            var (stdout, _) = await Task.Run(() => SshExec.Run(_host, cmd)).ConfigureAwait(true);
+            foreach (var line in stdout.Split('\n', StringSplitOptions.RemoveEmptyEntries))
+            {
+                if (line.EndsWith('/'))
+                    _entries.Add(line.TrimEnd('/'));
+            }
+        }
+    }
+}

--- a/src/Views/RepositoryToolbar.axaml.cs
+++ b/src/Views/RepositoryToolbar.axaml.cs
@@ -525,12 +525,22 @@ namespace SourceGit.Views
 
         private void NavigateToHead(object sender, RoutedEventArgs e)
         {
-            if (DataContext is ViewModels.Repository { CurrentBranch: not null } repo)
+            if (DataContext is ViewModels.Repository repo)
             {
                 var repoView = TopLevel.GetTopLevel(this)?.FindDescendantOfType<Repository>();
-                repoView?.LocalBranchTree?.Select(repo.CurrentBranch);
 
-                repo.NavigateToCommit(repo.CurrentBranch.Head);
+                if (repo.CurrentBranch != null)
+                {
+                    repoView?.LocalBranchTree?.Select(repo.CurrentBranch);
+                    repo.NavigateToCommit(repo.CurrentBranch.Head);
+                }
+                else
+                {
+                    // Remote/bare repositories may not have a checked-out current branch,
+                    // but HEAD is still available.
+                    repo.NavigateToCommit("HEAD");
+                }
+
                 e.Handled = true;
             }
         }

--- a/src/Views/TextDiffView.axaml.cs
+++ b/src/Views/TextDiffView.axaml.cs
@@ -1625,9 +1625,10 @@ namespace SourceGit.Views
 
             var tmpFile = Path.GetTempFileName();
             patch.Generate(tmpFile, false);
+            var patchContent = File.ReadAllText(tmpFile);
 
             using var lockWatcher = repo.LockWatcher();
-            await new Commands.Apply(repo.FullPath, tmpFile, true, "nowarn", "--cache --index").ExecAsync();
+            await new Commands.Apply(repo.FullPath, patchContent, true, "nowarn", "--cache --index").ExecAsync();
 
             vm.BlockNavigation.UpdateByChunk(chunk);
             repo.MarkWorkingCopyDirtyManually();
@@ -1651,9 +1652,10 @@ namespace SourceGit.Views
 
             var tmpFile = Path.GetTempFileName();
             patch.Generate(tmpFile, true);
+            var patchContent = File.ReadAllText(tmpFile);
 
             using var lockWatcher = repo.LockWatcher();
-            await new Commands.Apply(repo.FullPath, tmpFile, true, "nowarn", "--cache --index --reverse").ExecAsync();
+            await new Commands.Apply(repo.FullPath, patchContent, true, "nowarn", "--cache --index --reverse").ExecAsync();
 
             vm.BlockNavigation.UpdateByChunk(chunk);
             repo.MarkWorkingCopyDirtyManually();
@@ -1677,9 +1679,10 @@ namespace SourceGit.Views
 
             var tmpFile = Path.GetTempFileName();
             patch.Generate(tmpFile, true);
+            var patchContent = File.ReadAllText(tmpFile);
 
             using var lockWatcher = repo.LockWatcher();
-            await new Commands.Apply(repo.FullPath, tmpFile, true, "nowarn", "--reverse").ExecAsync();
+            await new Commands.Apply(repo.FullPath, patchContent, true, "nowarn", "--reverse").ExecAsync();
 
             vm.BlockNavigation.UpdateByChunk(chunk);
             repo.MarkWorkingCopyDirtyManually();

--- a/src/Views/WorkingCopy.axaml.cs
+++ b/src/Views/WorkingCopy.axaml.cs
@@ -321,7 +321,7 @@ namespace SourceGit.Views
                 var explore = new MenuItem();
                 explore.Header = App.Text("RevealFile");
                 explore.Icon = this.CreateMenuIcon("Icons.Explore");
-                explore.IsEnabled = File.Exists(path) || Directory.Exists(path);
+                explore.IsEnabled = !repo.IsRemote && (File.Exists(path) || Directory.Exists(path));
                 explore.Click += (_, e) =>
                 {
                     var target = hasSelectedFolder ? Native.OS.GetAbsPath(repo.FullPath, selectedSingleFolder) : path;
@@ -815,7 +815,7 @@ namespace SourceGit.Views
                     var explore = new MenuItem();
                     explore.Header = App.Text("RevealFile");
                     explore.Icon = this.CreateMenuIcon("Icons.Explore");
-                    explore.IsEnabled = Directory.Exists(dir);
+                    explore.IsEnabled = !repo.IsRemote && Directory.Exists(dir);
                     explore.Click += (_, e) =>
                     {
                         Native.OS.OpenInFileManager(dir);
@@ -1008,7 +1008,7 @@ namespace SourceGit.Views
                 };
 
                 var explore = new MenuItem();
-                explore.IsEnabled = File.Exists(path) || Directory.Exists(path);
+                explore.IsEnabled = !repo.IsRemote && (File.Exists(path) || Directory.Exists(path));
                 explore.Header = App.Text("RevealFile");
                 explore.Icon = this.CreateMenuIcon("Icons.Explore");
                 explore.Click += (_, e) =>
@@ -1223,7 +1223,7 @@ namespace SourceGit.Views
                 {
                     var dir = Path.Combine(repo.FullPath, selectedSingleFolder);
                     var explore = new MenuItem();
-                    explore.IsEnabled = Directory.Exists(dir);
+                    explore.IsEnabled = !repo.IsRemote && Directory.Exists(dir);
                     explore.Header = App.Text("RevealFile");
                     explore.Icon = this.CreateMenuIcon("Icons.Explore");
                     explore.Click += (_, e) =>

--- a/src/Views/WorkingCopy.axaml.cs
+++ b/src/Views/WorkingCopy.axaml.cs
@@ -113,7 +113,19 @@ namespace SourceGit.Views
                 {
                     var change = vm.SelectedUnstaged[0];
                     var fullpath = Native.OS.GetAbsPath(vm.Repository.FullPath, change.Path);
-                    if (File.Exists(fullpath))
+                    if (vm.Repository.IsRemote)
+                    {
+                        try
+                        {
+                            using var stream = vm.Repository.FileSystem.OpenRead(fullpath);
+                            var tmp = Path.GetTempFileName();
+                            await using (var fs = File.Create(tmp))
+                                await stream.CopyToAsync(fs);
+                            Native.OS.OpenWithDefaultEditor(tmp);
+                        }
+                        catch { }
+                    }
+                    else if (File.Exists(fullpath))
                         Native.OS.OpenWithDefaultEditor(fullpath);
                     e.Handled = true;
                 }
@@ -152,7 +164,19 @@ namespace SourceGit.Views
                 {
                     var change = vm.SelectedStaged[0];
                     var fullpath = Native.OS.GetAbsPath(vm.Repository.FullPath, change.Path);
-                    if (File.Exists(fullpath))
+                    if (vm.Repository.IsRemote)
+                    {
+                        try
+                        {
+                            using var stream = vm.Repository.FileSystem.OpenRead(fullpath);
+                            var tmp = Path.GetTempFileName();
+                            await using (var fs = File.Create(tmp))
+                                await stream.CopyToAsync(fs);
+                            Native.OS.OpenWithDefaultEditor(tmp);
+                        }
+                        catch { }
+                    }
+                    else if (File.Exists(fullpath))
                         Native.OS.OpenWithDefaultEditor(fullpath);
                     e.Handled = true;
                 }


### PR DESCRIPTION
## Overview

This PR adds SSH remote repository support to SourceGit, allowing users to open and manage git repositories that live on a remote SSH host — without cloning them locally. The design follows the VSCode Remote / JetBrains Gateway pattern: the client runs the full UI, while a lightweight headless server process on the remote host executes git commands and filesystem operations over a JSON-RPC protocol carried by the SSH channel.

## Key Features

- **Auto-deploy server binary**: The client probes the remote host for a deployed server binary, uploads it if missing or outdated (with version check), and launches it automatically. No manual remote setup needed.
- **Reuse local `~/.ssh/config`**: SSH connections use the host alias from the user's ssh config, so ProxyJump (jump hosts), identity files, agent forwarding, port, and passwordless auth are all honored. No bespoke SSH options.
- **Shared host session**: One SSH connection per host, shared by all repository tabs opened on that host. Closing a tab does not tear down the connection.
- **Remote folder picker**: Browse remote directories over the existing RPC connection to select the repository path.
- **Auto-refresh**: A remote `FileSystemWatcher` pushes change events back to the client so the UI auto-refreshes on working-tree changes. Additionally, `LockWatcher()` for remote repos triggers `RefreshAll()` after any git command (tag/push/commit/merge…), matching local behavior.
- **Tab restore on startup**: Remote tabs are saved and restored. Auto-connect is serialized per host to avoid concurrent connect races.
- **Reset/Reconnect UX**: Reset preserves open tabs (loading state), force-redeploys the server, and auto-reloads tabs on the new connection. Settings page shows a scrolling log with upload progress/speed.
- **Streaming RPC**: Large git outputs (e.g. `git log`) are streamed in base64 chunks over notifications, avoiding a giant JSON buffer and reducing GC/UI jank on large repos.
- **Binary file support**: `RemoteFileSystem.OpenRead` fetches files as base64 and caches to a local temp file, so binary previews (images) work correctly.
- **Container/minimal-host support**: Server upload falls back to `ssh cat > file` when `scp` is unavailable. Binary replace is atomic (`upload to .new → mv`) to avoid "Text file busy".

## Architecture

- `ICommandRunner` / `ICommandProcess`: abstraction over git process execution. Local repos use `LocalCommandRunner` (existing `Process.Start(git)`). Remote repos use `RemoteCommandRunner` (forwards to server via RPC).
- `CommandRunnerRegistry`: maps repository path to ICommandRunner. Commands look up the runner by their working directory.
- `IFileSystem`: abstraction over file I/O. Local repos use `LocalFileSystem` (direct File./Directory.). Remote repos use `RemoteFileSystem` (file_* RPC methods).
- `RpcServer` / `RpcClient`: JSON-RPC over stdio (SSH channel). Methods: ping, exec_git, exec_git_stream, file_exists/read/write/delete, list_dir, watch_start/stop, etc.
- `RemoteHostSession` / `RemoteHostManager`: manages the SSH connection and server lifecycle per host.
- `RemoteRepositoryOpener`: orchestrates auto-connect, server deploy, runner registration, repo construction, and watcher start.
- `RemoteWatcher`: subscribes to watch_event notifications, debounces, and calls RefreshAll() on the UI thread.

## UI Changes

- "Open Local Repository" dialog gains an SSH toggle. When enabled: host dropdown (from ~/.ssh/config), connection status dot (green/red/yellow), remote path with folder picker, group, and bookmark.
- Preferences -> Remote Hosts: add/test/connect/disconnect/reset hosts with a scrolling log showing steps, upload progress, and latency.
- Loading page (LoadingRemoteRepository) for async open: spinner + "Connecting to xxx..." message.

## Files Changed

- 67 files, ~3570 insertions, ~484 deletions

## Limitations / Future Work

- External diff/merge tools are not supported for remote repositories (throws).
- Alpine/musl containers not yet tested (linux-x64 glibc only).
- Server binary is currently bundled in the app; a future release could download it from GitHub Releases on demand.
- Translations added for en_US and zh_CN only.