### PR TITLE
fix(windows): refresh terminal environment from registry on launch

### DIFF
--- a/src/Native/Windows.cs
+++ b/src/Native/Windows.cs
@@ -159,6 +159,7 @@ namespace SourceGit.Native
             startInfo.WorkingDirectory = cwd;
             startInfo.FileName = terminal;
             startInfo.Arguments = args;
+            startInfo.UseShellExecute = true;
             Process.Start(startInfo);
         }
 

--- a/src/Native/Windows.cs
+++ b/src/Native/Windows.cs
@@ -159,8 +159,39 @@ namespace SourceGit.Native
             startInfo.WorkingDirectory = cwd;
             startInfo.FileName = terminal;
             startInfo.Arguments = args;
-            startInfo.UseShellExecute = true;
+            RefreshEnvFromRegistry(startInfo);
             Process.Start(startInfo);
+        }
+
+        private static void RefreshEnvFromRegistry(ProcessStartInfo startInfo)
+        {
+            // Read latest machine and user environment from registry, so that
+            // environment changes made after SourceGit started are picked up.
+            var machine = Environment.GetEnvironmentVariables(EnvironmentVariableTarget.Machine);
+            var user = Environment.GetEnvironmentVariables(EnvironmentVariableTarget.User);
+
+            foreach (System.Collections.DictionaryEntry kv in machine)
+                startInfo.Environment[kv.Key.ToString()] = kv.Value?.ToString() ?? "";
+
+            foreach (System.Collections.DictionaryEntry kv in user)
+            {
+                var key = kv.Key.ToString();
+                var value = kv.Value?.ToString() ?? "";
+                if (string.Equals(key, "Path", StringComparison.OrdinalIgnoreCase) && startInfo.Environment.TryGetValue(key, out var existing))
+                    startInfo.Environment[key] = existing + ";" + value;
+                else
+                    startInfo.Environment[key] = value;
+            }
+
+            // Preserve dynamic process-only variables not stored in registry
+            // (e.g. TEMP, USERNAME, COMPUTERNAME, PROCESSOR_*)
+            var proc = Environment.GetEnvironmentVariables(EnvironmentVariableTarget.Process);
+            foreach (System.Collections.DictionaryEntry kv in proc)
+            {
+                var key = kv.Key.ToString();
+                if (!startInfo.Environment.ContainsKey(key))
+                    startInfo.Environment[key] = kv.Value?.ToString() ?? "";
+            }
         }
 
         public void OpenInFileManager(string path)


### PR DESCRIPTION
## Problem

When SourceGit is running and the user installs new CLI tools (Node.js, Python, Rust, etc.) or modifies system/user environment variables, clicking "Open in Terminal" opens a terminal with the **stale** environment snapshot from when SourceGit was started. The new PATH entries are missing, so commands from newly installed tools are not found.

This affects all Windows terminal types: cmd, pwsh, git-bash, and Windows Terminal.

## Root Cause

`Process.Start` with default `UseShellExecute = false` uses `CreateProcess`, which inherits the parent process's Environment Block — the snapshot from SourceGit's startup time. `UseShellExecute = true` also does not solve this, as `ShellExecuteEx` with NULL `lpEnvironment` also inherits the parent environment.

## Solution

Add `RefreshEnvFromRegistry` method that re-reads the latest environment from the Windows registry each time "Open in Terminal" is clicked, and sets a custom `ProcessStartInfo.Environment` for the child process.

### Algorithm

1. Read Machine env from registry (`HKLM\...\Environment`)
2. Read User env from registry (`HKCU\Environment`) — overrides Machine, PATH is **appended** not replaced
3. Preserve dynamic process-only variables (TEMP, USERNAME, COMPUTERNAME, etc.) that are not in registry

