### PR TITLE
fix: remove stray placeholder in de_DE MergeConflictEditor.Title translation

### DIFF
--- a/src/Resources/Locales/de_DE.axaml
+++ b/src/Resources/Locales/de_DE.axaml
@@ -532,7 +532,7 @@ $1, $2, … Werte der Eingabe-Steuerelemente</x:String>
   <x:String x:Key="Text.MergeConflictEditor.Result" xml:space="preserve">ERGEBNIS</x:String>
   <x:String x:Key="Text.MergeConflictEditor.SaveAndStage" xml:space="preserve">SPEICHERN &amp; STAGEN</x:String>
   <x:String x:Key="Text.MergeConflictEditor.Theirs" xml:space="preserve">DEREN</x:String>
-  <x:String x:Key="Text.MergeConflictEditor.Title" xml:space="preserve">Merge-Konflikt – {0}</x:String>
+  <x:String x:Key="Text.MergeConflictEditor.Title" xml:space="preserve">Merge-Konflikte</x:String>
   <x:String x:Key="Text.MergeConflictEditor.UnsavedChanges" xml:space="preserve">Ungespeicherte Änderungen verwerfen?</x:String>
   <x:String x:Key="Text.MergeConflictEditor.UseMine" xml:space="preserve">MEINE VERWENDEN</x:String>
   <x:String x:Key="Text.MergeConflictEditor.UseTheirs" xml:space="preserve">DEREN VERWENDEN</x:String>


### PR DESCRIPTION
The German translation read `Merge-Konflikt – {0}`, but the key is bound via `DynamicResource` in `MergeConflictEditor.axaml` (lines 14 and 31), so `string.Format` is never applied and the literal `{0}` was rendered in the window title.

en_US has never had a placeholder for this key, and de_DE was the only one of the 13 locales defining it that contained one. Also switches to plural, matching en_US and every other locale whose grammar marks number.