### PR TITLE
Refactor AI service configuration flow: support manual model list fetching, selective addition, and repository-specific default model settings

### DIFF
--- a/src/AI/Service.cs
+++ b/src/AI/Service.cs
@@ -1,7 +1,6 @@
-﻿using System;
+using System;
 using System.ClientModel;
 using System.Collections.Generic;
-using System.Text.Json.Serialization;
 using Azure.AI.OpenAI;
 using CommunityToolkit.Mvvm.ComponentModel;
 using OpenAI;
@@ -35,23 +34,16 @@ namespace SourceGit.AI
             set;
         } = false;
 
-        [JsonIgnore]
         public List<string> AvailableModels
         {
-            get;
-            private set;
-        } = [];
+            get => _availableModels;
+            set => SetProperty(ref _availableModels, value);
+        }
 
         public string Model
         {
             get => _model;
             set => SetProperty(ref _model, value);
-        }
-
-        public bool AutoFetchAvailableModels
-        {
-            get => _autoFetchAvailableModels;
-            set => SetProperty(ref _autoFetchAvailableModels, value);
         }
 
         public string AdditionalPrompt
@@ -60,27 +52,51 @@ namespace SourceGit.AI
             set;
         } = string.Empty;
 
-        public void FetchAvailableModels()
+        public void AddModel(string model)
         {
-            if (!_autoFetchAvailableModels)
+            if (!_availableModels.Contains(model))
             {
-                if (!string.IsNullOrEmpty(Model))
-                    AvailableModels = [Model];
-                return;
+                var newList = new List<string>(_availableModels) { model };
+                AvailableModels = newList;
             }
+        }
 
+        public void RemoveModel(string model)
+        {
+            if (_availableModels.Contains(model))
+            {
+                var newList = new List<string>(_availableModels);
+                newList.Remove(model);
+                AvailableModels = newList;
+            }
+        }
+
+        public List<string> FetchModelsFromServer()
+        {
             var allModels = GetOpenAIClient().GetOpenAIModelClient().GetModels();
-            AvailableModels = new List<string>();
+            var result = new List<string>();
             foreach (var model in allModels.Value)
-                AvailableModels.Add(model.Id);
-
-            if (AvailableModels.Count > 0 && (string.IsNullOrEmpty(Model) || !AvailableModels.Contains(Model)))
-                Model = AvailableModels[0];
+                result.Add(model.Id);
+            return result;
         }
 
         public ChatClient GetChatClient()
         {
             return !string.IsNullOrEmpty(Model) ? GetOpenAIClient().GetChatClient(Model) : null;
+        }
+
+        public Service Clone()
+        {
+            return new Service
+            {
+                Name = Name,
+                Server = Server,
+                ApiKey = ApiKey,
+                ReadApiKeyFromEnv = ReadApiKeyFromEnv,
+                Model = Model,
+                AdditionalPrompt = AdditionalPrompt,
+                AvailableModels = new List<string>(AvailableModels),
+            };
         }
 
         private OpenAIClient GetOpenAIClient()
@@ -93,6 +109,6 @@ namespace SourceGit.AI
 
         private string _name = string.Empty;
         private string _model = string.Empty;
-        private bool _autoFetchAvailableModels = true;
+        private List<string> _availableModels = [];
     }
 }

--- a/src/App.axaml.cs
+++ b/src/App.axaml.cs
@@ -482,7 +482,6 @@ namespace SourceGit
 
             var pref = ViewModels.Preferences.Instance;
             pref.SetCanModify();
-            pref.UpdateAvailableAIModels();
 
             _launcher = new ViewModels.Launcher(startupRepo);
             desktop.MainWindow = new Views.Launcher() { DataContext = _launcher };

