### PR TITLE
feat: workspace lookup before opening from CLI

### DIFF
--- a/src/ViewModels/Launcher.cs
+++ b/src/ViewModels/Launcher.cs
@@ -87,6 +87,7 @@ namespace SourceGit.ViewModels
                 {
                     var node = Preferences.Instance.FindOrAddNodeByRepositoryPath(repo, null, false);
                     Welcome.Instance.Refresh();
+                    TrySwitchToContainingWorkspace(node);
                     OpenRepositoryInTab(node, null);
                     return true;
                 }
@@ -96,6 +97,7 @@ namespace SourceGit.ViewModels
                 {
                     var node = Preferences.Instance.FindOrAddNodeByRepositoryPath(test.StdOut.Trim(), null, false);
                     Welcome.Instance.Refresh();
+                    TrySwitchToContainingWorkspace(node);
                     OpenRepositoryInTab(node, null);
                     return true;
                 }
@@ -110,6 +112,16 @@ namespace SourceGit.ViewModels
             }
 
             return false;
+        }
+
+        private void TrySwitchToContainingWorkspace(RepositoryNode node)
+        {
+            if (ActiveWorkspace.Repositories.Contains(node.Id))
+                return;
+
+            var owner = Preferences.Instance.Workspaces.Find(w => w.Repositories.Contains(node.Id));
+            if (owner != null)
+                SwitchWorkspace(owner);
         }
 
         public void CloseAll()


### PR DESCRIPTION
This PR improves the command line repo opening by looking up the repository among the ones already opened in all workspaces.
Tests done on win 11, with 3 workspaces configured:
1. Program closed → CLI-open repo in a different workspace — works
2. Program closed → CLI-open a different repo already in the same workspace — works
3. Program open → CLI-open repo in a different workspace — works
4. Program open → CLI-open a different repo in the same workspace — works
5. Multi-tab target workspace — CLI-open correctly focused the right tab within the target workspace, not just whatever tab was last active there
6. Bare repository, using the test repo at C:\Development\test-bare-repo.git — switched workspace correctly, tested both closed and already-open app states
7. Case-insensitive path (CLI invoked with a lowercase path against a repo added with different casing) — matched correctly
8. Persistence after CLI switch — relaunching normally afterward opens into the workspace the CLI switch left you in, as expected