### PR TITLE
fix: build folder path from Backend.Path and silence null-revision bindings in revision file tree

### DIFF
--- a/src/Views/Blame.axaml
+++ b/src/Views/Blame.axaml
@@ -116,10 +116,10 @@
                      FontWeight="Bold"
                      Margin="0,0,6,0"
                      FontFamily="{DynamicResource Fonts.Monospace}"
-                     Text="{Binding Revision.SHA, Converter={x:Static c:StringConverters.ToShortSHA}, Mode=OneWay}"/>
+                     Text="{Binding Revision.SHA, Converter={x:Static c:StringConverters.ToShortSHA}, Mode=OneWay, FallbackValue={x:Null}}"/>
 
           <TextBlock Grid.Column="1"
-                     Text="{Binding Revision.Subject}"
+                     Text="{Binding Revision.Subject, FallbackValue={x:Null}}"
                      TextTrimming="CharacterEllipsis"/>
         </Grid>
       </Border>

--- a/src/Views/RevisionFileTreeView.axaml.cs
+++ b/src/Views/RevisionFileTreeView.axaml.cs
@@ -312,7 +312,7 @@ namespace SourceGit.Views
 
                         last.Add(folder);
                         last = folder.Children;
-                        prefix = folder.Backend + "/";
+                        prefix = folder.Backend.Path + "/";
                     }
 
                     last.Add(new ViewModels.RevisionFileTreeNode

--- a/src/Views/RevisionFiles.axaml
+++ b/src/Views/RevisionFiles.axaml
@@ -109,7 +109,7 @@
 
       <!-- File Tree -->
       <Border Grid.Row="1" Margin="0,4,0,0" BorderBrush="{DynamicResource Brush.Border2}" BorderThickness="1" Background="{DynamicResource Brush.Contents}">
-        <v:RevisionFileTreeView x:Name="FileTree" Revision="{Binding Commit.SHA}" SearchRequested="OnToggleSearch"/>
+        <v:RevisionFileTreeView x:Name="FileTree" Revision="{Binding Commit.SHA, FallbackValue={x:Null}}" SearchRequested="OnToggleSearch"/>
       </Border>
     </Grid>
 


### PR DESCRIPTION
- RevisionFileTreeView.SetSearchResultAsync: concatenate Backend.Path instead of stringifying the Backend Object, whose default ToString() leaked "SourceGit.Models.Object/" into child node paths and corrupted the DirHistories window title.

- RevisionFiles / Blame: add FallbackValue={x:Null} to Commit.SHA / Revision.SHA. These commits are loaded asynchronously and are null when the view first binds, which logged "Value is null" binding errors.

Before:
<img width="459" height="236" alt="image" src="https://github.com/user-attachments/assets/758f7e3b-8448-4225-9d28-bd953891c602" />
<img width="882" height="279" alt="image" src="https://github.com/user-attachments/assets/a1181a3f-b90c-4206-96f8-cebd0a50f789" />
