### PR TITLE
fix: remove history filter only on successful remote branch deletion

### DIFF
--- a/src/ViewModels/DeleteBranch.cs
+++ b/src/ViewModels/DeleteBranch.cs
@@ -65,7 +65,8 @@ namespace SourceGit.ViewModels
             else
             {
                 succ = await DeleteRemoteBranchAsync(Target, log);
-                _repo.UIStates.RemoveHistoryFilter(Target.FullName, Models.FilterType.RemoteBranch);
+                if (succ)
+                    _repo.UIStates.RemoveHistoryFilter(Target.FullName, Models.FilterType.RemoteBranch);
             }
 
             log.Complete();


### PR DESCRIPTION
In `DeleteBranch.Sure()`, `RemoveHistoryFilter` was called unconditionally
when deleting a remote branch, even if the deletion failed. Wrap it in
`if (succ)` to match the local branch and tracking branch paths.