### PR TITLE
fix: strip trailing CR in diff content to remove stray "CR" box

### DIFF
--- a/src/Commands/Diff.cs
+++ b/src/Commands/Diff.cs
@@ -204,6 +204,12 @@ namespace SourceGit.Commands
         {
             var prefix = line[0];
             var content = line.Substring(1);
+
+            // Strip the trailing '\r' carried over from CRLF/CR line endings;
+            // RawContent keeps the raw bytes for patch generation.
+            if (content.Length > 0 && content[^1] == '\r')
+                content = content[..^1];
+
             if (ParseLFSChange(prefix, content))
                 return true;
 


### PR DESCRIPTION
Git splits diff lines on `\n`, so the `\r` from CRLF/CR files stays glued to the line content in TextDiffLine.Content. After the editor trims the trailing newline, the last line is left with an isolated `\r`, which AvaloniaEdit renders as a boxed "CR" control character.

Strip it at parse time. RawContent keeps the raw bytes unchanged, so patch generation and the `\r\n` / `\n` line-ending markers are unaffected.

Introduced by commit 6a47cec3947093d8a9ace40c9965be1130f84a6c

Original:

<img width="536" height="117" alt="image" src="https://github.com/user-attachments/assets/8dd80cbb-425a-4137-b63f-a299828b15ca" />
