### PR TITLE
Add day-of-week and localized-date display options

### DIFF
--- a/src/App.axaml.cs
+++ b/src/App.axaml.cs
@@ -239,6 +239,7 @@ namespace SourceGit
 
             var pref = ViewModels.Preferences.Instance;
             SetLocale(pref.Locale);
+            Models.DateTimeFormat.UseCulture(pref.Locale);
             SetTheme(pref.Theme, pref.ThemeOverrides);
             SetFonts(pref.DefaultFontFamily, pref.MonospaceFontFamily);
         }

--- a/src/Models/DateTimeFormat.cs
+++ b/src/Models/DateTimeFormat.cs
@@ -33,6 +33,18 @@ namespace SourceGit.Models
             set;
         } = true;
 
+        public static int DayOfWeekStyle
+        {
+            get;
+            set;
+        } = 0;
+
+        public static bool UseLocalizedCulture
+        {
+            get;
+            set;
+        } = true;
+
         public string DateFormat
         {
             get;
@@ -40,14 +52,43 @@ namespace SourceGit.Models
 
         public string Example
         {
-            get => DateTime.Now.ToString(DateFormat, _culture);
+            get => DateTime.Now.ToString(DateFormat, ActiveCulture);
         }
 
-        private static readonly CultureInfo _culture = CreateCulture();
+        // Raised when the formatting culture changes at runtime (e.g. the app language
+        // was switched). Views that render dates in code subscribe to refresh themselves,
+        // since such a change is invisible to their bound properties.
+        public static event Action Changed;
 
-        private static CultureInfo CreateCulture()
+        private static CultureInfo ActiveCulture => UseLocalizedCulture ? _localizedCulture : _invariantCulture;
+
+        private static CultureInfo _localizedCulture = CreateCulture(CultureInfo.CurrentCulture);
+        private static readonly CultureInfo _invariantCulture = CreateCulture(CultureInfo.InvariantCulture);
+
+        // Ties the localized day/month names to the application's selected language
+        // (e.g. locale key "el_GR"), instead of the operating-system culture.
+        public static void UseCulture(string localeKey)
         {
-            var culture = (CultureInfo)CultureInfo.CurrentCulture.Clone();
+            var baseCulture = CultureInfo.CurrentCulture;
+            if (!string.IsNullOrEmpty(localeKey))
+            {
+                try
+                {
+                    baseCulture = CultureInfo.GetCultureInfo(localeKey.Replace('_', '-'));
+                }
+                catch (CultureNotFoundException)
+                {
+                    // fall back to the operating-system culture
+                }
+            }
+
+            _localizedCulture = CreateCulture(baseCulture);
+            Changed?.Invoke();
+        }
+
+        private static CultureInfo CreateCulture(CultureInfo baseCulture)
+        {
+            var culture = (CultureInfo)baseCulture.Clone();
             culture.DateTimeFormat.DateSeparator = "/";
             culture.DateTimeFormat.TimeSeparator = ":";
             return culture;
@@ -67,11 +108,18 @@ namespace SourceGit.Models
         public static string Format(DateTime localTime, bool dateOnly = false)
         {
             var actived = Supported[ActiveIndex];
-            if (dateOnly)
-                return localTime.ToString(actived.DateFormat, _culture);
+            var dateFormat = DayOfWeekStyle switch
+            {
+                1 => $"ddd {actived.DateFormat}",
+                2 => $"dddd {actived.DateFormat}",
+                _ => actived.DateFormat,
+            };
 
-            var format = Use24Hours ? $"{actived.DateFormat} HH:mm:ss" : $"{actived.DateFormat} hh:mm:ss tt";
-            return localTime.ToString(format, _culture);
+            if (dateOnly)
+                return localTime.ToString(dateFormat, ActiveCulture);
+
+            var format = Use24Hours ? $"{dateFormat} HH:mm:ss" : $"{dateFormat} hh:mm:ss tt";
+            return localTime.ToString(format, ActiveCulture);
         }
     }
 }

--- a/src/Resources/Locales/el_GR.axaml
+++ b/src/Resources/Locales/el_GR.axaml
@@ -660,8 +660,12 @@
   <x:String x:Key="Text.Preferences.General" xml:space="preserve">ΓΕΝΙΚΑ</x:String>
   <x:String x:Key="Text.Preferences.General.Check4UpdatesOnStartup" xml:space="preserve">Έλεγχος για ενημερώσεις κατά την εκκίνηση</x:String>
   <x:String x:Key="Text.Preferences.General.DateFormat" xml:space="preserve">Μορφή ημερομηνίας</x:String>
