### PR TITLE
fix: side-by-side diff scroll desync on hidden-tab rebuild and tab switch

### DIFF
--- a/src/Views/TextDiffView.axaml.cs
+++ b/src/Views/TextDiffView.axaml.cs
@@ -1014,6 +1014,8 @@ namespace SourceGit.Views
         {
             base.OnLoaded(e);
 
+            ApplyTemplate();
+
             _scrollViewer = this.FindDescendantOfType<ScrollViewer>();
             if (_scrollViewer != null)
             {
@@ -1198,6 +1200,8 @@ namespace SourceGit.Views
         protected override void OnLoaded(RoutedEventArgs e)
         {
             base.OnLoaded(e);
+
+            ApplyTemplate();
 
             _scrollViewer = this.FindDescendantOfType<ScrollViewer>();
             if (_scrollViewer != null)


### PR DESCRIPTION
## Why  
`OnLoaded` + `FindDescendantOfType<ScrollViewer>()` assumed the control  
template was already applied, which broke in two cases:  
1. Presenter rebuilt while its container is hidden (`IsVisible=false`),  
   e.g. toggling the shared `Preferences.UseSideBySideDiff` from the  
   other LOCAL/HISTORY tab — `Loaded` fires but template application  
   (tied to layout) is skipped for hidden subtrees.  
2. Commit-detail tabs (Info/Changes/Files) reuse the same presenter  
   instance across tab switches — clearing `_scrollViewer` to null in  
   `OnUnloaded` permanently lost the binding since `OnApplyTemplate`  
   only runs once per instance.  
  
## Fix  
Move `ScrollViewer` lookup + offset binding into `OnApplyTemplate`  
(matching `MergeConflictTextPresenter`), force `ApplyTemplate()` in  
`OnLoaded`, and stop resetting `_scrollViewer` in `OnUnloaded`.  
  
## Test  
1. Toggle Side-by-Side in LOCAL/HISTORY tab, switch to the other — stays synced.  
2. Commit detail: Changes → Info/Files → back to Changes — stays synced.