### PR TITLE
feat: show total added and deleted lines in commit changes view

### DIFF
--- a/src/Commands/QueryCommitStatistic.cs
+++ b/src/Commands/QueryCommitStatistic.cs
@@ -1,0 +1,42 @@
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+
+namespace SourceGit.Commands
+{
+    public partial class QueryCommitStatistic : Command
+    {
+        [GeneratedRegex(@"(\d+) files? changed(?:, (\d+) insertions?\(\+\))?(?:, (\d+) deletions?\(-\))?")]
+        private static partial Regex REG_SHORTSTAT();
+
+        public QueryCommitStatistic(string repo, string parentRevision, string targetRevision)
+        {
+            WorkingDirectory = repo;
+            Context = repo;
+            Args = $"--no-optional-locks diff --shortstat --no-color {parentRevision} {targetRevision}";
+        }
+
+        public async Task<(int files, int added, int deleted)> GetResultAsync()
+        {
+            var rs = await ReadToEndAsync().ConfigureAwait(false);
+            if (!rs.IsSuccess || string.IsNullOrWhiteSpace(rs.StdOut))
+                return (0, 0, 0);
+
+            var files = 0;
+            var added = 0;
+            var deleted = 0;
+
+            var match = REG_SHORTSTAT().Match(rs.StdOut.Trim());
+            if (match.Success)
+            {
+                if (match.Groups[1].Success)
+                    files = int.Parse(match.Groups[1].Value);
+                if (match.Groups[2].Success)
+                    added = int.Parse(match.Groups[2].Value);
+                if (match.Groups[3].Success)
+                    deleted = int.Parse(match.Groups[3].Value);
+            }
+
+            return (files, added, deleted);
+        }
+    }
+}

--- a/src/Resources/Locales/en_US.axaml
+++ b/src/Resources/Locales/en_US.axaml
@@ -176,6 +176,8 @@
   <x:String x:Key="Text.CommitCM.SaveAsPatch" xml:space="preserve">Save as Patch...</x:String>
   <x:String x:Key="Text.CommitDetail.Changes" xml:space="preserve">CHANGES</x:String>
   <x:String x:Key="Text.CommitDetail.Changes.Count" xml:space="preserve">changed file(s)</x:String>
+  <x:String x:Key="Text.CommitDetail.Changes.Added" xml:space="preserve">added</x:String>
+  <x:String x:Key="Text.CommitDetail.Changes.Deleted" xml:space="preserve">deleted</x:String>
   <x:String x:Key="Text.CommitDetail.Changes.Search" xml:space="preserve">Search Changes...</x:String>
   <x:String x:Key="Text.CommitDetail.CollapseToBottom" xml:space="preserve">Collapse details</x:String>
   <x:String x:Key="Text.CommitDetail.Files" xml:space="preserve">FILES</x:String>

--- a/src/Resources/Locales/zh_CN.axaml
+++ b/src/Resources/Locales/zh_CN.axaml
@@ -179,7 +179,9 @@
   <x:String x:Key="Text.CommitCM.Revert" xml:space="preserve">回滚此提交...</x:String>
   <x:String x:Key="Text.CommitCM.SaveAsPatch" xml:space="preserve">另存为补丁...</x:String>
   <x:String x:Key="Text.CommitDetail.Changes" xml:space="preserve">变更对比</x:String>
+  <x:String x:Key="Text.CommitDetail.Changes.Added" xml:space="preserve">新增</x:String>
   <x:String x:Key="Text.CommitDetail.Changes.Count" xml:space="preserve">个文件发生变更</x:String>
+  <x:String x:Key="Text.CommitDetail.Changes.Deleted" xml:space="preserve">删除</x:String>
   <x:String x:Key="Text.CommitDetail.Changes.Search" xml:space="preserve">查找变更...</x:String>
   <x:String x:Key="Text.CommitDetail.CollapseToBottom" xml:space="preserve">折叠详细面板</x:String>
   <x:String x:Key="Text.CommitDetail.Files" xml:space="preserve">文件列表</x:String>

--- a/src/Resources/Locales/zh_TW.axaml
+++ b/src/Resources/Locales/zh_TW.axaml
@@ -179,7 +179,9 @@
   <x:String x:Key="Text.CommitCM.Revert" xml:space="preserve">復原此提交...</x:String>
   <x:String x:Key="Text.CommitCM.SaveAsPatch" xml:space="preserve">另存為修補檔 (patch)...</x:String>
   <x:String x:Key="Text.CommitDetail.Changes" xml:space="preserve">變更對比</x:String>
+  <x:String x:Key="Text.CommitDetail.Changes.Added" xml:space="preserve">新增</x:String>
   <x:String x:Key="Text.CommitDetail.Changes.Count" xml:space="preserve">個檔案已變更</x:String>
+  <x:String x:Key="Text.CommitDetail.Changes.Deleted" xml:space="preserve">刪除</x:String>
   <x:String x:Key="Text.CommitDetail.Changes.Search" xml:space="preserve">搜尋變更...</x:String>
   <x:String x:Key="Text.CommitDetail.CollapseToBottom" xml:space="preserve">收合詳細面板</x:String>
   <x:String x:Key="Text.CommitDetail.Files" xml:space="preserve">檔案列表</x:String>

