### PR TITLE
feat(launcher): open submodule tabs next to parent with prefixed titles

### DIFF
--- a/src/ViewModels/Launcher.cs
+++ b/src/ViewModels/Launcher.cs
@@ -296,7 +296,7 @@ namespace SourceGit.ViewModels
                 IsUnmanaged = true
             };
 
-            OpenRepositoryInTab(node, null);
+            OpenRepositoryInTab(node, page);
         }
 
         public void OpenRepositoryInTab(RepositoryNode node, LauncherPage page)
@@ -353,6 +353,13 @@ namespace SourceGit.ViewModels
                     page.Node = node;
                     page.Data = repo;
                 }
+            }
+            else if (page.Node.IsRepository)
+            {
+                var parent = page;
+                page = new LauncherPage(node, repo);
+                var parentIdx = Pages.IndexOf(parent);
+                Pages.Insert(parentIdx + 1, page);
             }
             else
             {

--- a/src/ViewModels/Launcher.cs
+++ b/src/ViewModels/Launcher.cs
@@ -301,10 +301,21 @@ namespace SourceGit.ViewModels
 
         public void OpenRepositoryInTab(RepositoryNode node, LauncherPage page)
         {
+            // Compose submodule title from current parent name
+            if (page != null && page.Node.IsRepository)
+            {
+                var baseName = Path.GetFileName(node.Id);
+                node.Name = $"{page.Node.Name} : {baseName}";
+            }
+
             foreach (var one in Pages)
             {
                 if (one.Node.Id == node.Id)
                 {
+                    // Update title in case parent was renamed
+                    if (page != null && page.Node.IsRepository)
+                        one.Node.Name = node.Name;
+
                     ActivePage = one;
                     return;
                 }
@@ -357,6 +368,7 @@ namespace SourceGit.ViewModels
             else if (page.Node.IsRepository)
             {
                 var parent = page;
+                node.Name = $"{parent.Node.Name} : {node.Name}";
                 page = new LauncherPage(node, repo);
                 var parentIdx = Pages.IndexOf(parent);
                 Pages.Insert(parentIdx + 1, page);

--- a/src/ViewModels/Launcher.cs
+++ b/src/ViewModels/Launcher.cs
@@ -305,7 +305,6 @@ namespace SourceGit.ViewModels
             {
                 if (one.Node.Id == node.Id)
                 {
-                    // Update title in case parent was renamed
                     if (page != null && page.Node.IsRepository)
                         one.Node.Name = ComposeSubmoduleTitle(page, node);
 

--- a/src/ViewModels/Launcher.cs
+++ b/src/ViewModels/Launcher.cs
@@ -301,20 +301,13 @@ namespace SourceGit.ViewModels
 
         public void OpenRepositoryInTab(RepositoryNode node, LauncherPage page)
         {
-            // Compose submodule title from current parent name
-            if (page != null && page.Node.IsRepository)
-            {
-                var baseName = Path.GetFileName(node.Id);
-                node.Name = $"{page.Node.Name} : {baseName}";
-            }
-
             foreach (var one in Pages)
             {
                 if (one.Node.Id == node.Id)
                 {
                     // Update title in case parent was renamed
                     if (page != null && page.Node.IsRepository)
-                        one.Node.Name = node.Name;
+                        one.Node.Name = ComposeSubmoduleTitle(page, node);
 
                     ActivePage = one;
                     return;
@@ -368,7 +361,7 @@ namespace SourceGit.ViewModels
             else if (page.Node.IsRepository)
             {
                 var parent = page;
-                node.Name = $"{parent.Node.Name} : {node.Name}";
+                node.Name = ComposeSubmoduleTitle(parent, node);
                 page = new LauncherPage(node, repo);
                 var parentIdx = Pages.IndexOf(parent);
                 Pages.Insert(parentIdx + 1, page);
@@ -485,6 +478,12 @@ namespace SourceGit.ViewModels
 
             Title = builder.ToString();
             CommandPalette = null;
+        }
+
+        private static string ComposeSubmoduleTitle(LauncherPage parent, RepositoryNode node)
+        {
+            var baseName = Path.GetFileName(node.Id);
+            return $"{parent.Node.Name} : {baseName}";
         }
 
         private Workspace _activeWorkspace;

--- a/src/ViewModels/Launcher.cs
+++ b/src/ViewModels/Launcher.cs
@@ -482,7 +482,7 @@ namespace SourceGit.ViewModels
         private static string ComposeSubmoduleTitle(LauncherPage parent, RepositoryNode node)
         {
             var baseName = Path.GetFileName(node.Id);
-            return $"{parent.Node.Name} : {baseName}";
+            return $"{parent.Node.Name}: {baseName}";
         }
 
         private Workspace _activeWorkspace;

--- a/src/ViewModels/Repository.cs
+++ b/src/ViewModels/Repository.cs
@@ -1552,7 +1552,7 @@ namespace SourceGit.ViewModels
 
             var root = Path.GetFullPath(Path.Combine(FullPath, submodule));
             var normalizedPath = root.Replace('\\', '/').TrimEnd('/');
-            App.GetLauncher().OpenRepositoryInTab(normalizedPath, null);
+            App.GetLauncher().OpenRepositoryInTab(normalizedPath, selfPage);
         }
 
         public void AddWorktree()


### PR DESCRIPTION
Submodule tabs now insert right after the parent repo tab instead of appending at end, and display a `Parent : Submodule` title for quick identification.

## Changes

- **Tab placement** — Pass parent page hint through `OpenRepositoryInTab` so submodule tabs insert at `parentIdx + 1`
- **Title prefix** — Compose `"ParentName : SubfolderName"` for submodule tab titles using a single `ComposeSubmoduleTitle` helper
- **Live rename sync** — Recompose title on every open so renaming the parent immediately reflects in child tabs

## Before / After

| Before | After |
|--------|-------|
| A, B, C, D → open submodule in B → A, B, C, D, **BB** | A, B, C, D → open submodule in B → A, B, **B : BB**, C, D |

## Files Changed

- `src/ViewModels/Launcher.cs` — tab insertion logic + title composition
- `src/ViewModels/Repository.cs` — pass parent page to launcher