+  <x:String x:Key="Text.Preferences.General.DayOfWeek.None" xml:space="preserve">Χωρίς ημέρα</x:String>
+  <x:String x:Key="Text.Preferences.General.DayOfWeek.Short" xml:space="preserve">Σύντομη ημέρα</x:String>
+  <x:String x:Key="Text.Preferences.General.DayOfWeek.Full" xml:space="preserve">Πλήρης ημέρα</x:String>
   <x:String x:Key="Text.Preferences.General.EnableCompactFolders" xml:space="preserve">Ενεργοποίηση συμπαγών φακέλων στο δέντρο αλλαγών</x:String>
   <x:String x:Key="Text.Preferences.General.Locale" xml:space="preserve">Γλώσσα</x:String>
+  <x:String x:Key="Text.Preferences.General.LocalizedDates" xml:space="preserve">Τοπικές ημερομηνίες</x:String>
   <x:String x:Key="Text.Preferences.General.MaxHistoryCommits" xml:space="preserve">Commits ιστορικού</x:String>
   <x:String x:Key="Text.Preferences.General.ShowChangesPageByDefault" xml:space="preserve">Εμφάνιση της σελίδας `ΤΟΠΙΚΕΣ ΑΛΛΑΓΕΣ` από προεπιλογή</x:String>
   <x:String x:Key="Text.Preferences.General.ShowChangesTabInCommitDetailByDefault" xml:space="preserve">Εμφάνιση της καρτέλας `ΑΛΛΑΓΕΣ` στις λεπτομέρειες commit από προεπιλογή</x:String>

--- a/src/Resources/Locales/en_US.axaml
+++ b/src/Resources/Locales/en_US.axaml
@@ -682,8 +682,12 @@
   <x:String x:Key="Text.Preferences.General" xml:space="preserve">GENERAL</x:String>
   <x:String x:Key="Text.Preferences.General.Check4UpdatesOnStartup" xml:space="preserve">Check for updates on startup</x:String>
   <x:String x:Key="Text.Preferences.General.DateFormat" xml:space="preserve">Date Format</x:String>
+  <x:String x:Key="Text.Preferences.General.DayOfWeek.None" xml:space="preserve">No day of week</x:String>
+  <x:String x:Key="Text.Preferences.General.DayOfWeek.Short" xml:space="preserve">Short day</x:String>
+  <x:String x:Key="Text.Preferences.General.DayOfWeek.Full" xml:space="preserve">Full day</x:String>
   <x:String x:Key="Text.Preferences.General.EnableCompactFolders" xml:space="preserve">Enable compact folders in changes tree</x:String>
   <x:String x:Key="Text.Preferences.General.Locale" xml:space="preserve">Language</x:String>
+  <x:String x:Key="Text.Preferences.General.LocalizedDates" xml:space="preserve">Localized dates</x:String>
   <x:String x:Key="Text.Preferences.General.MaxHistoryCommits" xml:space="preserve">History Commits</x:String>
   <x:String x:Key="Text.Preferences.General.ShowChangesPageByDefault" xml:space="preserve">Show `LOCAL CHANGES` page by default</x:String>
   <x:String x:Key="Text.Preferences.General.ShowChangesTabInCommitDetailByDefault" xml:space="preserve">Show `CHANGES` tab in commit detail by default</x:String>

--- a/src/ViewModels/Preferences.cs
+++ b/src/ViewModels/Preferences.cs
@@ -36,8 +36,12 @@ namespace SourceGit.ViewModels
             get => _locale;
             set
             {
-                if (SetProperty(ref _locale, value) && !_isLoading)
-                    App.SetLocale(value);
+                if (SetProperty(ref _locale, value))
+                {
+                    Models.DateTimeFormat.UseCulture(value);
+                    if (!_isLoading)
+                        App.SetLocale(value);
+                }
             }
         }
 