--- a/src/ViewModels/CommitDetail.cs
+++ b/src/ViewModels/CommitDetail.cs
@@ -106,6 +106,18 @@ namespace SourceGit.ViewModels
             }
         }
 
+        public int TotalAddedLines
+        {
+            get => _totalAddedLines;
+            set => SetProperty(ref _totalAddedLines, value);
+        }
+
+        public int TotalDeletedLines
+        {
+            get => _totalDeletedLines;
+            set => SetProperty(ref _totalDeletedLines, value);
+        }
+
         public DiffContext DiffContext
         {
             get => _diffContext;
@@ -543,6 +555,22 @@ namespace SourceGit.ViewModels
                     });
                 }
             }, token);
+
+            Task.Run(async () =>
+            {
+                var (_, added, deleted) = await new Commands.QueryCommitStatistic(_repo.FullPath, _commit.FirstParentToCompare, _commit.SHA)
+                    .GetResultAsync()
+                    .ConfigureAwait(false);
+
+                if (!token.IsCancellationRequested)
+                {
+                    Dispatcher.UIThread.Post(() =>
+                    {
+                        TotalAddedLines = added;
+                        TotalDeletedLines = deleted;
+                    });
+                }
+            }, token);
         }
 
         private async Task<Models.InlineElementCollector> ParseInlinesInMessageAsync(string message)
@@ -750,5 +778,7 @@ namespace SourceGit.ViewModels
         private List<string> _revisionFileSearchSuggestion = null;
         private bool _canOpenRevisionFileWithDefaultEditor = false;
         private Vector _scrollOffset = Vector.Zero;
+        private int _totalAddedLines = 0;
+        private int _totalDeletedLines = 0;
     }
 }

--- a/src/Views/CommitChanges.axaml
+++ b/src/Views/CommitChanges.axaml
@@ -56,12 +56,32 @@
 
       <!-- Summary -->
       <Border Grid.Row="2" BorderBrush="{DynamicResource Brush.Border2}" BorderThickness="1,0,1,1" Background="Transparent">
-        <TextBlock Margin="4,0,0,0"
-                   Foreground="{DynamicResource Brush.FG2}"
-                   HorizontalAlignment="Left" VerticalAlignment="Center">
-          <Run Text="{Binding Changes.Count, Mode=OneWay}" FontWeight="Bold"/>
-          <Run Text="{DynamicResource Text.CommitDetail.Changes.Count}"/>
-        </TextBlock>
+        <Grid Margin="4,0,0,0" VerticalAlignment="Center">
+          <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="Auto"/>
+            <ColumnDefinition Width="*"/>
+          </Grid.ColumnDefinitions>
+
+          <TextBlock Grid.Column="0"
+                     Foreground="{DynamicResource Brush.FG2}"
+                     HorizontalAlignment="Left" VerticalAlignment="Center">
+            <Run Text="{Binding Changes.Count, Mode=OneWay}" FontWeight="Bold"/>
+            <Run Text="{DynamicResource Text.CommitDetail.Changes.Count}"/>
+          </TextBlock>
+
+          <StackPanel Grid.Column="1" Orientation="Horizontal" HorizontalAlignment="Right" Margin="4,0,4,0" Spacing="6">
+            <TextBlock Foreground="Green" VerticalAlignment="Center">
+              <Run Text="+" FontWeight="Bold"/>
+              <Run Text="{Binding TotalAddedLines}" FontWeight="Bold"/>
+              <Run Text="{DynamicResource Text.CommitDetail.Changes.Added}"/>
+            </TextBlock>
+            <TextBlock Foreground="Red" VerticalAlignment="Center">
+              <Run Text="-" FontWeight="Bold"/>
+              <Run Text="{Binding TotalDeletedLines}" FontWeight="Bold"/>
+              <Run Text="{DynamicResource Text.CommitDetail.Changes.Deleted}"/>
+            </TextBlock>
+          </StackPanel>
+        </Grid>
       </Border>
     </Grid>
 


### PR DESCRIPTION
This PR adds a summary of total added and deleted lines in the commit detail **Changes** tab, shown alongside the existing file count in the bottom bar.

## Changes

- **New `QueryCommitStatistic` command** (`src/Commands/QueryCommitStatistic.cs`): runs `git diff --shortstat` to get total files changed, added lines, and deleted lines for a commit.
- **ViewModel** (`src/ViewModels/CommitDetail.cs`): added `TotalAddedLines` / `TotalDeletedLines` properties, fetched asynchronously in `Refresh()` alongside the existing change list task.
- **View** (`src/Views/CommitChanges.axaml`): extended the summary bar from a single `TextBlock` to a two-column `Grid` — file count on the left, `+N added  -M deleted` on the right (colors match `DiffView.axaml` conventions).
- **Localization**: added `Text.CommitDetail.Changes.Added` and `Text.CommitDetail.Changes.Deleted` keys to `en_US.axaml`, `zh_CN.axaml`, and `zh_TW.axaml`.


