### PR TITLE
feature: add total added/removed line counts to changes views

### DIFF
--- a/src/Commands/QueryDiffLineStats.cs
+++ b/src/Commands/QueryDiffLineStats.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SourceGit.Commands
+{
+    public class QueryDiffLineStats : Command
+    {
+        public QueryDiffLineStats(string repo, string start, string end, bool ignoreWhitespace, bool ignoreCRAtEOL)
+            : this(repo, ignoreWhitespace, ignoreCRAtEOL, $"{(string.IsNullOrEmpty(start) ? "-R" : start)} {end}")
+        {
+        }
+
+        public QueryDiffLineStats(string repo, bool staged, bool ignoreWhitespace, bool ignoreCRAtEOL)
+            : this(repo, ignoreWhitespace, ignoreCRAtEOL, staged ? "--cached" : string.Empty)
+        {
+        }
+
+        private QueryDiffLineStats(string repo, bool ignoreWhitespace, bool ignoreCRAtEOL, string suffix)
+        {
+            WorkingDirectory = repo;
+            Context = repo;
+            RaiseError = false;
+
+            var builder = new StringBuilder();
+            builder.Append("diff --no-color --no-ext-diff --numstat -z ");
+            if (ignoreCRAtEOL)
+                builder.Append("--ignore-cr-at-eol ");
+            if (ignoreWhitespace)
+                builder.Append("--ignore-space-change --ignore-blank-lines ");
+            builder.Append(suffix);
+            Args = builder.ToString().TrimEnd();
+        }
+
+        public async Task<(int added, int deleted)> GetResultAsync()
+        {
+            try
+            {
+                var rs = await ReadToEndAsync().ConfigureAwait(false);
+                if (string.IsNullOrWhiteSpace(rs.StdOut))
+                    return (0, 0);
+
+                int added = 0, deleted = 0;
+                foreach (var token in rs.StdOut.Split('\0', StringSplitOptions.RemoveEmptyEntries))
+                {
+                    var parts = token.Split('\t', 3);
+                    if (parts.Length < 2)
+                        continue;
+
+                    added += ParseCount(parts[0]);
+                    deleted += ParseCount(parts[1]);
+                }
+
+                return (added, deleted);
+            }
+            catch
+            {
+                return (0, 0);
+            }
+        }
+
+        private static int ParseCount(string value) => int.TryParse(value, out var parsed) ? parsed : 0;
+    }
+}

--- a/src/ViewModels/CommitDetail.cs
+++ b/src/ViewModels/CommitDetail.cs
@@ -91,6 +91,18 @@ namespace SourceGit.ViewModels
             set => SetProperty(ref _visibleChanges, value);
         }
 
