### PR TITLE
Add .tss to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 *.user
 *.suo
 *.code-workspace
+*.tss
 
 .DS_Store
 .DocumentRevisions-V100


### PR DESCRIPTION
With visual studio 2026 two .tss files are generated: should be removed from the git flow