### PR TITLE
fix: only start tab drag on left mouse button press

### DIFF
--- a/src/Views/LauncherTabBar.axaml.cs
+++ b/src/Views/LauncherTabBar.axaml.cs
@@ -222,9 +222,14 @@ namespace SourceGit.Views
                     (DataContext as ViewModels.Launcher)?.CloseTab(page);
                     e.Handled = true;
                 }
-                else
+                else if (point.Properties.IsLeftButtonPressed)
                 {
                     _pressedTabEvent = e;
+                    _startDragTab = false;
+                }
+                else
+                {
+                    _pressedTabEvent = null;
                     _startDragTab = false;
                 }
             }


### PR DESCRIPTION
Right-clicking a tab was recorded as the drag origin. Since the context menu marks PointerReleased as handled, the release handler never cleared it, so the next pointer move over a tab started an accidental drag and left a stuck grab cursor.


https://github.com/user-attachments/assets/32004e32-f72e-436c-92af-a75caae8b776