--- a/src/Models/RepositorySettings.cs
+++ b/src/Models/RepositorySettings.cs
@@ -46,7 +46,13 @@ namespace SourceGit.Models
         {
             get;
             set;
-        } = "---";
+        } = "";
+
+        public string PreferredAIModel
+        {
+            get;
+            set;
+        } = string.Empty;
 
         public AvaloniaList<CommitTemplate> CommitTemplates
         {

--- a/src/Resources/Locales/de_DE.axaml
+++ b/src/Resources/Locales/de_DE.axaml
@@ -242,9 +242,9 @@ $1, $2, … Werte der Eingabe-Steuerelemente</x:String>
   <x:String x:Key="Text.Configure.IssueTracker.Share" xml:space="preserve">Diese Regel per .issuetracker-Datei teilen</x:String>
   <x:String x:Key="Text.Configure.IssueTracker.URLTemplate" xml:space="preserve">Ergebnis-URL:</x:String>
   <x:String x:Key="Text.Configure.IssueTracker.URLTemplate.Tip" xml:space="preserve">Verwende bitte $1, $2, um auf Regex-Gruppenwerte zuzugreifen.</x:String>
-  <x:String x:Key="Text.Configure.OpenAI" xml:space="preserve">OPEN AI</x:String>
-  <x:String x:Key="Text.Configure.OpenAI.Preferred" xml:space="preserve">Bevorzugter Dienst:</x:String>
-  <x:String x:Key="Text.Configure.OpenAI.Preferred.Tip" xml:space="preserve">Der ausgewählte ‚Bevorzugte Dienst‘ wird nur in diesem Repository gesetzt und verwendet. Wenn keiner gesetzt ist und mehrere Dienste verfügbar sind, wird ein Kontextmenü zur Auswahl angezeigt.</x:String>
+  <x:String x:Key="Text.Configure.AI" xml:space="preserve">OPEN AI</x:String>
+  <x:String x:Key="Text.Configure.AI.DefaultService" xml:space="preserve">Bevorzugter Dienst:</x:String>
+  <x:String x:Key="Text.Configure.AI.DefaultService.Tip" xml:space="preserve">Der ausgewählte ‚Bevorzugte Dienst‘ wird nur in diesem Repository gesetzt und verwendet. Wenn keiner gesetzt ist und mehrere Dienste verfügbar sind, wird ein Kontextmenü zur Auswahl angezeigt.</x:String>
   <x:String x:Key="Text.Configure.Proxy" xml:space="preserve">HTTP-Proxy</x:String>
   <x:String x:Key="Text.Configure.Proxy.Placeholder" xml:space="preserve">HTTP-Proxy für dieses Repository</x:String>
   <x:String x:Key="Text.Configure.User" xml:space="preserve">Benutzername</x:String>

--- a/src/Resources/Locales/el_GR.axaml
+++ b/src/Resources/Locales/el_GR.axaml
@@ -264,9 +264,9 @@
   <x:String x:Key="Text.Configure.IssueTracker.Share" xml:space="preserve">Κοινή χρήση αυτού του κανόνα στο αρχείο .issuetracker</x:String>
   <x:String x:Key="Text.Configure.IssueTracker.URLTemplate" xml:space="preserve">URL αποτελέσματος:</x:String>
   <x:String x:Key="Text.Configure.IssueTracker.URLTemplate.Tip" xml:space="preserve">Χρησιμοποιήστε $1, $2 για πρόσβαση στις τιμές των ομάδων της κανονικής έκφρασης.</x:String>
-  <x:String x:Key="Text.Configure.OpenAI" xml:space="preserve">AI</x:String>
-  <x:String x:Key="Text.Configure.OpenAI.Preferred" xml:space="preserve">Προτιμώμενη υπηρεσία:</x:String>
-  <x:String x:Key="Text.Configure.OpenAI.Preferred.Tip" xml:space="preserve">Αν οριστεί η «Προτιμώμενη υπηρεσία», το SourceGit θα τη χρησιμοποιεί μόνο σε αυτό το αποθετήριο. Διαφορετικά, αν υπάρχουν περισσότερες από μία διαθέσιμες υπηρεσίες, θα εμφανίζεται μενού για να επιλέξετε μία.</x:String>
+  <x:String x:Key="Text.Configure.AI" xml:space="preserve">AI</x:String>
+  <x:String x:Key="Text.Configure.AI.DefaultService" xml:space="preserve">Προτιμώμενη υπηρεσία:</x:String>
+  <x:String x:Key="Text.Configure.AI.DefaultService.Tip" xml:space="preserve">Αν οριστεί η «Προτιμώμενη υπηρεσία», το SourceGit θα τη χρησιμοποιεί μόνο σε αυτό το αποθετήριο. Διαφορετικά, αν υπάρχουν περισσότερες από μία διαθέσιμες υπηρεσίες, θα εμφανίζεται μενού για να επιλέξετε μία.</x:String>
   <x:String x:Key="Text.Configure.Proxy" xml:space="preserve">HTTP Proxy</x:String>
   <x:String x:Key="Text.Configure.Proxy.Placeholder" xml:space="preserve">HTTP proxy που χρησιμοποιεί αυτό το αποθετήριο</x:String>
   <x:String x:Key="Text.Configure.User" xml:space="preserve">Όνομα χρήστη</x:String>
@@ -633,7 +633,6 @@
   <x:String x:Key="Text.Preferences.AI.AdditionalPrompt" xml:space="preserve">Επιπλέον prompt (χρησιμοποιήστε `-` για να απαριθμήσετε τις απαιτήσεις σας)</x:String>
   <x:String x:Key="Text.Preferences.AI.ApiKey" xml:space="preserve">Κλειδί API</x:String>
   <x:String x:Key="Text.Preferences.AI.Model" xml:space="preserve">Μοντέλο</x:String>
-  <x:String x:Key="Text.Preferences.AI.Model.AutoFetchAvailableModels" xml:space="preserve">Αυτόματη ανάκτηση διαθέσιμων model-ids</x:String>
   <x:String x:Key="Text.Preferences.AI.Name" xml:space="preserve">Όνομα</x:String>
   <x:String x:Key="Text.Preferences.AI.ReadApiKeyFromEnv" xml:space="preserve">Η τιμή που εισήχθη είναι το όνομα για φόρτωση του κλειδιού API από το ENV</x:String>
   <x:String x:Key="Text.Preferences.AI.Server" xml:space="preserve">Διακομιστής</x:String>

--- a/src/Resources/Locales/en_US.axaml
+++ b/src/Resources/Locales/en_US.axaml
@@ -3,6 +3,7 @@
   <x:String x:Key="Text.About.Menu" xml:space="preserve">About SourceGit</x:String>
   <x:String x:Key="Text.About.ReleaseDate" xml:space="preserve">Release Date: {0}</x:String>
   <x:String x:Key="Text.About.ReleaseNotes" xml:space="preserve">Release Notes</x:String>
+  <x:String x:Key="Text.Add" xml:space="preserve">Add</x:String>
   <x:String x:Key="Text.About.SubTitle" xml:space="preserve">Opensource &amp; Free Git GUI Client</x:String>
   <x:String x:Key="Text.AddToIgnore" xml:space="preserve">Add File(s) To Ignore</x:String>
   <x:String x:Key="Text.AddToIgnore.Pattern" xml:space="preserve">Pattern:</x:String>
@@ -269,9 +270,12 @@
   <x:String x:Key="Text.Configure.IssueTracker.Share" xml:space="preserve">Share this rule in .issuetracker file</x:String>
   <x:String x:Key="Text.Configure.IssueTracker.URLTemplate" xml:space="preserve">Result URL:</x:String>
   <x:String x:Key="Text.Configure.IssueTracker.URLTemplate.Tip" xml:space="preserve">Please use $1, $2 to access regex groups values.</x:String>
-  <x:String x:Key="Text.Configure.OpenAI" xml:space="preserve">AI</x:String>
-  <x:String x:Key="Text.Configure.OpenAI.Preferred" xml:space="preserve">Preferred Service:</x:String>
-  <x:String x:Key="Text.Configure.OpenAI.Preferred.Tip" xml:space="preserve">If the 'Preferred Service' is set, SourceGit will only use it in this repository. Otherwise, if there is more than one service available, a context menu to choose one of them will be shown.</x:String>
+  <x:String x:Key="Text.Configure.AI" xml:space="preserve">AI</x:String>
+  <x:String x:Key="Text.Configure.AI.DefaultService" xml:space="preserve">Default Service:</x:String>
+  <x:String x:Key="Text.Configure.AI.PreferredModel" xml:space="preserve">Default Model:</x:String>
+  <x:String x:Key="Text.Configure.AI.DefaultService.Tip" xml:space="preserve">If set, SourceGit will use this service and model directly for AI commit message generation in this repository. Otherwise, a selection menu will be shown.</x:String>
+  <x:String x:Key="Text.Configure.AI.DefaultService.None" xml:space="preserve">(None)</x:String>
+  <x:String x:Key="Text.Configure.AI.PreferredModel.None" xml:space="preserve">(None)</x:String>
   <x:String x:Key="Text.Configure.Proxy" xml:space="preserve">HTTP Proxy</x:String>
   <x:String x:Key="Text.Configure.Proxy.Placeholder" xml:space="preserve">HTTP proxy used by this repository</x:String>
   <x:String x:Key="Text.Configure.User" xml:space="preserve">User Name</x:String>
@@ -655,10 +659,15 @@
   <x:String x:Key="Text.Preferences.AI.AdditionalPrompt" xml:space="preserve">Additional Prompt (Use `-` to list your requirements)</x:String>
   <x:String x:Key="Text.Preferences.AI.ApiKey" xml:space="preserve">API Key</x:String>
   <x:String x:Key="Text.Preferences.AI.Model" xml:space="preserve">Model</x:String>
-  <x:String x:Key="Text.Preferences.AI.Model.AutoFetchAvailableModels" xml:space="preserve">Fetch available model-ids automatically</x:String>
+  <x:String x:Key="Text.Preferences.AI.Model.AddModel" xml:space="preserve">Add Model</x:String>
+  <x:String x:Key="Text.Preferences.AI.Model.FetchModels" xml:space="preserve">Fetch Models</x:String>
+  <x:String x:Key="Text.Preferences.AI.Model.Fetching" xml:space="preserve">Fetching models...</x:String>
+  <x:String x:Key="Text.Preferences.AI.Model.RemoveModel" xml:space="preserve">Remove Model</x:String>
+  <x:String x:Key="Text.Preferences.AI.Model.SelectModels" xml:space="preserve">Select Models</x:String>
   <x:String x:Key="Text.Preferences.AI.Name" xml:space="preserve">Name</x:String>
   <x:String x:Key="Text.Preferences.AI.ReadApiKeyFromEnv" xml:space="preserve">Entered value is the name to load API key from ENV</x:String>
   <x:String x:Key="Text.Preferences.AI.Server" xml:space="preserve">Server</x:String>
+  <x:String x:Key="Text.Preferences.AI.Services" xml:space="preserve">AI Services</x:String>
   <x:String x:Key="Text.Preferences.Appearance" xml:space="preserve">APPEARANCE</x:String>
   <x:String x:Key="Text.Preferences.Appearance.DefaultFont" xml:space="preserve">Default Font</x:String>
   <x:String x:Key="Text.Preferences.Appearance.EditorTabWidth" xml:space="preserve">Editor Tab Width</x:String>

--- a/src/Resources/Locales/es_ES.axaml
+++ b/src/Resources/Locales/es_ES.axaml
@@ -21,10 +21,10 @@
   <x:String x:Key="Text.AddWorktree.WhatToCheckout" xml:space="preserve">Qué Checkout:</x:String>
   <x:String x:Key="Text.AddWorktree.WhatToCheckout.CreateNew" xml:space="preserve">Crear Nueva Rama</x:String>
   <x:String x:Key="Text.AddWorktree.WhatToCheckout.Existing" xml:space="preserve">Rama Existente</x:String>
-  <x:String x:Key="Text.AIAssistant" xml:space="preserve">Asistente OpenAI</x:String>
+  <x:String x:Key="Text.AIAssistant" xml:space="preserve">Asistente AI</x:String>
   <x:String x:Key="Text.AIAssistant.Model" xml:space="preserve">Modelo</x:String>
   <x:String x:Key="Text.AIAssistant.Regen" xml:space="preserve">RE-GENERAR</x:String>
-  <x:String x:Key="Text.AIAssistant.Tip" xml:space="preserve">Usar OpenAI para generar mensaje de commit</x:String>
+  <x:String x:Key="Text.AIAssistant.Tip" xml:space="preserve">Usar AI para generar mensaje de commit</x:String>
   <x:String x:Key="Text.AIAssistant.Use" xml:space="preserve">Usar</x:String>
   <x:String x:Key="Text.App.Hide" xml:space="preserve">Ocultar SourceGit</x:String>
   <x:String x:Key="Text.App.HideOthers" xml:space="preserve">Ocultar Otros</x:String>
@@ -273,9 +273,9 @@
   <x:String x:Key="Text.Configure.IssueTracker.Share" xml:space="preserve">Compartir esta regla en el archivo .issuetracker</x:String>
   <x:String x:Key="Text.Configure.IssueTracker.URLTemplate" xml:space="preserve">URL Resultante:</x:String>
   <x:String x:Key="Text.Configure.IssueTracker.URLTemplate.Tip" xml:space="preserve">Por favor, use $1, $2 para acceder a los valores de los grupos regex.</x:String>
-  <x:String x:Key="Text.Configure.OpenAI" xml:space="preserve">OPEN AI</x:String>
-  <x:String x:Key="Text.Configure.OpenAI.Preferred" xml:space="preserve">Servicio Preferido:</x:String>
-  <x:String x:Key="Text.Configure.OpenAI.Preferred.Tip" xml:space="preserve">Si el 'Servicio Preferido' está establecido, SourceGit sólo lo usará en este repositorio. De lo contrario, si hay más de un servicio disponible, se mostrará un menú de contexto para elegir uno.</x:String>
+  <x:String x:Key="Text.Configure.AI" xml:space="preserve">OPEN AI</x:String>
+  <x:String x:Key="Text.Configure.AI.DefaultService" xml:space="preserve">Servicio Preferido:</x:String>
+  <x:String x:Key="Text.Configure.AI.DefaultService.Tip" xml:space="preserve">Si el 'Servicio Preferido' está establecido, SourceGit sólo lo usará en este repositorio. De lo contrario, si hay más de un servicio disponible, se mostrará un menú de contexto para elegir uno.</x:String>
   <x:String x:Key="Text.Configure.Proxy" xml:space="preserve">Proxy HTTP</x:String>
   <x:String x:Key="Text.Configure.Proxy.Placeholder" xml:space="preserve">Proxy HTTP utilizado por este repositorio</x:String>
   <x:String x:Key="Text.Configure.User" xml:space="preserve">Nombre del Usuario</x:String>
@@ -648,7 +648,6 @@
   <x:String x:Key="Text.Preferences.AI.AdditionalPrompt" xml:space="preserve">Prompt adicional (Usa `-` para listar tus requerimientos)</x:String>
   <x:String x:Key="Text.Preferences.AI.ApiKey" xml:space="preserve">Clave API</x:String>
   <x:String x:Key="Text.Preferences.AI.Model" xml:space="preserve">Modelo</x:String>
-  <x:String x:Key="Text.Preferences.AI.Model.AutoFetchAvailableModels" xml:space="preserve">Traer automáticamente los model-ids disponibles</x:String>
   <x:String x:Key="Text.Preferences.AI.Name" xml:space="preserve">Nombre</x:String>
   <x:String x:Key="Text.Preferences.AI.ReadApiKeyFromEnv" xml:space="preserve">El valor ingresado es el nombre de la clave API a cargar desde ENV</x:String>
   <x:String x:Key="Text.Preferences.AI.Server" xml:space="preserve">Servidor</x:String>

--- a/src/Resources/Locales/fr_FR.axaml
+++ b/src/Resources/Locales/fr_FR.axaml
@@ -262,9 +262,9 @@
   <x:String x:Key="Text.Configure.IssueTracker.Share" xml:space="preserve">Partager cette règle dans le fichier .issuetracker</x:String>
   <x:String x:Key="Text.Configure.IssueTracker.URLTemplate" xml:space="preserve">URL résultant:</x:String>
   <x:String x:Key="Text.Configure.IssueTracker.URLTemplate.Tip" xml:space="preserve">Veuillez utiliser $1, $2 pour accéder aux valeurs des groupes regex.</x:String>
-  <x:String x:Key="Text.Configure.OpenAI" xml:space="preserve">IA</x:String>
-  <x:String x:Key="Text.Configure.OpenAI.Preferred" xml:space="preserve">Service préféré:</x:String>
-  <x:String x:Key="Text.Configure.OpenAI.Preferred.Tip" xml:space="preserve">Si le 'Service préféré' est défini, SourceGit l'utilisera seulement dans ce repository. Sinon, si plus d'un service est disponible, un menu contextuel permettant de choisir l'un d'eux sera affiché.</x:String>
+  <x:String x:Key="Text.Configure.AI" xml:space="preserve">IA</x:String>
+  <x:String x:Key="Text.Configure.AI.DefaultService" xml:space="preserve">Service préféré:</x:String>
+  <x:String x:Key="Text.Configure.AI.DefaultService.Tip" xml:space="preserve">Si le 'Service préféré' est défini, SourceGit l'utilisera seulement dans ce repository. Sinon, si plus d'un service est disponible, un menu contextuel permettant de choisir l'un d'eux sera affiché.</x:String>
   <x:String x:Key="Text.Configure.Proxy" xml:space="preserve">Proxy HTTP</x:String>
   <x:String x:Key="Text.Configure.Proxy.Placeholder" xml:space="preserve">Proxy HTTP utilisé par ce dépôt</x:String>
   <x:String x:Key="Text.Configure.User" xml:space="preserve">Nom d'utilisateur</x:String>
@@ -627,7 +627,6 @@
   <x:String x:Key="Text.Preferences.AI.AdditionalPrompt" xml:space="preserve">Prompt supplémentaire (utilisez `-` pour lister vos exigences)</x:String>
   <x:String x:Key="Text.Preferences.AI.ApiKey" xml:space="preserve">Clé d'API</x:String>
   <x:String x:Key="Text.Preferences.AI.Model" xml:space="preserve">Modèle</x:String>
-  <x:String x:Key="Text.Preferences.AI.Model.AutoFetchAvailableModels" xml:space="preserve">Récupérer automatiquement les modèles disponibles</x:String>
   <x:String x:Key="Text.Preferences.AI.Name" xml:space="preserve">Nom</x:String>
   <x:String x:Key="Text.Preferences.AI.ReadApiKeyFromEnv" xml:space="preserve">La valeur saisie est le nom pour charger la clé API depuis l'ENV</x:String>
   <x:String x:Key="Text.Preferences.AI.Server" xml:space="preserve">Serveur</x:String>

--- a/src/Resources/Locales/he_IL.axaml
+++ b/src/Resources/Locales/he_IL.axaml
@@ -262,9 +262,9 @@
   <x:String x:Key="Text.Configure.IssueTracker.Share" xml:space="preserve">שיתוף כלל זה בקובץ .issuetracker</x:String>
   <x:String x:Key="Text.Configure.IssueTracker.URLTemplate" xml:space="preserve">URL התוצאה:</x:String>
   <x:String x:Key="Text.Configure.IssueTracker.URLTemplate.Tip" xml:space="preserve">השתמש ב־$1, $2 לגישה לערכי קבוצות ה־regex.</x:String>
-  <x:String x:Key="Text.Configure.OpenAI" xml:space="preserve">AI</x:String>
-  <x:String x:Key="Text.Configure.OpenAI.Preferred" xml:space="preserve">שירות מועדף:</x:String>
-  <x:String x:Key="Text.Configure.OpenAI.Preferred.Tip" xml:space="preserve">אם מוגדר 'שירות מועדף', SourceGit ישתמש רק בו במאגר זה. אחרת, אם זמינים מספר שירותים, יוצג תפריט הקשר לבחירת אחד מהם.</x:String>
+  <x:String x:Key="Text.Configure.AI" xml:space="preserve">AI</x:String>
+  <x:String x:Key="Text.Configure.AI.DefaultService" xml:space="preserve">שירות מועדף:</x:String>
+  <x:String x:Key="Text.Configure.AI.DefaultService.Tip" xml:space="preserve">אם מוגדר 'שירות מועדף', SourceGit ישתמש רק בו במאגר זה. אחרת, אם זמינים מספר שירותים, יוצג תפריט הקשר לבחירת אחד מהם.</x:String>
   <x:String x:Key="Text.Configure.Proxy" xml:space="preserve">HTTP Proxy</x:String>
   <x:String x:Key="Text.Configure.Proxy.Placeholder" xml:space="preserve">HTTP proxy לשימוש המאגר הזה</x:String>
   <x:String x:Key="Text.Configure.User" xml:space="preserve">שם משתמש</x:String>
@@ -627,7 +627,6 @@
   <x:String x:Key="Text.Preferences.AI.AdditionalPrompt" xml:space="preserve">Prompt נוסף (השתמש ב־`-` לרשימת דרישות)</x:String>
   <x:String x:Key="Text.Preferences.AI.ApiKey" xml:space="preserve">API Key</x:String>
   <x:String x:Key="Text.Preferences.AI.Model" xml:space="preserve">מודל</x:String>
-  <x:String x:Key="Text.Preferences.AI.Model.AutoFetchAvailableModels" xml:space="preserve">Fetch אוטומטי של model-ids זמינים</x:String>
   <x:String x:Key="Text.Preferences.AI.Name" xml:space="preserve">שם</x:String>
   <x:String x:Key="Text.Preferences.AI.ReadApiKeyFromEnv" xml:space="preserve">הערך שהוזן הוא שם משתנה סביבה לטעינת ה־API key</x:String>
   <x:String x:Key="Text.Preferences.AI.Server" xml:space="preserve">שרת</x:String>

--- a/src/Resources/Locales/id_ID.axaml
+++ b/src/Resources/Locales/id_ID.axaml
@@ -217,9 +217,9 @@
   <x:String x:Key="Text.Configure.IssueTracker.Share" xml:space="preserve">Bagikan aturan ini di berkas .issuetracker</x:String>
   <x:String x:Key="Text.Configure.IssueTracker.URLTemplate" xml:space="preserve">URL Hasil:</x:String>
   <x:String x:Key="Text.Configure.IssueTracker.URLTemplate.Tip" xml:space="preserve">Gunakan $1, $2 untuk mengakses nilai grup regex.</x:String>
-  <x:String x:Key="Text.Configure.OpenAI" xml:space="preserve">AI</x:String>
-  <x:String x:Key="Text.Configure.OpenAI.Preferred" xml:space="preserve">Layanan Pilihan:</x:String>
-  <x:String x:Key="Text.Configure.OpenAI.Preferred.Tip" xml:space="preserve">Jika 'Layanan Pilihan' diatur, SourceGit hanya akan menggunakannya di repositori ini. Jika tidak, jika ada lebih dari satu layanan yang tersedia, menu konteks untuk memilih salah satunya akan ditampilkan.</x:String>
+  <x:String x:Key="Text.Configure.AI" xml:space="preserve">AI</x:String>
+  <x:String x:Key="Text.Configure.AI.DefaultService" xml:space="preserve">Layanan Pilihan:</x:String>
+  <x:String x:Key="Text.Configure.AI.DefaultService.Tip" xml:space="preserve">Jika 'Layanan Pilihan' diatur, SourceGit hanya akan menggunakannya di repositori ini. Jika tidak, jika ada lebih dari satu layanan yang tersedia, menu konteks untuk memilih salah satunya akan ditampilkan.</x:String>
   <x:String x:Key="Text.Configure.Proxy" xml:space="preserve">Proksi HTTP</x:String>
   <x:String x:Key="Text.Configure.Proxy.Placeholder" xml:space="preserve">Proksi HTTP yang digunakan oleh repositori ini</x:String>
   <x:String x:Key="Text.Configure.User" xml:space="preserve">Nama Pengguna</x:String>

--- a/src/Resources/Locales/it_IT.axaml
+++ b/src/Resources/Locales/it_IT.axaml
@@ -241,9 +241,9 @@ ${pure_files:N} Come ${files:N}, ma senza cartelle</x:String>
   <x:String x:Key="Text.Configure.IssueTracker.Share" xml:space="preserve">Condividi questa regola nel file .issuetracker</x:String>
   <x:String x:Key="Text.Configure.IssueTracker.URLTemplate" xml:space="preserve">URL Risultato:</x:String>
   <x:String x:Key="Text.Configure.IssueTracker.URLTemplate.Tip" xml:space="preserve">Utilizza $1, $2 per accedere ai valori dei gruppi regex.</x:String>
-  <x:String x:Key="Text.Configure.OpenAI" xml:space="preserve">AI</x:String>
-  <x:String x:Key="Text.Configure.OpenAI.Preferred" xml:space="preserve">Servizio preferito:</x:String>
-  <x:String x:Key="Text.Configure.OpenAI.Preferred.Tip" xml:space="preserve">Se il 'Servizio Preferito' é impostato, SourceGit utilizzerà solo quello per questo repository. Altrimenti, se ci sono più servizi disponibili, verrà mostrato un menu contestuale per sceglierne uno.</x:String>
+  <x:String x:Key="Text.Configure.AI" xml:space="preserve">AI</x:String>
+  <x:String x:Key="Text.Configure.AI.DefaultService" xml:space="preserve">Servizio preferito:</x:String>
+  <x:String x:Key="Text.Configure.AI.DefaultService.Tip" xml:space="preserve">Se il 'Servizio Preferito' é impostato, SourceGit utilizzerà solo quello per questo repository. Altrimenti, se ci sono più servizi disponibili, verrà mostrato un menu contestuale per sceglierne uno.</x:String>
   <x:String x:Key="Text.Configure.Proxy" xml:space="preserve">Proxy HTTP</x:String>
   <x:String x:Key="Text.Configure.Proxy.Placeholder" xml:space="preserve">Proxy HTTP usato da questo repository</x:String>
   <x:String x:Key="Text.Configure.User" xml:space="preserve">Nome Utente</x:String>

--- a/src/Resources/Locales/ja_JP.axaml
+++ b/src/Resources/Locales/ja_JP.axaml
@@ -273,9 +273,9 @@
   <x:String x:Key="Text.Configure.IssueTracker.Share" xml:space="preserve">このルールを .issuetracker ファイルで共有</x:String>
   <x:String x:Key="Text.Configure.IssueTracker.URLTemplate" xml:space="preserve">最終的な URL:</x:String>
   <x:String x:Key="Text.Configure.IssueTracker.URLTemplate.Tip" xml:space="preserve">正規表現のグループ値は $1, $2 で取得してください。</x:String>
-  <x:String x:Key="Text.Configure.OpenAI" xml:space="preserve">AI</x:String>
-  <x:String x:Key="Text.Configure.OpenAI.Preferred" xml:space="preserve">優先するサービス:</x:String>
-  <x:String x:Key="Text.Configure.OpenAI.Preferred.Tip" xml:space="preserve">'優先するサービス' を設定すると、このリポジトリではそのサービスのみを使用するようになります。そうでなければ、複数のサービスが存在する場合に限り、その中からひとつを選択できるコンテキストメニューが表示されます。</x:String>
+  <x:String x:Key="Text.Configure.AI" xml:space="preserve">AI</x:String>
+  <x:String x:Key="Text.Configure.AI.DefaultService" xml:space="preserve">優先するサービス:</x:String>
+  <x:String x:Key="Text.Configure.AI.DefaultService.Tip" xml:space="preserve">'優先するサービス' を設定すると、このリポジトリではそのサービスのみを使用するようになります。そうでなければ、複数のサービスが存在する場合に限り、その中からひとつを選択できるコンテキストメニューが表示されます。</x:String>
   <x:String x:Key="Text.Configure.Proxy" xml:space="preserve">HTTP プロキシ</x:String>
   <x:String x:Key="Text.Configure.Proxy.Placeholder" xml:space="preserve">このリポジトリで使用する HTTP プロキシ</x:String>
   <x:String x:Key="Text.Configure.User" xml:space="preserve">ユーザー名</x:String>
@@ -659,7 +659,6 @@
   <x:String x:Key="Text.Preferences.AI.AdditionalPrompt" xml:space="preserve">追加のプロンプト (`-` で必要事項を羅列してください)</x:String>
   <x:String x:Key="Text.Preferences.AI.ApiKey" xml:space="preserve">API キー</x:String>
   <x:String x:Key="Text.Preferences.AI.Model" xml:space="preserve">モデル</x:String>
-  <x:String x:Key="Text.Preferences.AI.Model.AutoFetchAvailableModels" xml:space="preserve">利用できるモデル ID を自動的に取得</x:String>
   <x:String x:Key="Text.Preferences.AI.Name" xml:space="preserve">名前</x:String>
   <x:String x:Key="Text.Preferences.AI.ReadApiKeyFromEnv" xml:space="preserve">この値を環境変数の名前とし、そこから API キーを読み込む</x:String>
   <x:String x:Key="Text.Preferences.AI.Server" xml:space="preserve">サーバー</x:String>

--- a/src/Resources/Locales/ko_KR.axaml
+++ b/src/Resources/Locales/ko_KR.axaml
@@ -260,9 +260,9 @@
   <x:String x:Key="Text.Configure.IssueTracker.Share" xml:space="preserve">.issuetracker 파일에 이 규칙 공유</x:String>
   <x:String x:Key="Text.Configure.IssueTracker.URLTemplate" xml:space="preserve">결과 URL:</x:String>
   <x:String x:Key="Text.Configure.IssueTracker.URLTemplate.Tip" xml:space="preserve">정규식 그룹 값에 접근하려면 $1, $2를 사용하세요.</x:String>
-  <x:String x:Key="Text.Configure.OpenAI" xml:space="preserve">AI</x:String>
-  <x:String x:Key="Text.Configure.OpenAI.Preferred" xml:space="preserve">선호하는 서비스:</x:String>
-  <x:String x:Key="Text.Configure.OpenAI.Preferred.Tip" xml:space="preserve">'선호하는 서비스'가 설정되면, SourceGit은 이 저장소에서 해당 서비스만 사용합니다. 그렇지 않고 사용 가능한 서비스가 두 개 이상인 경우, 하나를 선택할 수 있는 컨텍스트 메뉴가 표시됩니다.</x:String>
+  <x:String x:Key="Text.Configure.AI" xml:space="preserve">AI</x:String>
+  <x:String x:Key="Text.Configure.AI.DefaultService" xml:space="preserve">선호하는 서비스:</x:String>
+  <x:String x:Key="Text.Configure.AI.DefaultService.Tip" xml:space="preserve">'선호하는 서비스'가 설정되면, SourceGit은 이 저장소에서 해당 서비스만 사용합니다. 그렇지 않고 사용 가능한 서비스가 두 개 이상인 경우, 하나를 선택할 수 있는 컨텍스트 메뉴가 표시됩니다.</x:String>
   <x:String x:Key="Text.Configure.Proxy" xml:space="preserve">HTTP 프록시</x:String>
   <x:String x:Key="Text.Configure.Proxy.Placeholder" xml:space="preserve">이 저장소에서 사용하는 HTTP 프록시</x:String>
   <x:String x:Key="Text.Configure.User" xml:space="preserve">사용자 이름</x:String>
@@ -630,7 +630,6 @@
   <x:String x:Key="Text.Preferences.AI.AdditionalPrompt" xml:space="preserve">추가 프롬프트(`-`로 요구 사항 나열)</x:String>
   <x:String x:Key="Text.Preferences.AI.ApiKey" xml:space="preserve">API 키</x:String>
   <x:String x:Key="Text.Preferences.AI.Model" xml:space="preserve">모델</x:String>
-  <x:String x:Key="Text.Preferences.AI.Model.AutoFetchAvailableModels" xml:space="preserve">사용 가능한 모델 ID 자동 가져오기</x:String>
   <x:String x:Key="Text.Preferences.AI.Name" xml:space="preserve">이름</x:String>
   <x:String x:Key="Text.Preferences.AI.ReadApiKeyFromEnv" xml:space="preserve">입력된 값은 환경변수(ENV)에서 API 키를 불러올 이름입니다</x:String>
   <x:String x:Key="Text.Preferences.AI.Server" xml:space="preserve">서버</x:String>

--- a/src/Resources/Locales/pt_BR.axaml
+++ b/src/Resources/Locales/pt_BR.axaml
@@ -167,9 +167,9 @@
   <x:String x:Key="Text.Configure.IssueTracker.RuleName" xml:space="preserve">Nome da Regra:</x:String>
   <x:String x:Key="Text.Configure.IssueTracker.URLTemplate" xml:space="preserve">URL de Resultado:</x:String>
   <x:String x:Key="Text.Configure.IssueTracker.URLTemplate.Tip" xml:space="preserve">Por favor, use $1, $2 para acessar os valores de grupos do regex.</x:String>
-  <x:String x:Key="Text.Configure.OpenAI" xml:space="preserve">IA</x:String>
-  <x:String x:Key="Text.Configure.OpenAI.Preferred" xml:space="preserve">Serviço desejado:</x:String>
-  <x:String x:Key="Text.Configure.OpenAI.Preferred.Tip" xml:space="preserve">Se o 'Serviço desejado' for definido, SourceGit usará ele neste Repositório. Senão, caso haja mais de um serviço disponível, será exibido um menu para seleção.</x:String>
+  <x:String x:Key="Text.Configure.AI" xml:space="preserve">IA</x:String>
+  <x:String x:Key="Text.Configure.AI.DefaultService" xml:space="preserve">Serviço desejado:</x:String>
+  <x:String x:Key="Text.Configure.AI.DefaultService.Tip" xml:space="preserve">Se o 'Serviço desejado' for definido, SourceGit usará ele neste Repositório. Senão, caso haja mais de um serviço disponível, será exibido um menu para seleção.</x:String>
   <x:String x:Key="Text.Configure.Proxy" xml:space="preserve">Proxy HTTP</x:String>
   <x:String x:Key="Text.Configure.Proxy.Placeholder" xml:space="preserve">Proxy HTTP usado por este repositório</x:String>
   <x:String x:Key="Text.Configure.User" xml:space="preserve">Nome de Usuário</x:String>

--- a/src/Resources/Locales/ru_RU.axaml
+++ b/src/Resources/Locales/ru_RU.axaml
@@ -21,10 +21,10 @@
   <x:String x:Key="Text.AddWorktree.WhatToCheckout" xml:space="preserve">Переключиться на:</x:String>
   <x:String x:Key="Text.AddWorktree.WhatToCheckout.CreateNew" xml:space="preserve">Создать новую ветку</x:String>
   <x:String x:Key="Text.AddWorktree.WhatToCheckout.Existing" xml:space="preserve">Ветку из списка</x:String>
-  <x:String x:Key="Text.AIAssistant" xml:space="preserve">Помощник OpenAI</x:String>
+  <x:String x:Key="Text.AIAssistant" xml:space="preserve">Помощник AI</x:String>
   <x:String x:Key="Text.AIAssistant.Model" xml:space="preserve">Модель</x:String>
   <x:String x:Key="Text.AIAssistant.Regen" xml:space="preserve">ПЕРЕСОЗДАТЬ</x:String>
-  <x:String x:Key="Text.AIAssistant.Tip" xml:space="preserve">Использовать OpenAI для создания сообщения о ревизии</x:String>
+  <x:String x:Key="Text.AIAssistant.Tip" xml:space="preserve">Использовать AI для создания сообщения о ревизии</x:String>
   <x:String x:Key="Text.AIAssistant.Use" xml:space="preserve">Использовать</x:String>
   <x:String x:Key="Text.App.Hide" xml:space="preserve">Скрыть SourceGit</x:String>
   <x:String x:Key="Text.App.HideOthers" xml:space="preserve">Скрыть остальные</x:String>
@@ -273,9 +273,9 @@
   <x:String x:Key="Text.Configure.IssueTracker.Share" xml:space="preserve">Опубликовать это правило в файле .issuetracker</x:String>
   <x:String x:Key="Text.Configure.IssueTracker.URLTemplate" xml:space="preserve">Адрес результата:</x:String>
   <x:String x:Key="Text.Configure.IssueTracker.URLTemplate.Tip" xml:space="preserve">Пожалуйста, используйте $1, $2 для доступа к значениям групп регулярных выражений.</x:String>
-  <x:String x:Key="Text.Configure.OpenAI" xml:space="preserve">ОТКРЫТЬ ИИ</x:String>
-  <x:String x:Key="Text.Configure.OpenAI.Preferred" xml:space="preserve">Предпочтительный сервис:</x:String>
-  <x:String x:Key="Text.Configure.OpenAI.Preferred.Tip" xml:space="preserve">Если «Предпочтительный сервис» установлен, SourceGit будет использовать только этот репозиторий. В противном случае, если доступно более одной услуги, будет отображено контекстное меню для выбора одной из них.</x:String>
+  <x:String x:Key="Text.Configure.AI" xml:space="preserve">ОТКРЫТЬ ИИ</x:String>
+  <x:String x:Key="Text.Configure.AI.DefaultService" xml:space="preserve">Предпочтительный сервис:</x:String>
+  <x:String x:Key="Text.Configure.AI.DefaultService.Tip" xml:space="preserve">Если «Предпочтительный сервис» установлен, SourceGit будет использовать только этот репозиторий. В противном случае, если доступно более одной услуги, будет отображено контекстное меню для выбора одной из них.</x:String>
   <x:String x:Key="Text.Configure.Proxy" xml:space="preserve">HTTP-прокси</x:String>
   <x:String x:Key="Text.Configure.Proxy.Placeholder" xml:space="preserve">HTTP-прокси для репозитория</x:String>
   <x:String x:Key="Text.Configure.User" xml:space="preserve">Имя пользователя</x:String>
@@ -648,7 +648,6 @@
   <x:String x:Key="Text.Preferences.AI.AdditionalPrompt" xml:space="preserve">Дополнительная подсказка (Для перечисления ваших требований используйте `-`)</x:String>
   <x:String x:Key="Text.Preferences.AI.ApiKey" xml:space="preserve">Ключ API</x:String>
   <x:String x:Key="Text.Preferences.AI.Model" xml:space="preserve">Модель</x:String>
-  <x:String x:Key="Text.Preferences.AI.Model.AutoFetchAvailableModels" xml:space="preserve">Автоматическое получение доступных идентификаторов моделей</x:String>
   <x:String x:Key="Text.Preferences.AI.Name" xml:space="preserve">Имя:</x:String>
   <x:String x:Key="Text.Preferences.AI.ReadApiKeyFromEnv" xml:space="preserve">Введённое значение — это имя для загрузки API-ключа из ENV</x:String>
   <x:String x:Key="Text.Preferences.AI.Server" xml:space="preserve">Сервер</x:String>

--- a/src/Resources/Locales/ta_IN.axaml
+++ b/src/Resources/Locales/ta_IN.axaml
@@ -146,9 +146,9 @@
   <x:String x:Key="Text.Configure.IssueTracker.RuleName" xml:space="preserve">விதியின் பெயர்:</x:String>
   <x:String x:Key="Text.Configure.IssueTracker.URLTemplate" xml:space="preserve">முடிவு முகவரி:</x:String>
   <x:String x:Key="Text.Configure.IssueTracker.URLTemplate.Tip" xml:space="preserve">வழக்கவெளி குழுக்கள் மதிப்புகளை அணுக $1, $2 ஐப் பயன்படுத்து</x:String>
-  <x:String x:Key="Text.Configure.OpenAI" xml:space="preserve">செநு</x:String>
-  <x:String x:Key="Text.Configure.OpenAI.Preferred" xml:space="preserve">விருப்பமான சேவை:</x:String>
-  <x:String x:Key="Text.Configure.OpenAI.Preferred.Tip" xml:space="preserve">'விருப்பமான சேவை' அமைக்கப்பட்டிருந்தால், மூலஅறிவிலி இந்த களஞ்சியத்தில் மட்டுமே அதைப் பயன்படுத்தும். இல்லையெனில், ஒன்றுக்கு மேற்பட்ட சேவைகள் இருந்தால், அவற்றில் ஒன்றைத் தேர்ந்தெடுப்பதற்கான சூழல் பட்டயல் காண்பிக்கப்படும்.</x:String>
+  <x:String x:Key="Text.Configure.AI" xml:space="preserve">செநு</x:String>
+  <x:String x:Key="Text.Configure.AI.DefaultService" xml:space="preserve">விருப்பமான சேவை:</x:String>
+  <x:String x:Key="Text.Configure.AI.DefaultService.Tip" xml:space="preserve">'விருப்பமான சேவை' அமைக்கப்பட்டிருந்தால், மூலஅறிவிலி இந்த களஞ்சியத்தில் மட்டுமே அதைப் பயன்படுத்தும். இல்லையெனில், ஒன்றுக்கு மேற்பட்ட சேவைகள் இருந்தால், அவற்றில் ஒன்றைத் தேர்ந்தெடுப்பதற்கான சூழல் பட்டயல் காண்பிக்கப்படும்.</x:String>
   <x:String x:Key="Text.Configure.Proxy" xml:space="preserve">உஉபநெ பதிலாள்</x:String>
   <x:String x:Key="Text.Configure.Proxy.Placeholder" xml:space="preserve">இந்த களஞ்சியத்தால் பயன்படுத்தப்படும் உஉபநெ பதிலாள்</x:String>
   <x:String x:Key="Text.Configure.User" xml:space="preserve">பயனர் பெயர்</x:String>

--- a/src/Resources/Locales/uk_UA.axaml
+++ b/src/Resources/Locales/uk_UA.axaml
@@ -147,9 +147,9 @@
   <x:String x:Key="Text.Configure.IssueTracker.RuleName" xml:space="preserve">Назва правила:</x:String>
   <x:String x:Key="Text.Configure.IssueTracker.URLTemplate" xml:space="preserve">URL результату:</x:String>
   <x:String x:Key="Text.Configure.IssueTracker.URLTemplate.Tip" xml:space="preserve">Використовуйте $1, $2 для доступу до значень груп регулярного виразу.</x:String>
-  <x:String x:Key="Text.Configure.OpenAI" xml:space="preserve">AI</x:String>
-  <x:String x:Key="Text.Configure.OpenAI.Preferred" xml:space="preserve">Бажаний сервіс:</x:String>
-  <x:String x:Key="Text.Configure.OpenAI.Preferred.Tip" xml:space="preserve">Якщо 'Бажаний сервіс' встановлено, SourceGit буде використовувати лише його у цьому сховищі. Інакше, якщо доступно більше одного сервісу, буде показано контекстне меню для вибору.</x:String>
+  <x:String x:Key="Text.Configure.AI" xml:space="preserve">AI</x:String>
+  <x:String x:Key="Text.Configure.AI.DefaultService" xml:space="preserve">Бажаний сервіс:</x:String>
+  <x:String x:Key="Text.Configure.AI.DefaultService.Tip" xml:space="preserve">Якщо 'Бажаний сервіс' встановлено, SourceGit буде використовувати лише його у цьому сховищі. Інакше, якщо доступно більше одного сервісу, буде показано контекстне меню для вибору.</x:String>
   <x:String x:Key="Text.Configure.Proxy" xml:space="preserve">HTTP Проксі</x:String>
   <x:String x:Key="Text.Configure.Proxy.Placeholder" xml:space="preserve">HTTP проксі, що використовується цим сховищем</x:String>
   <x:String x:Key="Text.Configure.User" xml:space="preserve">Ім'я користувача</x:String>

--- a/src/Resources/Locales/zh_CN.axaml
+++ b/src/Resources/Locales/zh_CN.axaml
@@ -7,6 +7,7 @@
   <x:String x:Key="Text.About.Menu" xml:space="preserve">关于本软件</x:String>
   <x:String x:Key="Text.About.ReleaseDate" xml:space="preserve">发布日期：{0}</x:String>
   <x:String x:Key="Text.About.ReleaseNotes" xml:space="preserve">浏览版本更新说明</x:String>
+  <x:String x:Key="Text.Add" xml:space="preserve">添加</x:String>
   <x:String x:Key="Text.About.SubTitle" xml:space="preserve">开源免费的Git客户端</x:String>
   <x:String x:Key="Text.AddToIgnore" xml:space="preserve">新增忽略文件</x:String>
   <x:String x:Key="Text.AddToIgnore.Pattern" xml:space="preserve">匹配模式 ：</x:String>
@@ -273,9 +274,12 @@
   <x:String x:Key="Text.Configure.IssueTracker.Share" xml:space="preserve">写入 .issuetracker 文件共享此规则</x:String>
   <x:String x:Key="Text.Configure.IssueTracker.URLTemplate" xml:space="preserve">为ISSUE生成的URL链接 ：</x:String>
   <x:String x:Key="Text.Configure.IssueTracker.URLTemplate.Tip" xml:space="preserve">可在URL中使用$1，$2等变量填入正则表达式匹配的内容</x:String>
-  <x:String x:Key="Text.Configure.OpenAI" xml:space="preserve">AI</x:String>
-  <x:String x:Key="Text.Configure.OpenAI.Preferred" xml:space="preserve">启用特定服务 ：</x:String>
-  <x:String x:Key="Text.Configure.OpenAI.Preferred.Tip" xml:space="preserve">当【启用特定服务】被设置时，SourceGit将在本仓库中仅使用该服务。否则将弹出可用的AI服务列表供用户选择。</x:String>
+  <x:String x:Key="Text.Configure.AI" xml:space="preserve">AI</x:String>
+  <x:String x:Key="Text.Configure.AI.DefaultService" xml:space="preserve">默认模型服务：</x:String>
+  <x:String x:Key="Text.Configure.AI.PreferredModel" xml:space="preserve">默认模型 ：</x:String>
+  <x:String x:Key="Text.Configure.AI.DefaultService.Tip" xml:space="preserve">设置后，SourceGit将在本仓库中直接使用该服务和模型生成提交信息，否则将弹出选择菜单。</x:String>
+  <x:String x:Key="Text.Configure.AI.DefaultService.None" xml:space="preserve">(无)</x:String>
+  <x:String x:Key="Text.Configure.AI.PreferredModel.None" xml:space="preserve">(无)</x:String>
   <x:String x:Key="Text.Configure.Proxy" xml:space="preserve">HTTP代理</x:String>
   <x:String x:Key="Text.Configure.Proxy.Placeholder" xml:space="preserve">HTTP网络代理</x:String>
   <x:String x:Key="Text.Configure.User" xml:space="preserve">用户名</x:String>
@@ -658,10 +662,15 @@
   <x:String x:Key="Text.Preferences.AI.AdditionalPrompt" xml:space="preserve">附加提示词 (请使用 `-` 列出您的要求)</x:String>
   <x:String x:Key="Text.Preferences.AI.ApiKey" xml:space="preserve">API密钥</x:String>
   <x:String x:Key="Text.Preferences.AI.Model" xml:space="preserve">模型</x:String>
-  <x:String x:Key="Text.Preferences.AI.Model.AutoFetchAvailableModels" xml:space="preserve">自动拉取可用模型列表</x:String>
+  <x:String x:Key="Text.Preferences.AI.Model.AddModel" xml:space="preserve">添加模型</x:String>
+  <x:String x:Key="Text.Preferences.AI.Model.FetchModels" xml:space="preserve">获取模型列表</x:String>
+  <x:String x:Key="Text.Preferences.AI.Model.Fetching" xml:space="preserve">正在获取模型列表...</x:String>
+  <x:String x:Key="Text.Preferences.AI.Model.RemoveModel" xml:space="preserve">删除模型</x:String>
+  <x:String x:Key="Text.Preferences.AI.Model.SelectModels" xml:space="preserve">选择模型</x:String>
   <x:String x:Key="Text.Preferences.AI.Name" xml:space="preserve">配置名称</x:String>
   <x:String x:Key="Text.Preferences.AI.ReadApiKeyFromEnv" xml:space="preserve">从环境变量（填写环境变量名）中读取API密钥</x:String>
   <x:String x:Key="Text.Preferences.AI.Server" xml:space="preserve">服务地址</x:String>
+  <x:String x:Key="Text.Preferences.AI.Services" xml:space="preserve">模型服务</x:String>
   <x:String x:Key="Text.Preferences.Appearance" xml:space="preserve">外观配置</x:String>
   <x:String x:Key="Text.Preferences.Appearance.DefaultFont" xml:space="preserve">缺省字体</x:String>
   <x:String x:Key="Text.Preferences.Appearance.EditorTabWidth" xml:space="preserve">编辑器制表符宽度</x:String>

--- a/src/Resources/Locales/zh_TW.axaml
+++ b/src/Resources/Locales/zh_TW.axaml
@@ -7,6 +7,7 @@
   <x:String x:Key="Text.About.Menu" xml:space="preserve">關於 SourceGit</x:String>
   <x:String x:Key="Text.About.ReleaseDate" xml:space="preserve">發行日期: {0}</x:String>
   <x:String x:Key="Text.About.ReleaseNotes" xml:space="preserve">版本說明</x:String>
+  <x:String x:Key="Text.Add" xml:space="preserve">新增</x:String>
   <x:String x:Key="Text.About.SubTitle" xml:space="preserve">開源免費的 Git 客戶端</x:String>
   <x:String x:Key="Text.AddToIgnore" xml:space="preserve">新增忽略檔案</x:String>
   <x:String x:Key="Text.AddToIgnore.Pattern" xml:space="preserve">比對模式: </x:String>
@@ -273,9 +274,10 @@
   <x:String x:Key="Text.Configure.IssueTracker.Share" xml:space="preserve">寫入 .issuetracker 檔案以共用此規則</x:String>
   <x:String x:Key="Text.Configure.IssueTracker.URLTemplate" xml:space="preserve">為 Issue 產生的網址連結:</x:String>
   <x:String x:Key="Text.Configure.IssueTracker.URLTemplate.Tip" xml:space="preserve">可在網址中使用 $1、$2 等變數填入正規表達式相符的內容</x:String>
-  <x:String x:Key="Text.Configure.OpenAI" xml:space="preserve">AI</x:String>
-  <x:String x:Key="Text.Configure.OpenAI.Preferred" xml:space="preserve">偏好服務:</x:String>
-  <x:String x:Key="Text.Configure.OpenAI.Preferred.Tip" xml:space="preserve">設定 [偏好服務] 後，SourceGit 將於此存放庫中使用該服務，否則會顯示 AI 服務列表供使用者選擇。</x:String>
+  <x:String x:Key="Text.Configure.AI" xml:space="preserve">AI</x:String>
+  <x:String x:Key="Text.Configure.AI.DefaultService" xml:space="preserve">預設模型服務：</x:String>
+  <x:String x:Key="Text.Configure.AI.PreferredModel" xml:space="preserve">預設模型:</x:String>
+  <x:String x:Key="Text.Configure.AI.DefaultService.Tip" xml:space="preserve">設定後，SourceGit將於此存放庫中直接使用該服務和模型生成提交資訊，否則會顯示選擇選單。</x:String>
   <x:String x:Key="Text.Configure.Proxy" xml:space="preserve">HTTP 代理</x:String>
   <x:String x:Key="Text.Configure.Proxy.Placeholder" xml:space="preserve">HTTP 網路代理</x:String>
   <x:String x:Key="Text.Configure.User" xml:space="preserve">使用者名稱</x:String>
@@ -658,10 +660,15 @@
   <x:String x:Key="Text.Preferences.AI.AdditionalPrompt" xml:space="preserve">附加提示詞 (請使用 '-' 列出您的要求)</x:String>
   <x:String x:Key="Text.Preferences.AI.ApiKey" xml:space="preserve">API 金鑰</x:String>
   <x:String x:Key="Text.Preferences.AI.Model" xml:space="preserve">模型</x:String>
-  <x:String x:Key="Text.Preferences.AI.Model.AutoFetchAvailableModels" xml:space="preserve">自動獲取可用的模型列表</x:String>
+  <x:String x:Key="Text.Preferences.AI.Model.AddModel" xml:space="preserve">新增模型</x:String>
+  <x:String x:Key="Text.Preferences.AI.Model.FetchModels" xml:space="preserve">取得模型列表</x:String>
+  <x:String x:Key="Text.Preferences.AI.Model.Fetching" xml:space="preserve">正在取得模型列表...</x:String>
+  <x:String x:Key="Text.Preferences.AI.Model.RemoveModel" xml:space="preserve">刪除模型</x:String>
+  <x:String x:Key="Text.Preferences.AI.Model.SelectModels" xml:space="preserve">選擇模型</x:String>
   <x:String x:Key="Text.Preferences.AI.Name" xml:space="preserve">名稱</x:String>
   <x:String x:Key="Text.Preferences.AI.ReadApiKeyFromEnv" xml:space="preserve">從環境變數中 (輸入環境變數名稱) 讀取 API 金鑰</x:String>
   <x:String x:Key="Text.Preferences.AI.Server" xml:space="preserve">伺服器</x:String>
+  <x:String x:Key="Text.Preferences.AI.Services" xml:space="preserve">模型服務</x:String>
   <x:String x:Key="Text.Preferences.Appearance" xml:space="preserve">外觀設定</x:String>
   <x:String x:Key="Text.Preferences.Appearance.DefaultFont" xml:space="preserve">預設字型</x:String>
   <x:String x:Key="Text.Preferences.Appearance.EditorTabWidth" xml:space="preserve">編輯器 Tab 寬度</x:String>

--- a/src/ViewModels/AIAssistant.cs
+++ b/src/ViewModels/AIAssistant.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Threading;

--- a/src/ViewModels/Preferences.cs
+++ b/src/ViewModels/Preferences.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using System.Threading.Tasks;
 using Avalonia.Collections;
 using CommunityToolkit.Mvvm.ComponentModel;
 
@@ -624,20 +623,6 @@ namespace SourceGit.ViewModels
 
         public void UpdateAvailableAIModels()
         {
-            Task.Run(() =>
-            {
-                foreach (var service in OpenAIServices)
-                {
-                    try
-                    {
-                        service.FetchAvailableModels();
-                    }
-                    catch
-                    {
-                        // Ignore errors.
-                    }
-                }
-            });
         }
 
         public void Save()

--- a/src/ViewModels/Repository.cs
+++ b/src/ViewModels/Repository.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
@@ -1583,26 +1583,33 @@ namespace SourceGit.ViewModels
             log.Complete();
         }
 
