### PR TITLE
ux: show registering progress after scanning repositories

### DIFF
--- a/src/ViewModels/ScanRepositories.cs
+++ b/src/ViewModels/ScanRepositories.cs
@@ -93,8 +93,10 @@ namespace SourceGit.ViewModels
             await minDelay;
 
             var normalizedRoot = rootDir.FullName.Replace('\\', '/').TrimEnd('/');
-            foreach (var f in found)
+            for (var i = 0; i < found.Count; i++)
             {
+                var f = found[i];
+                ProgressDescription = $"Registering ({i + 1}/{found.Count}) {f}...";
                 var parent = new DirectoryInfo(f).Parent!.FullName.Replace('\\', '/').TrimEnd('/');
                 if (parent.Equals(normalizedRoot, StringComparison.OrdinalIgnoreCase))
                 {


### PR DESCRIPTION
After scanning completes, `ProgressDescription` is not updated during the
registering phase, so users see the last scanned path (e.g. `avatars/`)
while repositories are being registered. Switch to a `for` loop to show
per-repository progress.