### PR TITLE
fix: prefer exact match over suffix match when auto-selecting tracking branch for worktree

### DIFF
--- a/src/ViewModels/AddWorktree.cs
+++ b/src/ViewModels/AddWorktree.cs
@@ -137,7 +137,8 @@ namespace SourceGit.ViewModels
             var name = GetBranchName(true);
             if (!string.IsNullOrEmpty(name))
             {
-                var remoteBranch = RemoteBranches.Find(b => b.Name.Equals(name, StringComparison.Ordinal) || b.Name.EndsWith("/" + name, StringComparison.Ordinal));
+                var remoteBranch = RemoteBranches.Find(b => b.Name.Equals(name, StringComparison.Ordinal));
+                remoteBranch ??= RemoteBranches.Find(b => b.Name.EndsWith("/" + name, StringComparison.Ordinal));
                 if (remoteBranch != null)
                 {
                     SelectedTrackingBranch = remoteBranch;

--- a/src/ViewModels/AddWorktree.cs
+++ b/src/ViewModels/AddWorktree.cs
@@ -137,7 +137,14 @@ namespace SourceGit.ViewModels
             var name = GetBranchName(true);
             if (!string.IsNullOrEmpty(name))
             {
-                var remoteBranch = RemoteBranches.Find(b => b.Name.EndsWith(name, StringComparison.Ordinal));
+                var remoteBranch = RemoteBranches.Find(b => b.Name.Equals(name, StringComparison.Ordinal));
+                if (remoteBranch != null)
+                {
+                    SelectedTrackingBranch = remoteBranch;
+                    return;
+                }
+
+                remoteBranch = RemoteBranches.Find(b => b.Name.EndsWith(name, StringComparison.Ordinal));
                 if (remoteBranch != null)
                 {
                     SelectedTrackingBranch = remoteBranch;

--- a/src/ViewModels/AddWorktree.cs
+++ b/src/ViewModels/AddWorktree.cs
@@ -137,14 +137,7 @@ namespace SourceGit.ViewModels
             var name = GetBranchName(true);
             if (!string.IsNullOrEmpty(name))
             {
-                var remoteBranch = RemoteBranches.Find(b => b.Name.Equals(name, StringComparison.Ordinal));
-                if (remoteBranch != null)
-                {
-                    SelectedTrackingBranch = remoteBranch;
-                    return;
-                }
-
-                remoteBranch = RemoteBranches.Find(b => b.Name.EndsWith(name, StringComparison.Ordinal));
+                var remoteBranch = RemoteBranches.Find(b => b.Name.Equals(name, StringComparison.Ordinal) || b.Name.EndsWith("/" + name, StringComparison.Ordinal));
                 if (remoteBranch != null)
                 {
                     SelectedTrackingBranch = remoteBranch;


### PR DESCRIPTION
When adding a worktree with an existing local branch and enabling "Set Upstream Tracking Branch", the `AutoSelectTrackingBranch()` method used `EndsWith` to match remote branches against the local branch name. This caused unintended matches — for example, local branch `smart_build` would match `fix_smart_build` instead of the exact match `smart_build`.

This commit fixes the logic by:
1. First attempting an **exact match** (`Equals`) against remote branch names
2. Falling back to the original **suffix match** (`EndsWith`) only if no exact match is found
3. Keeping `RemoteBranches[0]` as the final fallback