-        public List<AI.Service> GetPreferredOpenAIServices()
+        public List<AI.Service> GetAllOpenAIServices()
         {
-            var services = Preferences.Instance.OpenAIServices;
-            if (services == null || services.Count == 0)
-                return [];
+            return new List<AI.Service>(Preferences.Instance.OpenAIServices ?? []);
+        }
 
-            if (services.Count == 1)
-                return [services[0]];
+        public (string Service, string Model) GetOpenAIConfig()
+        {
+            return (_settings.PreferredOpenAIService, _settings.PreferredAIModel);
+        }
 
-            var preferred = _settings.PreferredOpenAIService;
-            var all = new List<AI.Service>();
-            foreach (var service in services)
-            {
-                if (service.Name.Equals(preferred, StringComparison.Ordinal))
-                    return [service];
+        public AI.Service ResolveAIService()
+        {
+            var allServices = GetAllOpenAIServices();
+            var (preferredServiceName, preferredModelName) = GetOpenAIConfig();
 
-                all.Add(service);
-            }
+            if (string.IsNullOrEmpty(preferredServiceName) || allServices.Count == 0)
+                return null;
 
-            return all;
+            var service = allServices.Find(s => s.Name == preferredServiceName);
+            if (service == null)
+                return null;
+
+            var resolved = service.Clone();
+            if (!string.IsNullOrEmpty(preferredModelName))
+                resolved.Model = preferredModelName;
+
+            return resolved;
         }
 
         public void DiscardAllChanges()

