### PR TITLE
fix: shorten GetPipeName() output causing Unix crash

### DIFF
--- a/src/Models/IpcChannel.cs
+++ b/src/Models/IpcChannel.cs
@@ -74,7 +74,7 @@ namespace SourceGit.Models
             var dataDir = Native.OS.DataDir.Replace('\\', '/').TrimEnd('/');
             var hash = SHA256.HashData(Encoding.UTF8.GetBytes(dataDir));
             var hashStr = Convert.ToHexString(hash)[..16];
-            return $"SourceGitIPCChannel{Environment.UserName}_{hashStr}";
+            return $"SGit{Environment.UserName}_{hashStr}";
         }
 
         private async void StartServer()


### PR DESCRIPTION
This is a hotfix to combat the hard crash on unix machines which was introduced by e0e2ab6ce766af737110492c5c3d6612e763ed67

On Unix machines the NamedPipeServerStream is created with a `Path.GetTempPath()` and "CoreFXPipe_" prefix, causing the recent change to go over the maximum length of the pipename of 104 characters: [dotnet Unix PipeStream sourcecode](https://github.com/dotnet/runtime/blob/9f9485d11b6047bf9f9aefa0aa5e6c412a929a7c/src/libraries/System.IO.Pipes/src/System/IO/Pipes/PipeStream.Unix.cs#L217-L226).

**Note**
In the case of a long username this can still break as we now add an extra 16 characters from the hash to this pipe name.

Closes #2576 