@@ -164,6 +168,34 @@ namespace SourceGit.ViewModels
                 if (value != Models.DateTimeFormat.Use24Hours)
                 {
                     Models.DateTimeFormat.Use24Hours = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
+        public int DayOfWeekStyle
+        {
+            get => Models.DateTimeFormat.DayOfWeekStyle;
+            set
+            {
+                if (value != Models.DateTimeFormat.DayOfWeekStyle &&
+                    value >= 0 &&
+                    value <= 2)
+                {
+                    Models.DateTimeFormat.DayOfWeekStyle = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
+        public bool DateTimeUseLocalizedCulture
+        {
+            get => Models.DateTimeFormat.UseLocalizedCulture;
+            set
+            {
+                if (value != Models.DateTimeFormat.UseLocalizedCulture)
+                {
+                    Models.DateTimeFormat.UseLocalizedCulture = value;
                     OnPropertyChanged();
                 }
             }

--- a/src/Views/CommitTimeTextBlock.cs
+++ b/src/Views/CommitTimeTextBlock.cs
@@ -46,6 +46,30 @@ namespace SourceGit.Views
             set => SetAndRaise(DateTimeFormatProperty, ref _dateTimeFormat, value);
         }
 
+        public static readonly DirectProperty<CommitTimeTextBlock, int> DayOfWeekStyleProperty =
+            AvaloniaProperty.RegisterDirect<CommitTimeTextBlock, int>(
+                nameof(DayOfWeekStyle),
+                static o => o.DayOfWeekStyle,
+                static (o, v) => o.DayOfWeekStyle = v);
+
+        public int DayOfWeekStyle
+        {
+            get => _dayOfWeekStyle;
+            set => SetAndRaise(DayOfWeekStyleProperty, ref _dayOfWeekStyle, value);
+        }
+
+        public static readonly DirectProperty<CommitTimeTextBlock, bool> UseLocalizedCultureProperty =
+            AvaloniaProperty.RegisterDirect<CommitTimeTextBlock, bool>(
+                nameof(UseLocalizedCulture),
+                static o => o.UseLocalizedCulture,
+                static (o, v) => o.UseLocalizedCulture = v);
+
+        public bool UseLocalizedCulture
+        {
+            get => _useLocalizedCulture;
+            set => SetAndRaise(UseLocalizedCultureProperty, ref _useLocalizedCulture, value);
+        }
+
         public static readonly DirectProperty<CommitTimeTextBlock, ulong> TimestampProperty =
             AvaloniaProperty.RegisterDirect<CommitTimeTextBlock, ulong>(
                 nameof(Timestamp),
@@ -83,7 +107,10 @@ namespace SourceGit.Views
                     HorizontalAlignment = HorizontalAlignment.Center;
                 }
             }
-            else if (change.Property == DateTimeFormatProperty || change.Property == Use24HoursProperty)
+            else if (change.Property == DateTimeFormatProperty ||
+                     change.Property == Use24HoursProperty ||
+                     change.Property == DayOfWeekStyleProperty ||
+                     change.Property == UseLocalizedCultureProperty)
             {
                 if (ShowAsDateTime)
                     SetCurrentValue(TextProperty, GetDisplayText());
@@ -107,14 +134,24 @@ namespace SourceGit.Views
                 }
             };
             _refreshTimer.IsEnabled = !ShowAsDateTime;
+
+            Models.DateTimeFormat.Changed += OnDateTimeFormatChanged;
         }
 
         protected override void OnUnloaded(RoutedEventArgs e)
         {
+            Models.DateTimeFormat.Changed -= OnDateTimeFormatChanged;
+
             _refreshTimer.Tag = null;
             _refreshTimer.IsEnabled = false;
 
             base.OnUnloaded(e);
+        }
+
+        private void OnDateTimeFormatChanged()
+        {
+            if (ShowAsDateTime)
+                SetCurrentValue(TextProperty, GetDisplayText());
         }
 
         protected override void OnDataContextChanged(EventArgs e)
@@ -174,6 +211,8 @@ namespace SourceGit.Views
         private bool _showAsDateTime = true;
         private bool _use24Hours = true;
         private int _dateTimeFormat = 0;
+        private int _dayOfWeekStyle = 0;
+        private bool _useLocalizedCulture = true;
         private ulong _timestamp = 0;
         private DispatcherTimer _refreshTimer = null;
     }

--- a/src/Views/DateTimePresenter.cs
+++ b/src/Views/DateTimePresenter.cs
@@ -3,6 +3,7 @@
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Data;
+using Avalonia.Interactivity;
 
 namespace SourceGit.Views
 {
@@ -44,6 +45,30 @@ namespace SourceGit.Views
             set => SetAndRaise(DateTimeFormatProperty, ref _dateTimeFormat, value);
         }
 