--- a/src/ViewModels/RepositoryConfigure.cs
+++ b/src/ViewModels/RepositoryConfigure.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
@@ -137,8 +137,72 @@ namespace SourceGit.ViewModels
 
         public string PreferredOpenAIService
         {
-            get => _repo.Settings.PreferredOpenAIService;
-            set => _repo.Settings.PreferredOpenAIService = value;
+            get
+            {
+                var value = _repo.Settings.PreferredOpenAIService;
+                if (string.IsNullOrEmpty(value))
+                    return App.Text("Configure.AI.DefaultService.None");
+                return value;
+            }
+            set
+            {
+                var noneText = App.Text("Configure.AI.DefaultService.None");
+                var storedValue = (value == noneText) ? "" : value;
+
+                if (_repo.Settings.PreferredOpenAIService != storedValue)
+                {
+                    _repo.Settings.PreferredOpenAIService = storedValue;
+
+                    var modelNoneText = App.Text("Configure.AI.PreferredModel.None");
+                    var models = GetModelsForService(storedValue);
+                    if (models.Count > 0)
+                        models.Insert(0, modelNoneText);
+
+                    AvailableAIModels = models;
+                    IsModelSelectorEnabled = models.Count > 0;
+
+                    if (!AvailableAIModels.Contains(PreferredAIModel))
+                        PreferredAIModel = modelNoneText;
+
+                    OnPropertyChanged();
+                    OnPropertyChanged(nameof(AvailableAIModels));
+                    OnPropertyChanged(nameof(IsModelSelectorEnabled));
+                }
+            }
+        }
+
+        public bool IsModelSelectorEnabled
+        {
+            get => _isModelSelectorEnabled;
+            private set => SetProperty(ref _isModelSelectorEnabled, value);
+        }
+
+        public List<string> AvailableAIModels
+        {
+            get => _availableAIModels;
+            private set => SetProperty(ref _availableAIModels, value);
+        }
+
+        public string PreferredAIModel
+        {
+            get
+            {
+                var value = _repo.Settings.PreferredAIModel;
+                if (string.IsNullOrEmpty(value))
+                    return App.Text("Configure.AI.PreferredModel.None");
+                return value;
+            }
+            set
+            {
+                var noneText = App.Text("Configure.AI.PreferredModel.None");
+                var storedValue = (value == noneText) ? "" : value;
+
+                if (_repo.Settings.PreferredAIModel != storedValue)
+                {
+                    _repo.Settings.PreferredAIModel = storedValue;
+                    OnPropertyChanged();
+                }
+            }
         }
 
         public AvaloniaList<Models.CustomAction> CustomActions
