### PR TITLE
feat: add "fetch all repositories" action in workspace menu

### DIFF
--- a/src/Resources/Locales/en_US.axaml
+++ b/src/Resources/Locales/en_US.axaml
@@ -1059,6 +1059,7 @@
   <x:String x:Key="Text.WorkingCopy.UseCommitTemplate" xml:space="preserve">Template: ${0}$</x:String>
   <x:String x:Key="Text.Workspace" xml:space="preserve">WORKSPACE: </x:String>
   <x:String x:Key="Text.Workspace.Configure" xml:space="preserve">Configure Workspaces...</x:String>
+  <x:String x:Key="Text.Workspace.FetchAllRepositories" xml:space="preserve">Fetch All Repositories</x:String>
   <x:String x:Key="Text.Worktree" xml:space="preserve">WORKTREE</x:String>
   <x:String x:Key="Text.Worktree.Branch" xml:space="preserve">BRANCH</x:String>
   <x:String x:Key="Text.Worktree.CopyPath" xml:space="preserve">Copy Path</x:String>

--- a/src/Resources/Locales/zh_CN.axaml
+++ b/src/Resources/Locales/zh_CN.axaml
@@ -1063,6 +1063,7 @@
   <x:String x:Key="Text.WorkingCopy.UseCommitTemplate" xml:space="preserve">模板：${0}$</x:String>
   <x:String x:Key="Text.Workspace" xml:space="preserve">工作区：</x:String>
   <x:String x:Key="Text.Workspace.Configure" xml:space="preserve">配置工作区...</x:String>
+  <x:String x:Key="Text.Workspace.FetchAllRepositories" xml:space="preserve">拉取工作区所有仓库</x:String>
   <x:String x:Key="Text.Worktree" xml:space="preserve">本地工作树</x:String>
   <x:String x:Key="Text.Worktree.Branch" xml:space="preserve">連結分支</x:String>
   <x:String x:Key="Text.Worktree.CopyPath" xml:space="preserve">复制工作树路径</x:String>

--- a/src/Resources/Locales/zh_TW.axaml
+++ b/src/Resources/Locales/zh_TW.axaml
@@ -1039,6 +1039,7 @@
   <x:String x:Key="Text.WorkingCopy.UseCommitTemplate" xml:space="preserve">範本: ${0}$</x:String>
   <x:String x:Key="Text.Workspace" xml:space="preserve">工作區: </x:String>
   <x:String x:Key="Text.Workspace.Configure" xml:space="preserve">設定工作區...</x:String>
+  <x:String x:Key="Text.Workspace.FetchAllRepositories" xml:space="preserve">提取工作區所有存放庫</x:String>
   <x:String x:Key="Text.Worktree" xml:space="preserve">本機工作樹</x:String>
   <x:String x:Key="Text.Worktree.Branch" xml:space="preserve">分支</x:String>
   <x:String x:Key="Text.Worktree.CopyPath" xml:space="preserve">複製工作樹路徑</x:String>

--- a/src/ViewModels/Launcher.cs
+++ b/src/ViewModels/Launcher.cs
@@ -1,6 +1,8 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Text;
+using System.Threading.Tasks;
 
 using Avalonia.Collections;
 using Avalonia.Threading;
@@ -120,6 +122,26 @@ namespace SourceGit.ViewModels
                 CloseRepositoryInTab(one, false);
 
             _ignoreIndexChange = false;
+        }
+
+        public async Task FetchAllRepositoriesAsync()
+        {
+            // avoid collection was modified while enumerating.
+            var pages = new List<LauncherPage>();
+            pages.AddRange(Pages);
+
+            var count = 0;
+            foreach (var page in pages)
+            {
+                if (page.Data is Repository repo)
+                {
+                    if (await repo.FetchAllRemotesAsync())
+                        count++;
+                }
+            }
+
+            if (count > 0)
+                Models.Notification.Send(null, $"Fetched {count} repositories");
         }
 
         public void SwitchWorkspace(Workspace to)

--- a/src/ViewModels/Repository.cs
+++ b/src/ViewModels/Repository.cs
@@ -697,6 +697,40 @@ namespace SourceGit.ViewModels
                 ShowPopup(new Fetch(this));
         }
 
+        public async Task<bool> FetchAllRemotesAsync()
+        {
+            if (IsAutoFetching)
+                return false;
+
+            CommandLog log = null;
+
+            try
+            {
+                var lockFile = Path.Combine(GitDir, "index.lock");
+                if (File.Exists(lockFile))
+                    return false;
+
+                if (_remotes.Count == 0)
+                    return false;
+
+                IsAutoFetching = true;
+                log = CreateLog("Fetch");
+
+                foreach (var remote in _remotes)
+                    await new Commands.Fetch(FullPath, remote).Use(log).ExecAsync();
+
+                _lastFetchTime = DateTime.Now;
+            }
+            catch
+            {
+                // Ignore all exceptions.
+            }
+
+            IsAutoFetching = false;
+            log?.Complete();
+            return true;
+        }
+
         public async Task PullAsync(bool autoStart)
         {
             if (IsBare || !CanCreatePopup())

--- a/src/Views/Launcher.axaml.cs
+++ b/src/Views/Launcher.axaml.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 
 using Avalonia;
 using Avalonia.Controls;
@@ -408,6 +409,19 @@ namespace SourceGit.Views
                 }
 
                 menu.Items.Add(new MenuItem() { Header = "-" });
+
+                var hasRepos = launcher.Pages.Any(p => p.Data is ViewModels.Repository);
+
+                var fetchAll = new MenuItem();
+                fetchAll.Header = App.Text("Workspace.FetchAllRepositories");
+                fetchAll.Icon = this.CreateMenuIcon("Icons.Fetch");
+                fetchAll.IsEnabled = hasRepos;
+                fetchAll.Click += async (_, ev) =>
+                {
+                    await launcher.FetchAllRepositoriesAsync();
+                    ev.Handled = true;
+                };
+                menu.Items.Add(fetchAll);
 
                 var configure = new MenuItem();
                 configure.Header = App.Text("Workspace.Configure");


### PR DESCRIPTION
## What

Add a "Fetch All Repositories" menu item to the workspace dropdown menu,
allowing users to fetch all open repositories in the active workspace with
a single action.

## Why

When working with multiple repositories in a workspace, users currently have
to switch to each tab and trigger fetch individually (e.g., Ctrl+Down).
This action automates that process without requiring tab switching.

## Changes

- `src/ViewModels/Repository.cs`: Add `FetchAllRemotesAsync()` that directly
  runs `Commands.Fetch` for all remotes (similar to auto-fetch behavior),
  showing the `IsAutoFetching` overlay instead of the `Fetch.axaml` popup.
  Repositories with no remotes or an active `index.lock` are skipped silently.
- `src/ViewModels/Launcher.cs`: Add `FetchAllRepositoriesAsync()` that
  iterates over a snapshot of `Pages` (to avoid collection-modified exceptions
  during async enumeration) and calls `FetchAllRemotesAsync()` on each open
  repository. Sends a completion notification to the active page when done.
- `src/Views/Launcher.axaml.cs`: Add menu item with `Icons.Fetch` icon in
  `OnOpenWorkspaceMenu` after the separator, enabled only when at least one
  repository is open.
- `src/Resources/Locales/`: Add `Text.Workspace.FetchAllRepositories` key to
  `en_US.axaml`, `zh_CN.axaml`, and `zh_TW.axaml`.
