### PR TITLE
Fix silent startup failure on macOS when $TMPDIR is long

### DIFF
--- a/src/Models/IpcChannel.cs
+++ b/src/Models/IpcChannel.cs
@@ -20,12 +20,12 @@ namespace SourceGit.Models
             {
                 _singletonLock = File.Open(Path.Combine(Native.OS.DataDir, "process.lock"), FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None);
                 IsFirstInstance = true;
-                _server = new NamedPipeServerStream(
+                _server = WithShortTmpDir(() => new NamedPipeServerStream(
                     GetPipeName(),
                     PipeDirection.In,
                     -1,
                     PipeTransmissionMode.Byte,
-                    PipeOptions.Asynchronous | PipeOptions.CurrentUserOnly);
+                    PipeOptions.Asynchronous | PipeOptions.CurrentUserOnly));
                 _cancellationTokenSource = new CancellationTokenSource();
                 Task.Run(StartServer);
             }
@@ -39,7 +39,7 @@ namespace SourceGit.Models
         {
             try
             {
-                using (var client = new NamedPipeClientStream(".", GetPipeName(), PipeDirection.Out, PipeOptions.Asynchronous | PipeOptions.CurrentUserOnly))
+                using (var client = WithShortTmpDir(() => new NamedPipeClientStream(".", GetPipeName(), PipeDirection.Out, PipeOptions.Asynchronous | PipeOptions.CurrentUserOnly)))
                 {
                     client.Connect(1000);
                     if (!client.IsConnected)
@@ -75,6 +75,32 @@ namespace SourceGit.Models
             var hash = SHA256.HashData(Encoding.UTF8.GetBytes(dataDir));
             var hashStr = Convert.ToHexString(hash)[..16];
             return $"SourceGitIPCChannel{Environment.UserName}_{hashStr}";
+        }
+
+        // .NET's named pipes on non-Windows platforms are backed by a Unix domain
+        // socket created under Path.GetTempPath() (i.e. $TMPDIR). macOS assigns each
+        // user a long per-session TMPDIR (/var/folders/xx/<27 random chars>/T/), which
+        // combined with our pipe name routinely exceeds the 104-byte sun_path limit for
+        // AF_UNIX addresses. When that happens, NamedPipeServerStream/NamedPipeClientStream
+        // throw, IsFirstInstance silently becomes false, and the app exits immediately
+        // with no diagnostics - it looks like SourceGit simply refuses to start.
+        // Forcing a short TMPDIR just for the pipe path keeps the socket path short
+        // regardless of the platform's default temp directory.
+        private static T WithShortTmpDir<T>(Func<T> factory)
+        {
+            if (OperatingSystem.IsWindows())
+                return factory();
+
+            var original = Environment.GetEnvironmentVariable("TMPDIR");
+            try
+            {
+                Environment.SetEnvironmentVariable("TMPDIR", "/tmp");
+                return factory();
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("TMPDIR", original);
+            }
         }
 
         private async void StartServer()


### PR DESCRIPTION
## Summary

On macOS, SourceGit can fail to start with **zero visible feedback**: no window, no console output, no crash log, exit code 0. This reproduces reliably for users with a username longer than roughly 8 characters (i.e. most people), regardless of install method (Homebrew cask, the signed dmg from the website, or a local build).

## Root cause

`Models/IpcChannel.cs` uses a `NamedPipeServerStream`/`NamedPipeClientStream` for the single-instance check. On non-Windows platforms, .NET backs named pipes with a Unix domain socket placed under `Path.GetTempPath()` (`$TMPDIR`), prefixed internally with `CoreFxPipe_`.

macOS assigns every session a per-user `TMPDIR` shaped like `/var/folders/xx/<27 random chars>/T/` (~49 characters on its own). Combined with our pipe name (`SourceGitIPCChannel<username>_<hash16>`), the resulting path routinely exceeds the 104-byte `sun_path` limit for `AF_UNIX` addresses:

```
$TMPDIR (~49) + "CoreFxPipe_" (11) + "SourceGitIPCChannel" (19) + <username> + "_" + <hash16> (16)
```

That budget is already ~60 chars before the app-specific name even starts, leaving under ~44 chars for `SourceGitIPCChannel<username>_<hash16>` (36 fixed + username length) — so any username longer than ~8 characters overflows.

When the pipe creation throws, `IpcChannel`'s constructor catches it and sets `IsFirstInstance = false` (even though `IsFirstInstance` was already optimistically set `true` moments earlier and the process-lock file open — which doesn't hit this path length limit — succeeded fine). `App.axaml.cs`'s `TryLaunchAsNormal` then calls `Environment.Exit(0)` immediately, believing another instance is already running. Nothing is logged anywhere.

I confirmed this directly with a minimal repro (creating a `NamedPipeServerStream` with the exact same generated pipe name) — it throws `System.ArgumentOutOfRangeException: The path '.../CoreFxPipe_SourceGitIPCChannel<user>_<hash>' is of an invalid length for use with domain sockets on this platform. The length must be between 1 and 104 characters, inclusive.`

## Fix

Force a short, guaranteed-valid `TMPDIR` just around the `NamedPipeServerStream`/`NamedPipeClientStream` construction calls (both the server side in the constructor and the client side in `SendToFirstInstance`, since both independently resolve the socket path), restoring the original value afterward. This keeps the resulting socket path short regardless of the platform's actual temp directory, on any Unix platform (guarded with `OperatingSystem.IsWindows()` since Windows named pipes don't use `TMPDIR` at all).

## Test plan

- [x] Built from source (`dotnet build`) and confirmed the fix compiles cleanly (0 warnings/errors)
- [x] Ran two instances back-to-back with the default (long) macOS `TMPDIR` and no workaround:
  - Instance A starts and stays running (previously it would self-exit within ~50ms)
  - Instance B correctly detects instance A as already running and exits cleanly, without disturbing instance A (real single-instance behavior working, not just "doesn't crash")
- [x] Published a self-contained `osx-arm64` build (`dotnet publish -r osx-arm64`) with the official `build/scripts/package.osx-app.sh` packaging and confirmed the resulting `.app` launches correctly via `open`/Finder/Dock (the actual user-facing launch path), with no environment workaround needed