@@ -160,12 +224,27 @@ namespace SourceGit.ViewModels
             foreach (var remote in _repo.Remotes)
                 Remotes.Add(remote.Name);
 
-            AvailableOpenAIServices = new List<string>() { "---" };
+            var serviceNoneText = App.Text("Configure.AI.DefaultService.None");
+            var modelNoneText = App.Text("Configure.AI.PreferredModel.None");
+
+            AvailableOpenAIServices = new List<string>() { serviceNoneText };
             foreach (var service in Preferences.Instance.OpenAIServices)
                 AvailableOpenAIServices.Add(service.Name);
 
             if (!AvailableOpenAIServices.Contains(PreferredOpenAIService))
-                PreferredOpenAIService = "---";
+                PreferredOpenAIService = serviceNoneText;
+
+            // 使用存储值判断，而不是 getter 返回的本地化文本
+            var storedService = _repo.Settings.PreferredOpenAIService;
+            var models = GetModelsForService(storedService);
+            if (models.Count > 0)
+                models.Insert(0, modelNoneText);
+
+            AvailableAIModels = models;
+            IsModelSelectorEnabled = models.Count > 0;
+
+            if (!AvailableAIModels.Contains(PreferredAIModel))
+                PreferredAIModel = modelNoneText;
 
             _cached = new Commands.Config(repo.FullPath).ReadAll();
             if (_cached.TryGetValue("user.name", out var name))
