### PR TITLE
feature: add fulltext commit search across SHA/author/committer/message (implements #985)

### DIFF
--- a/src/Commands/QueryCommits.cs
+++ b/src/Commands/QueryCommits.cs
@@ -28,6 +28,10 @@ namespace SourceGit.Commands
             {
                 builder.Append("-i --author=").Append(filter.Quoted());
             }
+            else if (method == Models.CommitSearchMethod.ByCommitter)
+            {
+                builder.Append("-i --committer=").Append(filter.Quoted());
+            }
             else if (method == Models.CommitSearchMethod.ByMessage)
             {
                 var words = filter.Split([' ', '\t', '\r'], StringSplitOptions.RemoveEmptyEntries);

--- a/src/Models/Commit.cs
+++ b/src/Models/Commit.cs
@@ -4,13 +4,18 @@ using CommunityToolkit.Mvvm.ComponentModel;
 
 namespace SourceGit.Models
 {
+    // Bound by index to the search-method ComboBox in Views/Repository.axaml, so
+    // UI-selectable methods must stay first and in dropdown order. ByCommitter is
+    // internal-only (used by the fulltext `All` search).
     public enum CommitSearchMethod
     {
-        BySHA = 0,
+        All = 0,
+        BySHA,
         ByAuthor,
         ByMessage,
         ByPath,
         ByContent,
+        ByCommitter,
     }
 
     public class Commit : ObservableObject

--- a/src/Resources/Locales/en_US.axaml
+++ b/src/Resources/Locales/en_US.axaml
@@ -825,6 +825,7 @@
   <x:String x:Key="Text.Repository.Remotes.Add" xml:space="preserve">Add Remote</x:String>
   <x:String x:Key="Text.Repository.Resolve" xml:space="preserve">RESOLVE</x:String>
   <x:String x:Key="Text.Repository.Search" xml:space="preserve">Search Commit</x:String>
+  <x:String x:Key="Text.Repository.Search.ByAll" xml:space="preserve">SHA/Author/Message</x:String>
   <x:String x:Key="Text.Repository.Search.ByAuthor" xml:space="preserve">Author</x:String>
   <x:String x:Key="Text.Repository.Search.ByContent" xml:space="preserve">Content</x:String>
   <x:String x:Key="Text.Repository.Search.ByMessage" xml:space="preserve">Message</x:String>

--- a/src/ViewModels/SearchCommitContext.cs
+++ b/src/ViewModels/SearchCommitContext.cs
@@ -129,22 +129,21 @@ namespace SourceGit.ViewModels
                         result.Add(commit);
                     }
                 }
-                else if (_onlySearchCurrentBranch)
-                {
-                    result = await new Commands.QueryCommits(repoPath, _filter, method, true)
-                        .GetResultAsync()
-                        .ConfigureAwait(false);
-
-                    foreach (var c in result)
-                        c.IsMerged = true;
-                }
                 else
                 {
-                    result = await new Commands.QueryCommits(repoPath, _filter, method, false)
-                        .GetResultAsync()
-                        .ConfigureAwait(false);
+                    if (method == Models.CommitSearchMethod.All)
+                        result = await SearchAllFieldsAsync(repoPath).ConfigureAwait(false);
+                    else
+                        result = await new Commands.QueryCommits(repoPath, _filter, method, _onlySearchCurrentBranch)
+                            .GetResultAsync()
+                            .ConfigureAwait(false);
 
-                    if (result.Count > 0)
+                    if (_onlySearchCurrentBranch)
+                    {
+                        foreach (var c in result)
+                            c.IsMerged = true;
+                    }
+                    else if (result.Count > 0)
                     {
                         var set = await new Commands.QueryCurrentBranchCommitHashes(repoPath, result[^1].CommitterTime)
                             .GetResultAsync()
@@ -169,6 +168,55 @@ namespace SourceGit.ViewModels
                     }
                 });
             }, token);
