### PR TITLE
fix(AddWorktree): exclude current branch and worktree-attached branches from selection

### DIFF
--- a/src/ViewModels/AddWorktree.cs
+++ b/src/ViewModels/AddWorktree.cs
@@ -80,9 +80,14 @@ namespace SourceGit.ViewModels
             foreach (var branch in repo.Branches)
             {
                 if (branch.IsLocal)
-                    LocalBranches.Add(branch);
+                {
+                    if (!branch.IsCurrent && !branch.HasWorktree)
+                        LocalBranches.Add(branch);
+                }
                 else
+                {
                     RemoteBranches.Add(branch);
+                }
             }
         }
 


### PR DESCRIPTION
When adding a new worktree via the "Add Worktree" dialog, the branch selection list includes all local branches unconditionally. Selecting a branch that is already checked out in the current repository or attached to another worktree causes Git to fail with a fatal error, e.g.: fatal: 'develop' is already used by worktree at 'E:/code/2026-07/sourcegit'

Filter out ineligible branches in `AddWorktree` constructor before adding them
to `LocalBranches`:

- **Current branch** (`branch.IsCurrent`) — excluded because it is already checked out in the active worktree.
- **Branches attached to another worktree** (`branch.HasWorktree`) — excluded because they are already in use by an existing worktree.