@@ -347,9 +426,24 @@ namespace SourceGit.ViewModels
             }
         }
 
+        private List<string> GetModelsForService(string serviceName)
+        {
+            if (string.IsNullOrEmpty(serviceName))
+                return [];
+
+            foreach (var service in Preferences.Instance.OpenAIServices)
+            {
+                if (service.Name == serviceName)
+                    return new List<string>(service.AvailableModels);
+            }
+            return [];
+        }
+
         private readonly Repository _repo;
         private readonly Dictionary<string, string> _cached;
         private string _httpProxy;
+        private bool _isModelSelectorEnabled;
+        private List<string> _availableAIModels = [];
         private Models.CommitTemplate _selectedCommitTemplate = null;
         private Models.IssueTracker _selectedIssueTracker = null;
         private Models.CustomAction _selectedCustomAction = null;

--- a/src/Views/AIAssistant.axaml.cs
+++ b/src/Views/AIAssistant.axaml.cs
@@ -110,6 +110,8 @@ namespace SourceGit.Views
             apply.Click += (_, ev) =>
             {
                 vm.Use(selected);
+                if (TopLevel.GetTopLevel(this) is Window window)
+                    window.Close();
                 ev.Handled = true;
             };
 
@@ -166,7 +168,10 @@ namespace SourceGit.Views
         private void OnUseClicked(object sender, RoutedEventArgs e)
         {
             if (DataContext is ViewModels.AIAssistant vm && !string.IsNullOrEmpty(vm.Response))
+            {
                 vm.Use(vm.Response);
+                Close();
+            }
 
             e.Handled = true;
         }

--- a/src/Views/CommitMessageToolBox.axaml
+++ b/src/Views/CommitMessageToolBox.axaml
@@ -106,7 +106,7 @@
                   Classes="icon_button"
                   Width="28"
                   Margin="0,0,4,0" Padding="0"
-                  Click="OnOpenOpenAIHelper"
+                  Click="OnOpenAIHelper"
                   IsVisible="{Binding #ThisControl.ShowAdvancedOptions}"
                   ToolTip.Tip="{DynamicResource Text.AIAssistant.Tip}">
             <Path Width="13" Height="13" Data="{StaticResource Icons.AIAssist}"/>

--- a/src/Views/CommitMessageToolBox.axaml.cs
+++ b/src/Views/CommitMessageToolBox.axaml.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
+using System.Linq;
 using System.Text;
 
 using Avalonia;
@@ -649,7 +650,7 @@ namespace SourceGit.Views
             e.Handled = true;
         }
 
-        private void OnOpenOpenAIHelper(object sender, RoutedEventArgs e)
+        private void OnOpenAIHelper(object sender, RoutedEventArgs e)
         {
             if (DataContext is ViewModels.WorkingCopy vm && sender is Button button && _showAdvancedOptions)
             {
@@ -662,43 +663,59 @@ namespace SourceGit.Views
                     return;
                 }
 
-                var services = repo.GetPreferredOpenAIServices();
-                if (services.Count == 0)
+                var resolved = repo.ResolveAIService();
+                if (resolved != null)
                 {
-                    repo.SendNotification("Bad configuration for OpenAI", true);
-                    e.Handled = true;
-                    return;
+                    DoOpenAIAssistant(repo, resolved, vm.Staged);
                 }
-
-                if (services.Count == 1)
+                else
                 {
-                    DoOpenAIAssistant(repo, services[0], vm.Staged);
-                    e.Handled = true;
-                    return;
-                }
-
-                var menu = new ContextMenu();
-                foreach (var service in services)
-                {
-                    var dup = service;
-                    var item = new MenuItem();
-                    item.Header = service.Name;
-                    item.Click += (_, ev) =>
+                    var allServices = repo.GetAllOpenAIServices();
+                    if (allServices.Count == 0)
                     {
-                        DoOpenAIAssistant(repo, dup, vm.Staged);
-                        ev.Handled = true;
-                    };
-
-                    menu.Items.Add(item);
+                        repo.SendNotification("Bad configuration for AI", true);
+                    }
+                    else
+                    {
+                        ShowOpenAIServicesMenu(repo, allServices, vm.Staged, button);
+                    }
                 }
-
-                button.IsEnabled = false;
-                menu.Placement = PlacementMode.TopEdgeAlignedLeft;
-                menu.Closed += (_, _) => button.IsEnabled = true;
-                menu.Open(button);
             }
 
             e.Handled = true;
+        }
+
+        private void ShowOpenAIServicesMenu(ViewModels.Repository repo, List<AI.Service> services, List<Models.Change> changes, Button button)
+        {
+            var menu = new ContextMenu();
+            foreach (var service in services)
+            {
+                var item = new MenuItem();
+                item.Header = service.Name;
+
+                foreach (var model in service.AvailableModels)
+                {
+                    var dup = service;
+                    var dupModel = model;
+                    var modelItem = new MenuItem();
+                    modelItem.Header = dupModel;
+                    modelItem.Click += (_, ev) =>
+                    {
+                        var cloned = dup.Clone();
+                        cloned.Model = dupModel;
+                        DoOpenAIAssistant(repo, cloned, changes);
+                        ev.Handled = true;
+                    };
+                    item.Items.Add(modelItem);
+                }
+
+                menu.Items.Add(item);
+            }
+
+            button.IsEnabled = false;
+            menu.Placement = PlacementMode.TopEdgeAlignedLeft;
+            menu.Closed += (_, _) => button.IsEnabled = true;
+            menu.Open(button);
         }
 
         private void OnOpenConventionalCommitHelper(object _, RoutedEventArgs e)

--- a/src/Views/FetchAIModels.axaml
+++ b/src/Views/FetchAIModels.axaml
@@ -1,0 +1,92 @@
+<v:ChromelessWindow xmlns="https://github.com/avaloniaui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+                    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+                    xmlns:v="using:SourceGit.Views"
+                    mc:Ignorable="d" d:DesignWidth="400" d:DesignHeight="500"
+                    x:Class="SourceGit.Views.FetchAIModels"
+                    x:Name="ThisControl"
+                    Icon="/App.ico"
+                    Title="{DynamicResource Text.Preferences.AI.Model.SelectModels}"
+                    Width="400" Height="500"
+                    CanResize="True"
+                    WindowStartupLocation="CenterOwner">
+  <Grid RowDefinitions="Auto,*,Auto,Auto">
+    <!-- TitleBar -->
+    <Grid Grid.Row="0" Height="28" IsVisible="{Binding !#ThisControl.UseSystemWindowFrame}">
+      <Border Background="{DynamicResource Brush.TitleBar}"
+              BorderThickness="0,0,0,1" BorderBrush="{DynamicResource Brush.Border0}"
+              PointerPressed="BeginMoveWindow"/>
+
+      <TextBlock Classes="bold"
+                 Text="{DynamicResource Text.Preferences.AI.Model.SelectModels}"
+                 HorizontalAlignment="Center" VerticalAlignment="Center"
+                 IsHitTestVisible="False"/>
+
+      <v:CaptionButtons HorizontalAlignment="Right"
+                        IsCloseButtonOnly="True"
+                        IsVisible="{OnPlatform True, macOS=False}"/>
+    </Grid>
+
+    <!-- Loading indicator -->
+    <StackPanel Grid.Row="1"
+                x:Name="LoadingPanel"
+                Margin="16"
+                IsVisible="True"
+                Orientation="Vertical"
+                HorizontalAlignment="Center"
+                VerticalAlignment="Center">
+      <ProgressBar IsIndeterminate="True" Width="200" Height="4"/>
+      <TextBlock Margin="0,8,0,0"
+                 Text="{DynamicResource Text.Preferences.AI.Model.Fetching}"
+                 HorizontalAlignment="Center"/>
+    </StackPanel>
+
+    <!-- Model list -->
+    <Border Grid.Row="1" Margin="16,0,16,0"
+            x:Name="ModelListBorder"
+            IsVisible="False"
+            BorderThickness="1" BorderBrush="{DynamicResource Brush.Border2}"
+            Background="{DynamicResource Brush.Contents}">
+      <ListBox x:Name="ModelListBox"
+               Background="Transparent">
+        <ListBox.Styles>
+          <Style Selector="ListBoxItem">
+            <Setter Property="MinHeight" Value="0"/>
+            <Setter Property="Height" Value="28"/>
+            <Setter Property="Padding" Value="4,2"/>
+          </Style>
+        </ListBox.Styles>
+        <ListBox.ItemTemplate>
+          <DataTemplate DataType="v:FetchAIModelItem">
+            <CheckBox Content="{Binding Name}"
+                      IsChecked="{Binding IsChecked, Mode=TwoWay}"/>
+          </DataTemplate>
+        </ListBox.ItemTemplate>
+      </ListBox>
+    </Border>
+
+    <!-- Error message -->
+    <TextBlock Grid.Row="2"
+               x:Name="ErrorMessage"
+               Margin="16,0,16,0"
+               IsVisible="False"
+               TextWrapping="Wrap"
+               Foreground="{DynamicResource Brush.FG1}"/>
+
+    <!-- Buttons -->
+    <StackPanel Grid.Row="3" Margin="0,16,0,16" Orientation="Horizontal" HorizontalAlignment="Center">
+      <Button Classes="flat"
+              Width="80" Height="30"
+              Margin="4,0"
+              Content="{DynamicResource Text.Cancel}"
+              Click="OnCancel"/>
+
+      <Button Classes="flat primary"
+              Width="80" Height="30"
+              Margin="4,0"
+              Content="{DynamicResource Text.Sure}"
+              Click="OnAdd"/>
+    </StackPanel>
+  </Grid>
+</v:ChromelessWindow>