+        public static readonly DirectProperty<DateTimePresenter, int> DayOfWeekStyleProperty =
+            AvaloniaProperty.RegisterDirect<DateTimePresenter, int>(
+                nameof(DayOfWeekStyle),
+                static o => o.DayOfWeekStyle,
+                static (o, v) => o.DayOfWeekStyle = v);
+
+        public int DayOfWeekStyle
+        {
+            get => _dayOfWeekStyle;
+            set => SetAndRaise(DayOfWeekStyleProperty, ref _dayOfWeekStyle, value);
+        }
+
+        public static readonly DirectProperty<DateTimePresenter, bool> UseLocalizedCultureProperty =
+            AvaloniaProperty.RegisterDirect<DateTimePresenter, bool>(
+                nameof(UseLocalizedCulture),
+                static o => o.UseLocalizedCulture,
+                static (o, v) => o.UseLocalizedCulture = v);
+
+        public bool UseLocalizedCulture
+        {
+            get => _useLocalizedCulture;
+            set => SetAndRaise(UseLocalizedCultureProperty, ref _useLocalizedCulture, value);
+        }
+
         public static readonly DirectProperty<DateTimePresenter, ulong> TimestampProperty =
             AvaloniaProperty.RegisterDirect<DateTimePresenter, ulong>(
                 nameof(Timestamp),
@@ -73,6 +98,37 @@ namespace SourceGit.Views
                 Source = ViewModels.Preferences.Instance,
                 Path = "DateTimeFormat"
             });
+
+            Bind(DayOfWeekStyleProperty, new Binding()
+            {
+                Mode = BindingMode.OneWay,
+                Source = ViewModels.Preferences.Instance,
+                Path = "DayOfWeekStyle"
+            });
+
+            Bind(UseLocalizedCultureProperty, new Binding()
+            {
+                Mode = BindingMode.OneWay,
+                Source = ViewModels.Preferences.Instance,
+                Path = "DateTimeUseLocalizedCulture"
+            });
+        }
+
+        protected override void OnLoaded(RoutedEventArgs e)
+        {
+            base.OnLoaded(e);
+            Models.DateTimeFormat.Changed += OnDateTimeFormatChanged;
+        }
+
+        protected override void OnUnloaded(RoutedEventArgs e)
+        {
+            Models.DateTimeFormat.Changed -= OnDateTimeFormatChanged;
+            base.OnUnloaded(e);
+        }
+
+        private void OnDateTimeFormatChanged()
+        {
+            SetCurrentValue(TextProperty, Models.DateTimeFormat.Format(Timestamp, ShowDateOnly));
         }
 
         protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
@@ -82,6 +138,8 @@ namespace SourceGit.Views
             if (change.Property == ShowDateOnlyProperty ||
                 change.Property == Use24HoursProperty ||
                 change.Property == DateTimeFormatProperty ||
+                change.Property == DayOfWeekStyleProperty ||
+                change.Property == UseLocalizedCultureProperty ||
                 change.Property == TimestampProperty)
             {
                 var text = Models.DateTimeFormat.Format(Timestamp, ShowDateOnly);
@@ -92,6 +150,8 @@ namespace SourceGit.Views
         private bool _showDateOnly = false;
         private bool _use24Hours = true;
         private int _dateTimeFormat = 0;
+        private int _dayOfWeekStyle = 0;
+        private bool _useLocalizedCulture = true;
         private ulong _timestamp = 0;
     }
 }

--- a/src/Views/Histories.axaml
+++ b/src/Views/Histories.axaml
@@ -206,6 +206,8 @@
                                          Timestamp="{Binding AuthorTime, Mode=OneWay}"
                                          ShowAsDateTime="{Binding Source={x:Static vm:Preferences.Instance}, Path=!DisplayTimeAsPeriodInHistories, Mode=OneWay}"
                                          DateTimeFormat="{Binding Source={x:Static vm:Preferences.Instance}, Path=DateTimeFormat, Mode=OneWay}"
+                                         DayOfWeekStyle="{Binding Source={x:Static vm:Preferences.Instance}, Path=DayOfWeekStyle, Mode=OneWay}"
+                                         UseLocalizedCulture="{Binding Source={x:Static vm:Preferences.Instance}, Path=DateTimeUseLocalizedCulture, Mode=OneWay}"
                                          Use24Hours="{Binding Source={x:Static vm:Preferences.Instance}, Path=Use24Hours, Mode=OneWay}"/>
                 </Border>
               </DataTemplate>
@@ -226,6 +228,8 @@
                                          Timestamp="{Binding CommitterTime, Mode=OneWay}"
                                          ShowAsDateTime="{Binding Source={x:Static vm:Preferences.Instance}, Path=!DisplayTimeAsPeriodInHistories, Mode=OneWay}"
                                          DateTimeFormat="{Binding Source={x:Static vm:Preferences.Instance}, Path=DateTimeFormat, Mode=OneWay}"
