### PR TITLE
fix: off-by-one in commit message subject length calculation

### DIFF
--- a/src/Views/CommitMessageToolBox.axaml.cs
+++ b/src/Views/CommitMessageToolBox.axaml.cs
@@ -243,7 +243,7 @@ namespace SourceGit.Views
                     }
                 }
 
-                if (lastLineStart < lastNonLineBreakCharIdx)
+                if (lastLineStart <= lastNonLineBreakCharIdx)
                 {
                     var validCharLen = text.Substring(lastLineStart).TrimEnd().Length;
                     if (subjectLen > 0)


### PR DESCRIPTION
The trailing unterminated line was only counted when
`lastLineStart < lastNonLineBreakCharIdx`, so a 1-character line was
skipped until a second character was typed. Fixed by changing the
comparison to `<=`.