--- a/src/Views/FetchAIModels.axaml.cs
+++ b/src/Views/FetchAIModels.axaml.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Threading.Tasks;
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+
+namespace SourceGit.Views
+{
+    public class FetchAIModelItem : INotifyPropertyChanged
+    {
+        public string Name { get; }
+
+        public bool IsChecked
+        {
+            get => _isChecked;
+            set
+            {
+                if (_isChecked != value)
+                {
+                    _isChecked = value;
+                    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(IsChecked)));
+                }
+            }
+        }
+
+        public FetchAIModelItem(string name, bool isChecked)
+        {
+            Name = name;
+            _isChecked = isChecked;
+        }
+
+        public event PropertyChangedEventHandler PropertyChanged;
+        private bool _isChecked;
+    }
+
+    public partial class FetchAIModels : ChromelessWindow
+    {
+        public List<string> SelectedModels { get; private set; } = [];
+
+        public List<string> ServerModels { get; private set; } = [];
+
+        public FetchAIModels()
+        {
+            InitializeComponent();
+        }
+
+        public async void LoadModels(AI.Service service)
+        {
+            try
+            {
+                var models = await Task.Run(() => service.FetchModelsFromServer());
+                var existing = new HashSet<string>(service.AvailableModels);
+                ServerModels = models;
+
+                var items = new List<FetchAIModelItem>();
+                foreach (var model in models)
+                    items.Add(new FetchAIModelItem(model, existing.Contains(model)));
+
+                ModelListBox.ItemsSource = items;
+
+                LoadingPanel.IsVisible = false;
+                ModelListBorder.IsVisible = true;
+            }
+            catch (Exception ex)
+            {
+                LoadingPanel.IsVisible = false;
+                ErrorMessage.Text = ex.Message;
+                ErrorMessage.IsVisible = true;
+            }
+        }
+
+        private void OnAdd(object _1, RoutedEventArgs _2)
+        {
+            SelectedModels = [];
+            if (ModelListBox.ItemsSource is IEnumerable<FetchAIModelItem> items)
+            {
+                foreach (var item in items)
+                {
+                    if (item.IsChecked)
+                        SelectedModels.Add(item.Name);
+                }
+            }
+            Close(true);
+        }
+
+        private void OnCancel(object _1, RoutedEventArgs _2)
+        {
+            Close(false);
+        }
+    }
+}

--- a/src/Views/Preferences.axaml
+++ b/src/Views/Preferences.axaml
@@ -838,8 +838,12 @@
             <Border Grid.Column="0"
                     BorderThickness="1" BorderBrush="{DynamicResource Brush.Border2}"
                     Background="{DynamicResource Brush.Contents}">
-              <Grid RowDefinitions="*,1,Auto">
-                <ListBox Grid.Row="0"
+              <Grid RowDefinitions="Auto,*,1,Auto">
+                <TextBlock Grid.Row="0"
+                           Text="{DynamicResource Text.Preferences.AI.Services}"
+                           FontSize="12" FontWeight="SemiBold"
+                           Margin="8,4,0,4"/>
+                <ListBox Grid.Row="1"
                          Background="Transparent"
                          ItemsSource="{Binding OpenAIServices}"
                          SelectedItem="{Binding #ThisControl.SelectedOpenAIService, Mode=TwoWay}"
@@ -868,9 +872,9 @@
                   </ListBox.ItemTemplate>
                 </ListBox>
 
-                <Rectangle Grid.Row="1" Height="1" Fill="{DynamicResource Brush.Border2}" HorizontalAlignment="Stretch" VerticalAlignment="Bottom"/>
+                <Rectangle Grid.Row="2" Height="1" Fill="{DynamicResource Brush.Border2}" HorizontalAlignment="Stretch" VerticalAlignment="Bottom"/>
 
-                <StackPanel Grid.Row="2" Orientation="Horizontal" Background="{DynamicResource Brush.ToolBar}">
+                <StackPanel Grid.Row="3" Orientation="Horizontal" Background="{DynamicResource Brush.ToolBar}">
                   <Button Classes="icon_button" Click="OnAddOpenAIService">
                     <Path Width="14" Height="14" Data="{StaticResource Icons.Plus}"/>
                   </Button>
@@ -897,7 +901,8 @@
 
               <ContentControl.DataTemplates>
                 <DataTemplate DataType="ai:Service">
-                  <StackPanel Orientation="Vertical" MaxWidth="680">
+                  <ScrollViewer MaxHeight="500" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
+                    <StackPanel Orientation="Vertical" MaxWidth="680">
                     <TextBlock Text="{DynamicResource Text.Preferences.AI.Name}"/>
                     <TextBox Margin="0,4,0,0" CornerRadius="3" Height="28" Text="{Binding Name, Mode=TwoWay}"/>
 
@@ -912,25 +917,82 @@
                               IsChecked="{Binding ReadApiKeyFromEnv, Mode=TwoWay}"/>
 
                     <TextBlock Margin="0,8,0,0" Text="{DynamicResource Text.Preferences.AI.Model}"/>
-                    <TextBox Margin="0,4,0,0"
-                             CornerRadius="3"
-                             Height="28"
-                             Text="{Binding Model, Mode=TwoWay}"
-                             IsEnabled="{Binding !AutoFetchAvailableModels, Mode=OneWay}"/>
-                    <CheckBox Margin="0,4,0,0"
-                              Height="28"
-                              Content="{DynamicResource Text.Preferences.AI.Model.AutoFetchAvailableModels}"
-                              IsChecked="{Binding AutoFetchAvailableModels, Mode=TwoWay}"/>
+                    <Border Margin="0,4,0,0"
+                            BorderThickness="1" BorderBrush="{DynamicResource Brush.Border2}"
+                            Background="{DynamicResource Brush.Contents}"
+                            MinHeight="80">
+                      <ListBox x:Name="AIModelListBox"
+                               Background="Transparent"
+                               ScrollViewer.VerticalScrollBarVisibility="Auto"
+                               ItemsSource="{Binding AvailableModels}"
+                               SelectedValue="{Binding Model, Mode=TwoWay}"
+                               SelectedValueBinding="{Binding}"
+                               SelectionMode="Single">
+                        <ListBox.Styles>
+                          <Style Selector="ListBoxItem">
+                            <Setter Property="MinHeight" Value="0"/>
+                            <Setter Property="Height" Value="26"/>
+                            <Setter Property="Padding" Value="4,2"/>
+                          </Style>
+                        </ListBox.Styles>
+                        <ListBox.ItemTemplate>
+                          <DataTemplate>
+                            <Grid ColumnDefinitions="*,Auto,Auto">
+                              <TextBlock Grid.Column="0" Text="{Binding}" VerticalAlignment="Center" TextTrimming="CharacterEllipsis"/>
+                              <Button Grid.Column="1"
+                                      Classes="icon_button"
+                                      Tag="{Binding}"
+                                      Click="OnEditAIModelInList">
+                                <Path Width="8" Height="8" Data="{StaticResource Icons.Edit}"/>
+                              </Button>
+                              <Button Grid.Column="2"
+                                      Classes="icon_button"
+                                      Tag="{Binding}"
+                                      Click="OnRemoveAIModelInList">
+                                <Path Width="8" Height="8" Data="{StaticResource Icons.Close}"/>
+                              </Button>
+                            </Grid>
+                          </DataTemplate>
+                        </ListBox.ItemTemplate>
+                      </ListBox>
+                    </Border>
+                    <Border Margin="0,4,0,0"
+                            BorderThickness="1" BorderBrush="{DynamicResource Brush.Border2}"
+                            CornerRadius="3"
+                            HorizontalAlignment="Left"
+                            Background="{DynamicResource Brush.Contents}">
+                      <Grid ColumnDefinitions="Auto,Auto,Auto">
+                        <Button Grid.Column="0"
+                                BorderThickness="0"
+                                Background="Transparent"
+                                HorizontalAlignment="Stretch"
+                                HorizontalContentAlignment="Left"
+                                Click="OnFetchAIModels">
+                          <StackPanel Orientation="Horizontal">
+                            <Path Width="12" Height="12" Data="{StaticResource Icons.Fetch}" Margin="0,0,6,0"/>
+                            <TextBlock Text="{DynamicResource Text.Preferences.AI.Model.FetchModels}"/>
+                          </StackPanel>
+                        </Button>
+                        <Rectangle Grid.Column="1" Width="1" Fill="{DynamicResource Brush.Border2}" Margin="0,4"/>
+                        <Button Grid.Column="2"
+                                Classes="icon_button"
+                                Click="OnAddAIModel"
+                                ToolTip.Tip="{DynamicResource Text.Preferences.AI.Model.AddModel}">
+                          <Path Width="14" Height="14" Data="{StaticResource Icons.Plus}"/>
+                        </Button>
+                      </Grid>
+                    </Border>
 
                     <TextBlock Margin="0,12,0,0" Text="{DynamicResource Text.Preferences.AI.AdditionalPrompt}"/>
-                    <TextBox Height="120"
+                    <TextBox MinHeight="60"
                              Margin="0,4,0,0"
                              CornerRadius="3"
                              VerticalContentAlignment="Top"
                              Text="{Binding AdditionalPrompt, Mode=TwoWay}"
                              AcceptsReturn="true"
-                             TextWrapping="Wrap"/>
-                  </StackPanel>
+                              TextWrapping="Wrap"/>
+                    </StackPanel>
+                  </ScrollViewer>
                 </DataTemplate>
               </ContentControl.DataTemplates>
             </ContentControl>

--- a/src/Views/Preferences.axaml.cs
+++ b/src/Views/Preferences.axaml.cs
@@ -222,7 +222,6 @@ namespace SourceGit.Views
             }
 
             var preferences = ViewModels.Preferences.Instance;
-            preferences.UpdateAvailableAIModels();
             preferences.Save();
         }
 
@@ -435,6 +434,108 @@ namespace SourceGit.Views
 
             ViewModels.Preferences.Instance.OpenAIServices.Remove(SelectedOpenAIService);
             SelectedOpenAIService = null;
+            e.Handled = true;
+        }
+
+        private async void OnFetchAIModels(object sender, RoutedEventArgs e)
+        {
+            if (SelectedOpenAIService == null)
+                return;
+
+            var dialog = new FetchAIModels();
+            dialog.LoadModels(SelectedOpenAIService);
+            await this.ShowDialogAsync(dialog);
+
+            var serverSet = new HashSet<string>(dialog.ServerModels);
+            var customModels = new List<string>();
+            foreach (var model in SelectedOpenAIService.AvailableModels)
+            {
+                if (!serverSet.Contains(model))
+                    customModels.Add(model);
+            }
+
+            var newList = new List<string>(dialog.SelectedModels);
+            foreach (var model in customModels)
+            {
+                if (!newList.Contains(model))
+                    newList.Add(model);
+            }
+
+            SelectedOpenAIService.AvailableModels = newList;
+
+            if (string.IsNullOrEmpty(SelectedOpenAIService.Model) && SelectedOpenAIService.AvailableModels.Count > 0)
+                SelectedOpenAIService.Model = SelectedOpenAIService.AvailableModels[0];
+
+            e.Handled = true;
+        }
+
+        private async void OnAddAIModel(object sender, RoutedEventArgs e)
+        {
+            if (SelectedOpenAIService == null)
+                return;
+
+            var dialog = new TextInput();
+            dialog.SetData(App.Text("Preferences.AI.Model.AddModel"));
+            await this.ShowDialogAsync(dialog);
+
+            if (dialog.Value != null && !string.IsNullOrWhiteSpace(dialog.Value))
+            {
+                var model = dialog.Value.Trim();
+                SelectedOpenAIService.AddModel(model);
+
+                if (string.IsNullOrEmpty(SelectedOpenAIService.Model))
+                    SelectedOpenAIService.Model = model;
+            }
+
+            e.Handled = true;
+        }
+
+        private void OnRemoveAIModelInList(object sender, RoutedEventArgs e)
+        {
+            if (SelectedOpenAIService == null)
+                return;
+
+            if (sender is Button btn && btn.Tag is string model)
+            {
+                SelectedOpenAIService.RemoveModel(model);
+
+                if (SelectedOpenAIService.Model == model)
+                {
+                    if (SelectedOpenAIService.AvailableModels.Count > 0)
+                        SelectedOpenAIService.Model = SelectedOpenAIService.AvailableModels[0];
+                    else
+                        SelectedOpenAIService.Model = string.Empty;
+                }
+            }
+
+            e.Handled = true;
+        }
+
+        private async void OnEditAIModelInList(object sender, RoutedEventArgs e)
+        {
+            if (SelectedOpenAIService == null)
+                return;
+
+            if (sender is Button btn && btn.Tag is string oldModel)
+            {
+                var dialog = new TextInput();
+                dialog.SetData(App.Text("Preferences.AI.Model.AddModel"), oldModel);
+                await this.ShowDialogAsync(dialog);
+
+                if (dialog.Value != null && !string.IsNullOrWhiteSpace(dialog.Value))
+                {
+                    var newModel = dialog.Value.Trim();
+                    if (newModel != oldModel)
+                    {
+                        SelectedOpenAIService.RemoveModel(oldModel);
+                        SelectedOpenAIService.AddModel(newModel);
+
+                        if (SelectedOpenAIService.Model == oldModel)
+                            SelectedOpenAIService.Model = newModel;
+                    }
+                }
+            }
+
             e.Handled = true;
         }
 

