### PR TITLE
fix: use WindowState.Maximized-like layout for linux splitscreen mode

### DIFF
--- a/src/Native/Linux.cs
+++ b/src/Native/Linux.cs
@@ -171,4 +171,58 @@ namespace SourceGit.Native
             return File.Exists(local) ? local : string.Empty;
         }
     }
+
+    [SupportedOSPlatform("linux")]
+    public static class LinuxUtilities
+    {
+        public const string TiledFrameClass = "window_frame_tiled";
+
+        private const int EdgeTolerance = 2;
+
+        public static void UpdateCustomWindowFrameStyle(Window window)
+        {
+            if (OS.UseSystemWindowFrame || !window.Classes.Contains("custom_window_frame"))
+                return;
+
+            var tiled = IsWindowTiledOrSnapped(window);
+            if (tiled)
+            {
+                if (!window.Classes.Contains(TiledFrameClass))
+                    window.Classes.Add(TiledFrameClass);
+            }
+            else if (window.Classes.Contains(TiledFrameClass))
+            {
+                window.Classes.Remove(TiledFrameClass);
+            }
+        }
+
+        private static bool IsWindowTiledOrSnapped(Window window)
+        {
+            if (window.WindowState is WindowState.Maximized or WindowState.FullScreen)
+                return false;
+
+            if (window.Screens is not { } screens)
+                return false;
+
+            var screen = screens.ScreenFromWindow(window);
+            if (screen == null)
+                return false;
+
+            var workArea = screen.WorkingArea;
+            var size = PixelSize.FromSize(new Size(window.Width, window.Height), window.DesktopScaling);
+            var frame = new PixelRect(window.Position, size);
+
+            var edgeCount = 0;
+            if (Math.Abs(frame.X - workArea.X) <= EdgeTolerance)
+                edgeCount++;
+            if (Math.Abs(frame.Right - workArea.Right) <= EdgeTolerance)
+                edgeCount++;
+            if (Math.Abs(frame.Y - workArea.Y) <= EdgeTolerance)
+                edgeCount++;
+            if (Math.Abs(frame.Bottom - workArea.Bottom) <= EdgeTolerance)
+                edgeCount++;
+
+            return edgeCount >= 2;
+        }
+    }
 }

--- a/src/Resources/Styles.axaml
+++ b/src/Resources/Styles.axaml
@@ -126,7 +126,7 @@
                   Cursor="BottomRightCorner"
                   Tag="{x:Static WindowEdge.SouthEast}"/>
 
-          <Grid Margin="{TemplateBinding Padding}" Effect="drop-shadow(0 0 12 #60000000)">
+          <Grid x:Name="PART_ContentHost" Margin="{TemplateBinding Padding}" Effect="drop-shadow(0 0 12 #60000000)">
             <Border x:Name="PART_ContentRoot"
                     Background="{DynamicResource Brush.Window}"
                     BorderBrush="{DynamicResource Brush.WindowBorder}"
@@ -155,7 +155,15 @@
     </Setter>
   </Style>
 
-  <Style Selector="Window.custom_window_frame[WindowState=Maximized]">
+  <Style Selector="Window.custom_window_frame.window_frame_tiled /template/ Grid#PART_ContentHost">
+    <Setter Property="Effect" Value="{x:Null}"/>
+  </Style>
+
+  <Style Selector="Window.custom_window_frame.window_frame_tiled /template/ Border.resize_border">
+    <Setter Property="ZIndex" Value="1"/>
+  </Style>
+
+  <Style Selector="Window.custom_window_frame[WindowState=Maximized], Window.custom_window_frame.window_frame_tiled">
     <Setter Property="Padding" Value="0"/>
     <Setter Property="CornerRadius" Value="0"/>
   </Style>

--- a/src/Views/ChromelessWindow.cs
+++ b/src/Views/ChromelessWindow.cs
@@ -26,6 +26,11 @@ namespace SourceGit.Views
         {
             Focusable = true;
             Native.OS.SetupForWindow(this);
+
+            if (OperatingSystem.IsLinux() && !UseSystemWindowFrame)
+            {
+                PositionChanged += (_, _) => Native.LinuxUtilities.UpdateCustomWindowFrameStyle(this);
+            }
         }
 
         public void BeginMoveWindow(object _, PointerPressedEventArgs e)
@@ -81,6 +86,16 @@ namespace SourceGit.Views
 
             if (OperatingSystem.IsWindows())
                 Native.Win64Utilities.FixWindowFrame(this);
+            else if (OperatingSystem.IsLinux())
+                Native.LinuxUtilities.UpdateCustomWindowFrameStyle(this);
+        }
+
+        protected override void OnSizeChanged(SizeChangedEventArgs e)
+        {
+            base.OnSizeChanged(e);
+
+            if (OperatingSystem.IsLinux())
+                Native.LinuxUtilities.UpdateCustomWindowFrameStyle(this);
         }
 
         protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
@@ -89,6 +104,15 @@ namespace SourceGit.Views
 
             if (OperatingSystem.IsWindows() && change.Property == WindowStateProperty)
                 Native.Win64Utilities.FixWindowFrame(this);
+            else if (OperatingSystem.IsLinux() &&
+                     Classes.Contains("custom_window_frame") &&
+                     (change.Property == WindowStateProperty ||
+                      change.Property == BoundsProperty ||
+                      change.Property == WidthProperty ||
+                      change.Property == HeightProperty))
+            {
+                Native.LinuxUtilities.UpdateCustomWindowFrameStyle(this);
+            }
         }
 
         protected override void OnKeyDown(KeyEventArgs e)


### PR DESCRIPTION
In splitscreen mode, the window acts like `WindowState.Normal`, which adds 12px of outer padding to the window.
<img width="440" height="400" alt="screenshot" src="https://github.com/user-attachments/assets/2c65eec8-4eb3-4355-b7c5-0053d922ed1e" />
However, this mode should behave like  `WindowState.Maximized`, but without removing of a border and resize-zones.
<img width="440" height="400" alt="screenshot" src="https://github.com/user-attachments/assets/d9e4622c-abc7-4752-929b-840f7503e1c5" />