+                                         DayOfWeekStyle="{Binding Source={x:Static vm:Preferences.Instance}, Path=DayOfWeekStyle, Mode=OneWay}"
+                                         UseLocalizedCulture="{Binding Source={x:Static vm:Preferences.Instance}, Path=DateTimeUseLocalizedCulture, Mode=OneWay}"
                                          Use24Hours="{Binding Source={x:Static vm:Preferences.Instance}, Path=Use24Hours, Mode=OneWay}"/>
                 </Border>
               </DataTemplate>

--- a/src/Views/Preferences.axaml
+++ b/src/Views/Preferences.axaml
@@ -52,19 +52,27 @@
                        Text="{DynamicResource Text.Preferences.General.Locale}"
                        HorizontalAlignment="Right"
                        Margin="0,0,16,0"/>
-            <ComboBox Grid.Row="0" Grid.Column="1"
-                      MinHeight="28"
-                      Padding="8,0"
-                      HorizontalAlignment="Stretch"
-                      ItemsSource="{Binding Source={x:Static m:Locale.Supported}}"
-                      DisplayMemberBinding="{Binding Name, x:DataType=m:Locale}"
-                      SelectedItem="{Binding Locale, Mode=TwoWay, Converter={x:Static c:StringConverters.ToLocale}}"/>
+            <Grid Grid.Row="0" Grid.Column="1" ColumnDefinitions="*,Auto">
+              <ComboBox Grid.Column="0"
+                        MinHeight="28"
+                        Padding="8,0"
+                        HorizontalAlignment="Stretch"
+                        ItemsSource="{Binding Source={x:Static m:Locale.Supported}}"
+                        DisplayMemberBinding="{Binding Name, x:DataType=m:Locale}"
+                        SelectedItem="{Binding Locale, Mode=TwoWay, Converter={x:Static c:StringConverters.ToLocale}}"/>
+
+              <CheckBox Grid.Column="1"
+                        Height="32"
+                        Margin="8,0,0,0"
+                        Content="{DynamicResource Text.Preferences.General.LocalizedDates}"
+                        IsChecked="{Binding DateTimeUseLocalizedCulture, Mode=TwoWay}"/>
+            </Grid>
 
             <TextBlock Grid.Row="1" Grid.Column="0"
                        Text="{DynamicResource Text.Preferences.General.DateFormat}"
                        HorizontalAlignment="Right"
                        Margin="0,0,16,0"/>
-            <Grid Grid.Row="1" Grid.Column="1" ColumnDefinitions="*,Auto">
+            <Grid Grid.Row="1" Grid.Column="1" ColumnDefinitions="*,Auto,Auto">
               <ComboBox Grid.Column="0"
                         MinHeight="28"
                         Padding="8,0"
@@ -81,7 +89,17 @@
                 </ComboBox.ItemTemplate>
               </ComboBox>
 
-              <CheckBox Grid.Column="1"
+              <ComboBox Grid.Column="1"
+                        MinHeight="28"
+                        Margin="8,0,0,0"
+                        Padding="8,0"
+                        SelectedIndex="{Binding DayOfWeekStyle, Mode=TwoWay}">
+                <ComboBoxItem Content="{DynamicResource Text.Preferences.General.DayOfWeek.None}"/>
+                <ComboBoxItem Content="{DynamicResource Text.Preferences.General.DayOfWeek.Short}"/>
+                <ComboBoxItem Content="{DynamicResource Text.Preferences.General.DayOfWeek.Full}"/>
+              </ComboBox>
+
+              <CheckBox Grid.Column="2"
                         Height="32"
                         Margin="8,0,0,0"
                         Content="{DynamicResource Text.Preferences.General.Use24Hours}"


### PR DESCRIPTION
## Why

Sometimes you need to see the **weekday** of a commit, not just the date — especially when reasoning about workdays, where knowing it was e.g. a Friday matters as much as the calendar date itself. The current display only shows the date.

Also, while the app interface can be localized, the date is always rendered in English, which doesn't help users running the app in their own language. It is preferable to let the date follow the user's language too, when they want it.

Both options are opt-in and were kept deliberately non-intrusive — placed where there is already space and where they make sense in Preferences.

## What

**Day of week** — a dropdown in Preferences ▸ General (None / Short / Full) that prepends `ddd`/`dddd` to the active date format. Stored as `DayOfWeekStyle`; day names come from the active culture.

**Localized dates** — a toggle (`UseLocalizedCulture`) that ties day/month names to the application's selected language instead of the invariant/English culture. The culture is derived from the app locale key, not the OS culture.

Both flow through `DateTimeFormat.Format` and are bound into `CommitTimeTextBlock` and `DateTimePresenter`. New locale keys added to `en_US` and `el_GR`.