--- a/src/Views/RepositoryConfigure.axaml
+++ b/src/Views/RepositoryConfigure.axaml
@@ -519,14 +519,14 @@
 
       <TabItem>
         <TabItem.Header>
-          <TextBlock Classes="tab_header" Text="{DynamicResource Text.Configure.OpenAI}"/>
+          <TextBlock Classes="tab_header" Text="{DynamicResource Text.Configure.AI}"/>
         </TabItem.Header>
 
-        <Grid Margin="16,4,16,8" RowDefinitions="32,Auto" ColumnDefinitions="Auto,*">
+        <Grid Margin="16,4,16,8" RowDefinitions="32,32,Auto" ColumnDefinitions="Auto,*">
           <TextBlock Grid.Row="0" Grid.Column="0"
                      HorizontalAlignment="Right" VerticalAlignment="Center"
                      Margin="0,0,8,0"
-                     Text="{DynamicResource Text.Configure.OpenAI.Preferred}"/>
+                      Text="{DynamicResource Text.Configure.AI.DefaultService}"/>
           <ComboBox Grid.Row="0" Grid.Column="1"
                     Height="28" Padding="8,0"
                     VerticalAlignment="Center" HorizontalAlignment="Stretch"
@@ -542,9 +542,20 @@
             </ComboBox.ItemTemplate>
           </ComboBox>
 
-          <TextBlock Grid.Row="1" Grid.Column="1"
+          <TextBlock Grid.Row="1" Grid.Column="0"
+                     HorizontalAlignment="Right" VerticalAlignment="Center"
+                     Margin="0,0,8,0"
+                     Text="{DynamicResource Text.Configure.AI.PreferredModel}"/>
+          <ComboBox Grid.Row="1" Grid.Column="1"
+                    Height="28" Padding="8,0"
+                    VerticalAlignment="Center" HorizontalAlignment="Stretch"
+                    IsEnabled="{Binding IsModelSelectorEnabled}"
+                    ItemsSource="{Binding AvailableAIModels}"
+                    SelectedItem="{Binding PreferredAIModel, Mode=TwoWay}"/>
+
+          <TextBlock Grid.Row="2" Grid.Column="1"
                      Margin="0,6,0,0"
-                     Text="{DynamicResource Text.Configure.OpenAI.Preferred.Tip}"
+                      Text="{DynamicResource Text.Configure.AI.DefaultService.Tip}"
                      TextWrapping="Wrap"
                      Foreground="{DynamicResource Brush.FG2}"/>
         </Grid>

--- a/src/Views/TextInput.axaml
+++ b/src/Views/TextInput.axaml
@@ -1,0 +1,55 @@
+<v:ChromelessWindow xmlns="https://github.com/avaloniaui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+                    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+                    xmlns:v="using:SourceGit.Views"
+                    mc:Ignorable="d" d:DesignWidth="400" d:DesignHeight="160"
+                    x:Class="SourceGit.Views.TextInput"
+                    x:Name="ThisControl"
+                    Icon="/App.ico"
+                    Width="400"
+                    SizeToContent="Height"
+                    CanResize="False"
+                    WindowStartupLocation="CenterOwner">
+  <Grid RowDefinitions="Auto,Auto,Auto">
+    <!-- TitleBar -->
+    <Grid Grid.Row="0" Height="28" IsVisible="{Binding !#ThisControl.UseSystemWindowFrame}">
+      <Border Background="{DynamicResource Brush.TitleBar}"
+              BorderThickness="0,0,0,1" BorderBrush="{DynamicResource Brush.Border0}"
+              PointerPressed="BeginMoveWindow"/>
+
+      <TextBlock x:Name="TxtTitle"
+                 Classes="bold"
+                 HorizontalAlignment="Center" VerticalAlignment="Center"
+                 IsHitTestVisible="False"/>
+
+      <v:CaptionButtons HorizontalAlignment="Right"
+                        IsCloseButtonOnly="True"
+                        IsVisible="{OnPlatform True, macOS=False}"/>
+    </Grid>
+
+    <!-- Input -->
+    <TextBox x:Name="TxtInput"
+             Grid.Row="1"
+             Margin="16,12,16,0"
+             Height="32"
+             CornerRadius="3"
+             Focusable="True"/>
+
+    <!-- Buttons -->
+    <StackPanel Grid.Row="2" Margin="0,12,0,16" Orientation="Horizontal" HorizontalAlignment="Center">
+      <Button Classes="flat"
+              Width="80" Height="30"
+              Margin="4,0"
+              Content="{DynamicResource Text.Cancel}"
+              Click="OnCancel"/>
+
+      <Button Classes="flat primary"
+              Width="80" Height="30"
+              Margin="4,0"
+              Content="{DynamicResource Text.Sure}"
+              Click="OnOk"
+              HotKey="Enter"/>
+    </StackPanel>
+  </Grid>
+</v:ChromelessWindow>

--- a/src/Views/TextInput.axaml.cs
+++ b/src/Views/TextInput.axaml.cs
@@ -1,0 +1,39 @@
+using Avalonia.Input;
+using Avalonia.Interactivity;
+
+namespace SourceGit.Views
+{
+    public partial class TextInput : ChromelessWindow
+    {
+        public string Value { get; private set; }
+
+        public TextInput()
+        {
+            InitializeComponent();
+        }
+
+        public void SetData(string title, string defaultValue = "")
+        {
+            TxtTitle.Text = title;
+            TxtInput.Text = defaultValue;
+        }
+
+        protected override void OnLoaded(RoutedEventArgs e)
+        {
+            base.OnLoaded(e);
+            TxtInput.Focus(NavigationMethod.Directional);
+        }
+
+        private void OnOk(object _1, RoutedEventArgs _2)
+        {
+            Value = TxtInput.Text;
+            Close(true);
+        }
+
+        private void OnCancel(object _1, RoutedEventArgs _2)
+        {
+            Value = null;
+            Close(false);
+        }
+    }
+}

--- a/src/Views/WorkingCopy.axaml.cs
+++ b/src/Views/WorkingCopy.axaml.cs
@@ -1,6 +1,7 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 
 using Avalonia.Controls;
 using Avalonia.Input;
@@ -933,35 +934,46 @@ namespace SourceGit.Views
             var menu = new ContextMenu();
 
             MenuItem ai = null;
-            var services = repo.GetPreferredOpenAIServices();
-            if (services.Count > 0)
+            var allServices = repo.GetAllOpenAIServices();
+            if (allServices.Count > 0)
             {
                 ai = new MenuItem();
                 ai.Icon = this.CreateMenuIcon("Icons.AIAssist");
                 ai.Header = App.Text("ChangeCM.GenerateCommitMessage");
 
-                if (services.Count == 1)
+                var resolved = repo.ResolveAIService();
+                if (resolved != null)
                 {
                     ai.Click += (_, e) =>
                     {
-                        DoOpenAIAssistant(repo, services[0], selectedStaged);
+                        DoOpenAIAssistant(repo, resolved, selectedStaged);
                         e.Handled = true;
                     };
                 }
                 else
                 {
-                    foreach (var service in services)
+                    foreach (var svc in allServices)
                     {
-                        var dup = service;
-
                         var item = new MenuItem();
-                        item.Header = service.Name;
-                        item.Click += (_, e) =>
-                        {
-                            DoOpenAIAssistant(repo, dup, selectedStaged);
-                            e.Handled = true;
-                        };
+                        item.Header = svc.Name;
 
+                        var modelMenu = new ContextMenu();
+                        foreach (var m in svc.AvailableModels)
+                        {
+                            var dup = svc;
+                            var dupModel = m;
+                            var modelItem = new MenuItem();
+                            modelItem.Header = dupModel;
+                            modelItem.Click += (_, e) =>
+                            {
+                                var cloned = dup.Clone();
+                                cloned.Model = dupModel;
+                                DoOpenAIAssistant(repo, cloned, selectedStaged);
+                                e.Handled = true;
+                            };
+                            modelMenu.Items.Add(modelItem);
+                        }
+                        item.Items.Add(modelMenu);
                         ai.Items.Add(item);
                     }
                 }


### PR DESCRIPTION
**Overview**
This PR completely refactors the AI service configuration flow, replacing the previous uncontrollable auto-fetching mechanism with a more flexible manual model management system. Users can now fetch the model list with one click and select the desired models to add. Additionally, this PR introduces the ability to set default models per repository and optimizes the overall user experience for AI service/model selection.

---

**Key Changes**

**1. Core AI Service Refactoring (`AI.Service`)**
- Removed the `AutoFetchAvailableModels` flag and replaced it with an explicit `AvailableModels` list
- Added `AddModel`, `RemoveModel`, `FetchModelsFromServer`, and `Clone` methods for complete model lifecycle management
- Removed `JsonSerialization.JsonIgnore` from `AvailableModels` and updated Service model binding

**2. Repository-Specific Default Models**
- Added a `PreferredAIModel` field to `RepositorySettings`, allowing each repository to independently specify its default model

**3. Repository Service Resolution Refactoring (`Repository.cs`)**
- Split `GetPreferredOpenAIServices()` into three more granular methods:
  - `GetAllOpenAIServices()` – retrieves all available services
  - `GetOpenAIConfig()` – retrieves service configuration
  - `ResolveAIService()` – unified entry point for service/model resolution

**4. UI/UX Improvements**
- **Repository Configuration Screen**: Added a model dropdown next to the service selector, with the model list dynamically updating based on the selected service
- **Preferences AI Panel**: Replaced the text input + auto-fetch checkbox with a list-based model management interface (supports add, delete, edit, and fetch from server)
- **Context Menus** (`CommitMessageToolBox`, `WorkingCopy`): When no preferred service is configured, display a nested service→model menu

**5. New Dialogs**
- `FetchAIModels` dialog: fetches the model list from the AI server with a loading indicator and checkbox-based selection
- `TextInput` dialog: a reusable simple text input dialog

**6. Localization**
- Renamed locale keys from `Text.Configure.OpenAI*` to `Text.Configure.AI*`
- Added new keys for default service/model selection and model management UI
- Updated all **16** language files: en_US, zh_CN, zh_TW, de_DE, el_GR, es_ES, fr_FR, he_IL, id_ID, it_IT, ja_JP, ko_KR, pt_BR, ru_RU, ta_IN, uk_UA

**7. Miscellaneous**
- Removed the logic that automatically fetched the model list on application startup (`UpdateAvailableAIModels` is now a no-op)
- The AI assistant window now automatically closes after a commit message is submitted

---

**Breaking Changes**
- Removed the legacy `AutoFetchAvailableModels` flag. Existing configurations will need to manually fetch/populate the model list through the new UI.

Closes #2508 