### PR TITLE
fix: account for amend when generating AI commit message

### DIFF
--- a/src/AI/Agent.cs
+++ b/src/AI/Agent.cs
@@ -14,7 +14,7 @@ namespace SourceGit.AI
             _service = service;
         }
 
-        public async Task GenerateCommitMessageAsync(string repo, string currentBranch, string changeList, Action<string> onUpdate, CancellationToken cancellation)
+        public async Task GenerateCommitMessageAsync(string repo, string currentBranch, string changeList, string amendParent, Action<string> onUpdate, CancellationToken cancellation)
         {
             var chatClient = _service.GetChatClient();
             if (chatClient == null)
@@ -95,7 +95,7 @@ namespace SourceGit.AI
 
                             foreach (var call in completion.ToolCalls)
                             {
-                                var result = await ChatTools.ProcessAsync(call, onUpdate);
+                                var result = await ChatTools.ProcessAsync(call, onUpdate, amendParent);
                                 messages.Add(result);
                             }
 

--- a/src/AI/ChatTools.cs
+++ b/src/AI/ChatTools.cs
@@ -32,7 +32,7 @@ namespace SourceGit.AI
             }
             """)), false);
 
-        public static async Task<ToolChatMessage> ProcessAsync(ChatToolCall call, Action<string> output)
+        public static async Task<ToolChatMessage> ProcessAsync(ChatToolCall call, Action<string> output, string amendParent)
         {
             using var doc = JsonDocument.Parse(call.FunctionArguments);
 
@@ -49,7 +49,7 @@ namespace SourceGit.AI
                 output?.Invoke($"Read changes in file: {filePath.GetString()}");
 
                 var orgFilePath = hasOriginalFile ? originalFilePath.GetString() : string.Empty;
-                var rs = await new Commands.GetFileChangeForAI(repoPath.GetString(), filePath.GetString(), orgFilePath).ReadAsync();
+                var rs = await new Commands.GetFileChangeForAI(repoPath.GetString(), filePath.GetString(), orgFilePath, amendParent).ReadAsync();
                 var message = rs.IsSuccess ? rs.StdOut : string.Empty;
                 return new ToolChatMessage(call.Id, message);
             }

--- a/src/Commands/GetFileChangeForAI.cs
+++ b/src/Commands/GetFileChangeForAI.cs
@@ -6,13 +6,16 @@ namespace SourceGit.Commands
 {
     public class GetFileChangeForAI : Command
     {
-        public GetFileChangeForAI(string repo, string file, string originalFile)
+        public GetFileChangeForAI(string repo, string file, string originalFile, string amendParent)
         {
             WorkingDirectory = repo;
             Context = repo;
 
             var builder = new StringBuilder();
-            builder.Append("diff --no-color --no-ext-diff --diff-algorithm=minimal --cached -- ");
+            builder.Append("diff --no-color --no-ext-diff --diff-algorithm=minimal --cached ");
+            if (!string.IsNullOrEmpty(amendParent))
+                builder.Append(amendParent).Append(' ');
+            builder.Append("-- ");
             if (!string.IsNullOrEmpty(originalFile) && !file.Equals(originalFile, StringComparison.Ordinal))
                 builder.Append(originalFile.Quoted()).Append(' ');
             builder.Append(file.Quoted());

--- a/src/ViewModels/AIAssistant.cs
+++ b/src/ViewModels/AIAssistant.cs
@@ -49,6 +49,8 @@ namespace SourceGit.ViewModels
             foreach (var c in changes)
                 SerializeChange(c, builder);
             _changeList = builder.ToString();
+
+            _amendParent = changes.Count > 0 ? changes[0].DataForAmend?.ParentSHA : null;
         }
 
         public async Task GenAsync()
@@ -71,7 +73,7 @@ namespace SourceGit.ViewModels
 
             try
             {
-                await agent.GenerateCommitMessageAsync(_repo.FullPath, currentBranchName, _changeList, message =>
+                await agent.GenerateCommitMessageAsync(_repo.FullPath, currentBranchName, _changeList, _amendParent, message =>
                 {
                     builder.AppendLine(message);
 
@@ -145,6 +147,7 @@ namespace SourceGit.ViewModels
         private readonly Repository _repo = null;
         private readonly AI.Service _service = null;
         private readonly string _changeList = null;
+        private readonly string _amendParent = null;
         private CancellationTokenSource _cancel = null;
         private bool _isGenerating = false;
         private string _text = string.Empty;


### PR DESCRIPTION
When "Amend" was checked, the AI commit-message generator ignored that context: it read each file's diff against HEAD, so it only saw the new staged changes and missed the content of the commit being amended, producing a message that discarded the previous intent.

Detect amend from the staged changes (which carry the previous commit's parent SHA in amend mode) and pass that parent down to the file-diff tool, so the model reads each file against the parent and sees the full resulting commit.