+        public int TotalAddedLines
+        {
+            get => _totalAddedLines;
+            private set => SetProperty(ref _totalAddedLines, value);
+        }
+
+        public int TotalDeletedLines
+        {
+            get => _totalDeletedLines;
+            private set => SetProperty(ref _totalDeletedLines, value);
+        }
+
         public List<Models.Change> SelectedChanges
         {
             get => _selectedChanges;
@@ -513,10 +525,11 @@ namespace SourceGit.ViewModels
 
             Task.Run(async () =>
             {
-                var changes = await new Commands.CompareRevisions(_repo.FullPath, _commit.FirstParentToCompare, _commit.SHA)
-                    .WithCancellation(token)
-                    .ReadAsync()
-                    .ConfigureAwait(false);
+                var cmd = new Commands.CompareRevisions(_repo.FullPath, _commit.FirstParentToCompare, _commit.SHA) { CancellationToken = token };
+                var changes = await cmd.ReadAsync().ConfigureAwait(false);
+                var pref = Preferences.Instance;
+                var statsCmd = new Commands.QueryDiffLineStats(_repo.FullPath, _commit.FirstParentToCompare, _commit.SHA, pref.IgnoreWhitespaceChangesInDiff, pref.IgnoreCRAtEOLInDiff) { CancellationToken = token };
+                var stats = await statsCmd.GetResultAsync().ConfigureAwait(false);
 
                 var visible = changes;
                 if (!string.IsNullOrWhiteSpace(_searchChangeFilter))
@@ -535,6 +548,8 @@ namespace SourceGit.ViewModels
                     {
                         Changes = changes;
                         VisibleChanges = visible;
+                        TotalAddedLines = stats.added;
+                        TotalDeletedLines = stats.deleted;
 
                         if (visible.Count == 0)
                             SelectedChanges = null;
@@ -739,6 +754,8 @@ namespace SourceGit.ViewModels
         private List<Models.Change> _changes = [];
         private List<Models.Change> _visibleChanges = [];
         private List<Models.Change> _selectedChanges = null;
+        private int _totalAddedLines = 0;
+        private int _totalDeletedLines = 0;
         private string _searchChangeFilter = string.Empty;
         private DiffContext _diffContext = null;
         private string _viewRevisionFilePath = string.Empty;

--- a/src/ViewModels/Compare.cs
+++ b/src/ViewModels/Compare.cs
@@ -62,6 +62,18 @@ namespace SourceGit.ViewModels
             private set => SetProperty(ref _totalChanges, value);
         }
 
+        public int TotalAddedLines
+        {
+            get => _totalAddedLines;
+            private set => SetProperty(ref _totalAddedLines, value);
+        }
+
+        public int TotalDeletedLines
+        {
+            get => _totalDeletedLines;
+            private set => SetProperty(ref _totalDeletedLines, value);
+        }
+
         public List<Models.Change> VisibleChanges
         {
             get => _visibleChanges;
@@ -317,6 +329,15 @@ namespace SourceGit.ViewModels
                     .ReadAsync()
                     .ConfigureAwait(false);
 
+                var pref = Preferences.Instance;
+                var stats = await new Commands.QueryDiffLineStats(
+                        _repo.FullPath,
+                        _based,
+                        _to,
+                        pref.IgnoreWhitespaceChangesInDiff,
+                        pref.IgnoreCRAtEOLInDiff)
+                    .GetResultAsync().ConfigureAwait(false);
+
                 var visible = _changes;
                 if (!string.IsNullOrWhiteSpace(_searchFilter))
                 {
@@ -331,6 +352,8 @@ namespace SourceGit.ViewModels
                 Dispatcher.UIThread.Post(() =>
                 {
                     TotalChanges = _changes.Count;
+                    TotalAddedLines = stats.added;
+                    TotalDeletedLines = stats.deleted;
                     VisibleChanges = visible;
                     IsLoadingChanges = false;
 
@@ -398,6 +421,8 @@ namespace SourceGit.ViewModels
         private Models.Commit _baseHead = null;
         private Models.Commit _toHead = null;
         private int _totalChanges = 0;
+        private int _totalAddedLines = 0;
+        private int _totalDeletedLines = 0;
         private List<Models.Change> _changes = null;
         private List<Models.Change> _visibleChanges = null;
         private List<Models.Change> _selectedChanges = null;

--- a/src/ViewModels/RevisionCompare.cs
+++ b/src/ViewModels/RevisionCompare.cs
@@ -59,6 +59,18 @@ namespace SourceGit.ViewModels
             private set => SetProperty(ref _totalChanges, value);
         }
 
+        public int TotalAddedLines
+        {
+            get => _totalAddedLines;
+            private set => SetProperty(ref _totalAddedLines, value);
+        }
+
+        public int TotalDeletedLines
+        {
+            get => _totalDeletedLines;
+            private set => SetProperty(ref _totalDeletedLines, value);
+        }
+
         public List<Models.Change> VisibleChanges
         {
             get => _visibleChanges;
@@ -350,9 +362,20 @@ namespace SourceGit.ViewModels
         {
             Task.Run(async () =>
             {
-                _changes = await new Commands.CompareRevisions(_repo.FullPath, GetSHA(_startPoint), GetSHA(_endPoint))
+                var startSHA = GetSHA(_startPoint);
+                var endSHA = GetSHA(_endPoint);
+                _changes = await new Commands.CompareRevisions(_repo.FullPath, startSHA, endSHA)
                     .ReadAsync()
                     .ConfigureAwait(false);
+
+                var pref = Preferences.Instance;
+                var stats = await new Commands.QueryDiffLineStats(
+                        _repo.FullPath,
+                        startSHA,
+                        endSHA,
+                        pref.IgnoreWhitespaceChangesInDiff,
+                        pref.IgnoreCRAtEOLInDiff)
+                    .GetResultAsync().ConfigureAwait(false);
 
                 var visible = _changes;
                 if (!string.IsNullOrWhiteSpace(_searchFilter))
@@ -368,6 +391,8 @@ namespace SourceGit.ViewModels
                 Dispatcher.UIThread.Post(() =>
                 {
                     TotalChanges = _changes.Count;
+                    TotalAddedLines = stats.added;
+                    TotalDeletedLines = stats.deleted;
                     VisibleChanges = visible;
                     IsLoading = false;
 
@@ -394,6 +419,8 @@ namespace SourceGit.ViewModels
         private object _startPoint = null;
         private object _endPoint = null;
         private int _totalChanges = 0;
+        private int _totalAddedLines = 0;
+        private int _totalDeletedLines = 0;
         private List<Models.Change> _changes = null;
         private List<Models.Change> _visibleChanges = null;
         private List<Models.Change> _selectedChanges = null;

--- a/src/ViewModels/WorkingCopy.cs
+++ b/src/ViewModels/WorkingCopy.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
+using Avalonia.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 
 namespace SourceGit.ViewModels
@@ -160,6 +161,30 @@ namespace SourceGit.ViewModels
             private set => SetProperty(ref _visibleStaged, value);
         }
 
+        public int UnstagedAddedLines
+        {
+            get => _unstagedAddedLines;
+            private set => SetProperty(ref _unstagedAddedLines, value);
+        }
+
+        public int UnstagedDeletedLines
+        {
+            get => _unstagedDeletedLines;
+            private set => SetProperty(ref _unstagedDeletedLines, value);
+        }
+
+        public int StagedAddedLines
+        {
+            get => _stagedAddedLines;
+            private set => SetProperty(ref _stagedAddedLines, value);
+        }
+
+        public int StagedDeletedLines
+        {
+            get => _stagedDeletedLines;
+            private set => SetProperty(ref _stagedDeletedLines, value);
+        }
+
         public List<Models.Change> SelectedUnstaged
         {
             get => _selectedUnstaged;
@@ -312,6 +337,29 @@ namespace SourceGit.ViewModels
 
             UpdateInProgressState();
             UpdateDetail();
+
+            _ = Task.Run(async () =>
+            {
+                var pref = Preferences.Instance;
+                var unstagedStats = await new Commands.QueryDiffLineStats(
+                        _repo.FullPath, false, pref.IgnoreWhitespaceChangesInDiff, pref.IgnoreCRAtEOLInDiff)
+                    .GetResultAsync().ConfigureAwait(false);
+                var stagedStats = await new Commands.QueryDiffLineStats(
+                        _repo.FullPath, true, pref.IgnoreWhitespaceChangesInDiff, pref.IgnoreCRAtEOLInDiff)
+                    .GetResultAsync().ConfigureAwait(false);
+
+                Dispatcher.UIThread.Post(() =>
+                {
+                    // A newer SetData may have run while fetching stats; drop this stale update.
+                    if (!ReferenceEquals(_cached, changes))
+                        return;
+
+                    UnstagedAddedLines = unstagedStats.added;
+                    UnstagedDeletedLines = unstagedStats.deleted;
+                    StagedAddedLines = stagedStats.added;
+                    StagedDeletedLines = stagedStats.deleted;
+                });
+            });
         }
 
         public async Task StageChangesAsync(List<Models.Change> changes, Models.Change next)
@@ -821,6 +869,10 @@ namespace SourceGit.ViewModels
         private List<Models.Change> _visibleStaged = [];
         private List<Models.Change> _selectedUnstaged = [];
         private List<Models.Change> _selectedStaged = [];
+        private int _unstagedAddedLines = 0;
+        private int _unstagedDeletedLines = 0;
+        private int _stagedAddedLines = 0;
+        private int _stagedDeletedLines = 0;
         private object _detailContext = null;
         private string _filter = string.Empty;
         private string _commitMessage = string.Empty;

--- a/src/Views/CommitChanges.axaml
+++ b/src/Views/CommitChanges.axaml
@@ -4,6 +4,7 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="using:SourceGit.ViewModels"
              xmlns:v="using:SourceGit.Views"
+             xmlns:c="using:SourceGit.Converters"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:Class="SourceGit.Views.CommitChanges"
              x:DataType="vm:CommitDetail">
@@ -56,12 +57,24 @@
 
       <!-- Summary -->
       <Border Grid.Row="2" BorderBrush="{DynamicResource Brush.Border2}" BorderThickness="1,0,1,1" Background="Transparent">
-        <TextBlock Margin="4,0,0,0"
-                   Foreground="{DynamicResource Brush.FG2}"
-                   HorizontalAlignment="Left" VerticalAlignment="Center">
-          <Run Text="{Binding Changes.Count, Mode=OneWay}" FontWeight="Bold"/>
-          <Run Text="{DynamicResource Text.CommitDetail.Changes.Count}"/>
-        </TextBlock>
+        <StackPanel Orientation="Horizontal" Margin="4,0,0,0" VerticalAlignment="Center">
+          <TextBlock Foreground="{DynamicResource Brush.FG2}" HorizontalAlignment="Left" VerticalAlignment="Center">
+            <Run Text="{Binding Changes.Count, Mode=OneWay}" FontWeight="Bold"/>
+            <Run Text="{DynamicResource Text.CommitDetail.Changes.Count}"/>
+          </TextBlock>
+          <TextBlock FontSize="11"
+                     Margin="12,0,0,0"
+                     Foreground="Green"
+                     Text="{Binding TotalAddedLines, StringFormat=+{0}}"
+                     IsVisible="{Binding TotalAddedLines, Converter={x:Static c:IntConverters.IsGreaterThanZero}}"
+                     VerticalAlignment="Center"/>
+          <TextBlock FontSize="11"
+                     Margin="4,0,0,0"
+                     Foreground="Red"
+                     Text="{Binding TotalDeletedLines, StringFormat=-{0}}"
+                     IsVisible="{Binding TotalDeletedLines, Converter={x:Static c:IntConverters.IsGreaterThanZero}}"
+                     VerticalAlignment="Center"/>
+        </StackPanel>
       </Border>
     </Grid>
 

--- a/src/Views/Compare.axaml
+++ b/src/Views/Compare.axaml
@@ -193,12 +193,24 @@
 
           <!-- Summary -->
           <Border Grid.Row="2" BorderBrush="{DynamicResource Brush.Border2}" BorderThickness="1,0,1,1" Background="Transparent">
-            <TextBlock Margin="4,0,0,0"
-                       Foreground="{DynamicResource Brush.FG2}"
-                       HorizontalAlignment="Left" VerticalAlignment="Center">
-              <Run Text="{Binding TotalChanges, Mode=OneWay}" FontWeight="Bold"/>
-              <Run Text="{DynamicResource Text.CommitDetail.Changes.Count}"/>
-            </TextBlock>
+            <StackPanel Orientation="Horizontal" Margin="4,0,0,0" VerticalAlignment="Center">
+              <TextBlock Foreground="{DynamicResource Brush.FG2}" HorizontalAlignment="Left" VerticalAlignment="Center">
+                <Run Text="{Binding TotalChanges, Mode=OneWay}" FontWeight="Bold"/>
+                <Run Text="{DynamicResource Text.CommitDetail.Changes.Count}"/>
+              </TextBlock>
+              <TextBlock FontSize="11"
+                         Margin="12,0,0,0"
+                         Foreground="Green"
+                         Text="{Binding TotalAddedLines, StringFormat=+{0}}"
+                         IsVisible="{Binding TotalAddedLines, Converter={x:Static c:IntConverters.IsGreaterThanZero}}"
+                         VerticalAlignment="Center"/>
+              <TextBlock FontSize="11"
+                         Margin="4,0,0,0"
+                         Foreground="Red"
+                         Text="{Binding TotalDeletedLines, StringFormat=-{0}}"
+                         IsVisible="{Binding TotalDeletedLines, Converter={x:Static c:IntConverters.IsGreaterThanZero}}"
+                         VerticalAlignment="Center"/>
+            </StackPanel>
           </Border>
         </Grid>
 

--- a/src/Views/RevisionCompare.axaml
+++ b/src/Views/RevisionCompare.axaml
@@ -123,12 +123,24 @@
 
         <!-- Summary -->
         <Border Grid.Row="2" BorderBrush="{DynamicResource Brush.Border2}" BorderThickness="1,0,1,1" Background="Transparent">
-          <TextBlock Margin="4,0,0,0"
-                     Foreground="{DynamicResource Brush.FG2}"
-                     HorizontalAlignment="Left" VerticalAlignment="Center">
-            <Run Text="{Binding TotalChanges, Mode=OneWay}" FontWeight="Bold"/>
-            <Run Text="{DynamicResource Text.CommitDetail.Changes.Count}"/>
-          </TextBlock>
+          <StackPanel Orientation="Horizontal" Margin="4,0,0,0" VerticalAlignment="Center">
+            <TextBlock Foreground="{DynamicResource Brush.FG2}" HorizontalAlignment="Left" VerticalAlignment="Center">
+              <Run Text="{Binding TotalChanges, Mode=OneWay}" FontWeight="Bold"/>
+              <Run Text="{DynamicResource Text.CommitDetail.Changes.Count}"/>
+            </TextBlock>
+            <TextBlock FontSize="11"
+                       Margin="12,0,0,0"
+                       Foreground="Green"
+                       Text="{Binding TotalAddedLines, StringFormat=+{0}}"
+                       IsVisible="{Binding TotalAddedLines, Converter={x:Static c:IntConverters.IsGreaterThanZero}}"
+                       VerticalAlignment="Center"/>
+            <TextBlock FontSize="11"
+                       Margin="4,0,0,0"
+                       Foreground="Red"
+                       Text="{Binding TotalDeletedLines, StringFormat=-{0}}"
+                       IsVisible="{Binding TotalDeletedLines, Converter={x:Static c:IntConverters.IsGreaterThanZero}}"
+                       VerticalAlignment="Center"/>
+          </StackPanel>
         </Border>
       </Grid>
 

--- a/src/Views/WorkingCopy.axaml
+++ b/src/Views/WorkingCopy.axaml
@@ -67,7 +67,21 @@
               <Run Text="{DynamicResource Text.WorkingCopy.Unstaged}"/>
               <Run Text="{Binding Unstaged, Converter={x:Static c:ListConverters.ToCount}, Mode=OneWay}"/>
             </TextBlock>
-            <v:LoadingIcon Grid.Column="2" Width="14" Height="14" Margin="8,0,0,0" IsVisible="{Binding IsStaging}"/>
+            <StackPanel Grid.Column="2" Orientation="Horizontal" VerticalAlignment="Center">
+              <TextBlock FontSize="11"
+                         Margin="8,0,0,0"
+                         Foreground="Green"
+                         Text="{Binding UnstagedAddedLines, StringFormat=+{0}}"
+                         IsVisible="{Binding UnstagedAddedLines, Converter={x:Static c:IntConverters.IsGreaterThanZero}}"
+                         VerticalAlignment="Center"/>
+              <TextBlock FontSize="11"
+                         Margin="4,0,0,0"
+                         Foreground="Red"
+                         Text="{Binding UnstagedDeletedLines, StringFormat=-{0}}"
+                         IsVisible="{Binding UnstagedDeletedLines, Converter={x:Static c:IntConverters.IsGreaterThanZero}}"
+                         VerticalAlignment="Center"/>
+              <v:LoadingIcon Width="14" Height="14" Margin="8,0,0,0" IsVisible="{Binding IsStaging}"/>
+            </StackPanel>
 
             <Button Grid.Column="4"
                     Classes="icon_button"
@@ -154,7 +168,21 @@
               <Run Text="{DynamicResource Text.WorkingCopy.Staged}"/>
               <Run Text="{Binding Staged, Converter={x:Static c:ListConverters.ToCount}, Mode=OneWay}"/>
             </TextBlock>
-            <v:LoadingIcon Grid.Column="2" Width="14" Height="14" Margin="8,0,0,0" IsVisible="{Binding IsUnstaging}"/>
+            <StackPanel Grid.Column="2" Orientation="Horizontal" VerticalAlignment="Center">
+              <TextBlock FontSize="11"
+                         Margin="8,0,0,0"
+                         Foreground="Green"
+                         Text="{Binding StagedAddedLines, StringFormat=+{0}}"
+                         IsVisible="{Binding StagedAddedLines, Converter={x:Static c:IntConverters.IsGreaterThanZero}}"
+                         VerticalAlignment="Center"/>
+              <TextBlock FontSize="11"
+                         Margin="4,0,0,0"
+                         Foreground="Red"
+                         Text="{Binding StagedDeletedLines, StringFormat=-{0}}"
+                         IsVisible="{Binding StagedDeletedLines, Converter={x:Static c:IntConverters.IsGreaterThanZero}}"
+                         VerticalAlignment="Center"/>
+              <v:LoadingIcon Width="14" Height="14" Margin="8,0,0,0" IsVisible="{Binding IsUnstaging}"/>
+            </StackPanel>
             <Button Grid.Column="4" Classes="icon_button" Width="26" Height="14" Padding="0" Click="OnUnstageSelectedButtonClicked">
               <ToolTip.Tip>
                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center">


### PR DESCRIPTION
Completes what #2194 deferred - that PR added per-file line counts to the diff view only, noting it skipped totals "to avoid extra overhead." This adds the totals.

Shows total +N/-N (green/red, hidden when zero) in the summary bars of Working Copy (staged & unstaged), Commit Detail, Compare, and Revision Compare - same display convention as #2194.

Kept minimal: one new command (QueryDiffLineStats, git diff --numstat -z) run alongside each view's existing changes query.

Related: #1176.

<img width="1386" height="492" alt="image" src="https://github.com/user-attachments/assets/6d7b6ea7-c52c-4106-b074-13f6089c0316" />