+        }
+
+        private async Task<List<Models.Commit>> SearchAllFieldsAsync(string repoPath)
+        {
+            var result = new List<Models.Commit>();
+            var seen = new HashSet<string>();
+
+            var isCommitSHA = await new Commands.IsCommitSHA(repoPath, _filter)
+                .GetResultAsync()
+                .ConfigureAwait(false);
+
+            if (isCommitSHA)
+            {
+                var commit = await new Commands.QuerySingleCommit(repoPath, _filter)
+                    .GetResultAsync()
+                    .ConfigureAwait(false);
+
+                var matchesScope = commit != null;
+                if (matchesScope && _onlySearchCurrentBranch)
+                    matchesScope = await new Commands.IsAncestor(repoPath, commit.SHA, "HEAD")
+                        .GetResultAsync()
+                        .ConfigureAwait(false);
+
+                if (matchesScope && seen.Add(commit.SHA))
+                    result.Add(commit);
+            }
+
+            var fields = new[]
+            {
+                Models.CommitSearchMethod.ByMessage,
+                Models.CommitSearchMethod.ByAuthor,
+                Models.CommitSearchMethod.ByCommitter,
+            };
+
+            foreach (var field in fields)
+            {
+                var matched = await new Commands.QueryCommits(repoPath, _filter, field, _onlySearchCurrentBranch)
+                    .GetResultAsync()
+                    .ConfigureAwait(false);
+
+                foreach (var c in matched)
+                {
+                    if (seen.Add(c.SHA))
+                        result.Add(c);
+                }
+            }
+
+            result.Sort((l, r) => r.CommitterTime.CompareTo(l.CommitterTime));
+            return result;
         }
 
         public void EndSearch()
@@ -287,7 +335,7 @@ namespace SourceGit.ViewModels
 
         private Repository _repo = null;
         private CancellationTokenSource _cancellation = null;
-        private int _method = (int)Models.CommitSearchMethod.ByMessage;
+        private int _method = (int)Models.CommitSearchMethod.All;
         private string _filter = string.Empty;
         private bool _onlySearchCurrentBranch = false;
         private bool _isQuerying = false;

--- a/src/Views/Repository.axaml
+++ b/src/Views/Repository.axaml
@@ -617,6 +617,7 @@
                     BorderThickness="0"
                     SelectedIndex="{Binding SearchCommitContext.Method, Mode=TwoWay}">
             <ComboBox.Items>
+              <TextBlock Text="{DynamicResource Text.Repository.Search.ByAll}"/>
               <TextBlock Text="{DynamicResource Text.Repository.Search.BySHA}"/>
               <TextBlock Text="{DynamicResource Text.Repository.Search.ByAuthor}"/>
               <TextBlock Text="{DynamicResource Text.Repository.Search.ByMessage}"/>
@@ -628,7 +629,7 @@
           <CheckBox Height="24"
                     Margin="4,0,0,0"
                     IsChecked="{Binding SearchCommitContext.OnlySearchCurrentBranch, Mode=TwoWay}"
-                    IsVisible="{Binding SearchCommitContext.Method, Converter={x:Static c:IntConverters.IsGreaterThanZero}}">
+                    IsVisible="{Binding SearchCommitContext.Method, Converter={x:Static c:IntConverters.IsNotOne}}">
             <TextBlock Text="{DynamicResource Text.Repository.Search.InCurrentBranch}"/>
           </CheckBox>
         </StackPanel>


### PR DESCRIPTION
# Summary
This PR adds a "fulltext" search capability to perform a unified search across multiple commit fields at once, which was refused a year ago in #985 due to time constraints.

# How & why
Git has no bult-in logical "OR" `--grep`/`--author`/`--committer` in a single invocation, so the new `All` method (now the default) runs the field queries separately, plus an exact-SHA lookup, and merges the deduplicated results sorted by commit time. Adds an internal-only `ByCommitter` query mode to power it.

# Disclaimer
This was done with the help of Claude, as I have not done any C# development in the last 8 years. Feel free to reject on maintainability concerns.