### PR TITLE
Add OCamllex and OCamlyacc syntax highlighting support

### DIFF
--- a/THIRD-PARTY-LICENSES.md
+++ b/THIRD-PARTY-LICENSES.md
@@ -120,6 +120,20 @@ The project uses the following third-party libraries or assets
 - **License**: MIT License
 - **License Link**: https://github.com/shentao/vue-multiselect/blob/master/LICENSE
 
+### OCamllex
+
+- **Source**: https://github.com/textmate/ocaml.tmbundle/blob/master/Syntaxes/OCamllex.tmLanguage
+- **Commit**: 1eff26848b39368414cb4214183a2cba22f12d0e
+- **License**: Permission to copy, use, modify, sell and distribute this software is granted. This software is provided "as is" without express or implied warranty, and with no claim as to its suitability for any purpose.
+- **License Link**: https://github.com/textmate/ocaml.tmbundle/tree/master#license
+
+### OCamlyacc
+
+- **Source**: https://github.com/textmate/ocaml.tmbundle/blob/master/Syntaxes/OCamlyacc.tmLanguage
+- **Commit**: 08a892aef6a4b285b1902d9ed1427653fce53e31
+- **License**: Permission to copy, use, modify, sell and distribute this software is granted. This software is provided "as is" without express or implied warranty, and with no claim as to its suitability for any purpose.
+- **License Link**: https://github.com/textmate/ocaml.tmbundle/tree/master#license
+
 ### Erlang
 
 - **Source**: https://github.com/shentao/vue-multiselect/blob/master/docs/shiki/languages/erlang.tmLanguage.json

--- a/src/Models/TextMateHelper.cs
+++ b/src/Models/TextMateHelper.cs
@@ -29,6 +29,8 @@ namespace SourceGit.Models
             new ExtraGrammar("source.vue", [".vue"], "vue.json"),
             new ExtraGrammar("source.erlang", [".erl", ".escript", ".hrl"], "erlang.json"),
             new ExtraGrammar("source.ocaml", [".ml", ".mli"], "ocaml.json"),
+            new ExtraGrammar("source.ocamllex", [".mll"], "ocamllex.json"),
+            new ExtraGrammar("source.ocamlyacc", [".mly"], "ocamlyacc.json"),
         ];
 
         private static readonly Dictionary<string, IRawGrammar> s_cachedRawGrammars = new();

--- a/src/Resources/Grammars/ocaml.json
+++ b/src/Resources/Grammars/ocaml.json
@@ -729,7 +729,7 @@
     "commentBlock": {
       "begin": "\\(\\*(?!\\*[^\\)])",
       "end": "\\*\\)",
-      "name": "comment constant.regexp meta.separator.markdown",
+      "name": "comment",
       "contentName": "emphasis",
       "patterns": [
         {
@@ -743,7 +743,7 @@
     "commentDoc": {
       "begin": "\\(\\*\\*",
       "end": "\\*\\)",
-      "name": "comment constant.regexp meta.separator.markdown",
+      "name": "comment",
       "patterns": [
         {
           "match": "\\*"

--- a/src/Resources/Grammars/ocamllex.json
+++ b/src/Resources/Grammars/ocamllex.json
@@ -1,0 +1,302 @@
+{
+  "name": "ocamllex",
+  "scopeName": "source.ocamllex",
+  "fileTypes": [ "mll" ],
+  "foldingStartMarker": "{",
+  "foldingStopMarker": "}",
+  "keyEquivalent": "^~O",
+  "patterns": [
+    {
+      "begin": "^\\s*({)",
+      "beginCaptures": {
+        "1": {
+          "name": "punctuation.section.embedded.ocaml.begin.ocamllex"
+        }
+      },
+      "end": "^\\s*(})",
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.section.embedded.ocaml.end.ocamllex"
+        }
+      },
+      "name": "meta.embedded.ocaml",
+      "patterns": [
+        {
+          "include": "source.ocaml"
+        }
+      ]
+    },
+    {
+      "begin": "\\b(let)\\s+([a-z][a-zA-Z0-9'_]*)\\s+=",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.other.pattern-definition.ocamllex"
+        },
+        "2": {
+          "name": "entity.name.type.pattern.stupid-goddamn-hack.ocamllex"
+        }
+      },
+      "end": "^(?:\\s*let)|(?:\\s*(rule|$))",
+      "name": "meta.pattern-definition.ocaml",
+      "patterns": [
+        {
+          "include": "#match-patterns"
+        }
+      ]
+    },
+    {
+      "begin": "(rule|and)\\s+([a-z][a-zA-Z0-9_]*)\\s+(=)\\s+(parse)(?=\\s*$)|((?<!\\|)(\\|)(?!\\|))",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.other.ocamllex"
+        },
+        "2": {
+          "name": "entity.name.function.entrypoint.ocamllex"
+        },
+        "3": {
+          "name": "keyword.operator.ocamllex"
+        },
+        "4": {
+          "name": "keyword.other.ocamllex"
+        },
+        "5": {
+          "name": "punctuation.separator.match-pattern.ocamllex"
+        }
+      },
+      "end": "(?:^\\s*((and)\\b|(?=\\|)|$))",
+      "endCaptures": {
+        "3": {
+          "name": "keyword.other.entry-definition.ocamllex"
+        }
+      },
+      "name": "meta.pattern-match.ocaml",
+      "patterns": [
+        {
+          "include": "#match-patterns"
+        },
+        {
+          "include": "#actions"
+        }
+      ]
+    },
+    {
+      "include": "#strings"
+    },
+    {
+      "include": "#comments"
+    },
+    {
+      "match": "=",
+      "name": "keyword.operator.symbol.ocamllex"
+    },
+    {
+      "begin": "\\(",
+      "end": "\\)",
+      "name": "meta.paren-group.ocamllex",
+      "patterns": [
+        {
+          "include": "$self"
+        }
+      ]
+    },
+    {
+      "match": "(’|‘|“|”)",
+      "name": "invalid.illegal.unrecognized-character.ocamllex"
+    }
+  ],
+  "repository": {
+    "actions": {
+      "patterns": [
+        {
+          "begin": "[^\\']({)",
+          "beginCaptures": {
+            "1": {
+              "name": "punctuation.definition.action.begin.ocamllex"
+            }
+          },
+          "end": "(})",
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.definition.action.end.ocamllex"
+            }
+          },
+          "name": "meta.action.ocamllex",
+          "patterns": [
+            {
+              "include": "source.ocaml"
+            }
+          ]
+        }
+      ]
+    },
+    "chars": {
+      "patterns": [
+        {
+          "captures": {
+            "1": {
+              "name": "punctuation.definition.char.begin.ocamllex"
+            },
+            "4": {
+              "name": "punctuation.definition.char.end.ocamllex"
+            }
+          },
+          "match": "(')([^\\\\]|\\\\(x[a-fA-F0-9][a-fA-F0-9]|[0-2]\\d\\d|[bnrt'\"\\\\]))(')",
+          "name": "constant.character.ocamllex"
+        }
+      ]
+    },
+    "comments": {
+      "patterns": [
+        {
+          "begin": "\\(\\*",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.definition.comment.begin.ocaml"
+            }
+          },
+          "end": "\\*\\)",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.definition.comment.end.ocaml"
+            }
+          },
+          "name": "comment.block.ocaml",
+          "patterns": [
+            {
+              "include": "#comments"
+            }
+          ]
+        },
+        {
+          "begin": "(?=[^\\\\])(\")",
+          "end": "\"",
+          "name": "comment.block.string.quoted.double.ocaml",
+          "patterns": [
+            {
+              "match": "\\\\(x[a-fA-F0-9][a-fA-F0-9]|[0-2]\\d\\d|[bnrt'\"\\\\])",
+              "name": "comment.block.string.constant.character.escape.ocaml"
+            }
+          ]
+        }
+      ]
+    },
+    "match-patterns": {
+      "patterns": [
+        {
+          "begin": "(\\()",
+          "beginCaptures": {
+            "1": {
+              "name": "punctuation.definition.sub-pattern.begin.ocamllex"
+            }
+          },
+          "end": "(\\))",
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.definition.sub-pattern.end.ocamllex"
+            }
+          },
+          "name": "meta.pattern.sub-pattern.ocamllex",
+          "patterns": [
+            {
+              "include": "#match-patterns"
+            }
+          ]
+        },
+        {
+          "match": "[a-z][a-zA-Z0-9'_]",
+          "name": "entity.name.type.pattern.reference.stupid-goddamn-hack.ocamllex"
+        },
+        {
+          "match": "\\bas\\b",
+          "name": "keyword.other.pattern.ocamllex"
+        },
+        {
+          "match": "eof",
+          "name": "constant.language.eof.ocamllex"
+        },
+        {
+          "match": "_",
+          "name": "constant.language.universal-match.ocamllex"
+        },
+        {
+          "begin": "(\\[)(\\^?)",
+          "beginCaptures": {
+            "1": {
+              "name": "punctuation.definition.character-class.begin.ocamllex"
+            },
+            "2": {
+              "name": "punctuation.definition.character-class.negation.ocamllex"
+            }
+          },
+          "end": "(])(?!\\')",
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.definition.character-class.end.ocamllex"
+            }
+          },
+          "name": "meta.pattern.character-class.ocamllex",
+          "patterns": [
+            {
+              "match": "-",
+              "name": "punctuation.separator.character-class.range.ocamllex"
+            },
+            {
+              "include": "#chars"
+            }
+          ]
+        },
+        {
+          "match": "\\*|\\+|\\?",
+          "name": "keyword.operator.pattern.modifier.ocamllex"
+        },
+        {
+          "match": "\\|",
+          "name": "keyword.operator.pattern.alternation.ocamllex"
+        },
+        {
+          "include": "#chars"
+        },
+        {
+          "include": "#strings"
+        }
+      ]
+    },
+    "strings": {
+      "patterns": [
+        {
+          "begin": "(?=[^\\\\])(\")",
+          "beginCaptures": {
+            "1": {
+              "name": "punctuation.definition.string.begin.ocaml"
+            }
+          },
+          "end": "(\")",
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.definition.string.end.ocaml"
+            }
+          },
+          "name": "string.quoted.double.ocamllex",
+          "patterns": [
+            {
+              "match": "\\\\$[ \\t]*",
+              "name": "punctuation.separator.string.ignore-eol.ocaml"
+            },
+            {
+              "match": "\\\\(x[a-fA-F0-9][a-fA-F0-9]|[0-2]\\d\\d|[bnrt'\"\\\\])",
+              "name": "constant.character.string.escape.ocaml"
+            },
+            {
+              "match": "\\\\[\\|\\(\\)1-9$^.*+?\\[\\]]",
+              "name": "constant.character.regexp.escape.ocaml"
+            },
+            {
+              "match": "\\\\(?!(x[a-fA-F0-9][a-fA-F0-9]|[0-2]\\d\\d|[bnrt'\"\\\\]|[\\|\\(\\)1-9$^.*+?\\[\\]]|$[ \\t]*))(?:.)",
+              "name": "invalid.illegal.character.string.escape"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/src/Resources/Grammars/ocamlyacc.json
+++ b/src/Resources/Grammars/ocamlyacc.json
@@ -1,0 +1,343 @@
+{
+  "name": "ocamlyacc",
+  "scopeName": "source.ocamlyacc",
+  "fileTypes": [ "mly" ],
+  "foldingStartMarker": "%{|%%",
+  "foldingStopMarker": "%}|%%",
+  "keyEquivalent": "^~O",
+  "patterns": [
+    {
+      "begin": "(%{)\\s*$",
+      "beginCaptures": {
+        "1": {
+          "name": "punctuation.section.header.begin.ocamlyacc"
+        }
+      },
+      "end": "^\\s*(%})",
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.section.header.end.ocamlyacc"
+        }
+      },
+      "name": "meta.header.ocamlyacc",
+      "patterns": [
+        {
+          "include": "source.ocaml"
+        }
+      ]
+    },
+    {
+      "begin": "(?<=%})\\s*$",
+      "end": "(?:^)(?=%%)",
+      "name": "meta.declarations.ocamlyacc",
+      "patterns": [
+        {
+          "include": "#comments"
+        },
+        {
+          "include": "#declaration-matches"
+        }
+      ]
+    },
+    {
+      "begin": "(%%)\\s*$",
+      "beginCaptures": {
+        "1": {
+          "name": "punctuation.section.rules.begin.ocamlyacc"
+        }
+      },
+      "end": "^\\s*(%%)",
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.section.rules.end.ocamlyacc"
+        }
+      },
+      "name": "meta.rules.ocamlyacc",
+      "patterns": [
+        {
+          "include": "#comments"
+        },
+        {
+          "include": "#rules"
+        }
+      ]
+    },
+    {
+      "include": "source.ocaml"
+    },
+    {
+      "include": "#comments"
+    },
+    {
+      "match": "(’|‘|“|”)",
+      "name": "invalid.illegal.unrecognized-character.ocaml"
+    }
+  ],
+  "repository": {
+    "comments": {
+      "patterns": [
+        {
+          "begin": "/\\*",
+          "end": "\\*/",
+          "name": "comment.block.ocamlyacc",
+          "patterns": [
+            {
+              "include": "#comments"
+            }
+          ]
+        },
+        {
+          "begin": "(?=[^\\\\])(\")",
+          "end": "\"",
+          "name": "comment.block.string.quoted.double.ocamlyacc",
+          "patterns": [
+            {
+              "match": "\\\\(x[a-fA-F0-9][a-fA-F0-9]|[0-2]\\d\\d|[bnrt'\"\\\\])",
+              "name": "comment.block.string.constant.character.escape.ocamlyacc"
+            }
+          ]
+        }
+      ]
+    },
+    "declaration-matches": {
+      "patterns": [
+        {
+          "begin": "(%)(token)",
+          "beginCaptures": {
+            "1": {
+              "name": "keyword.other.decorator.token.ocamlyacc"
+            },
+            "2": {
+              "name": "keyword.other.token.ocamlyacc"
+            }
+          },
+          "end": "^\\s*($|(^\\s*(?=%)))",
+          "name": "meta.token.declaration.ocamlyacc",
+          "patterns": [
+            {
+              "include": "#symbol-types"
+            },
+            {
+              "match": "[A-Z][A-Za-z0-9_]*",
+              "name": "entity.name.type.token.ocamlyacc"
+            },
+            {
+              "include": "#comments"
+            }
+          ]
+        },
+        {
+          "begin": "(%)(left|right|nonassoc)",
+          "beginCaptures": {
+            "1": {
+              "name": "keyword.other.decorator.token.associativity.ocamlyacc"
+            },
+            "2": {
+              "name": "keyword.other.token.associativity.ocamlyacc"
+            }
+          },
+          "end": "(^\\s*$)|(^\\s*(?=%))",
+          "name": "meta.token.associativity.ocamlyacc",
+          "patterns": [
+            {
+              "match": "[A-Z][A-Za-z0-9_]*",
+              "name": "entity.name.type.token.ocamlyacc"
+            },
+            {
+              "match": "[a-z][A-Za-z0-9_]*",
+              "name": "entity.name.function.non-terminal.reference.ocamlyacc"
+            },
+            {
+              "include": "#comments"
+            }
+          ]
+        },
+        {
+          "begin": "(%)(start)",
+          "beginCaptures": {
+            "1": {
+              "name": "keyword.other.decorator.start-symbol.ocamlyacc"
+            },
+            "2": {
+              "name": "keyword.other.start-symbol.ocamlyacc"
+            }
+          },
+          "end": "(^\\s*$)|(^\\s*(?=%))",
+          "name": "meta.start-symbol.ocamlyacc",
+          "patterns": [
+            {
+              "match": "[a-z][A-Za-z0-9_]*",
+              "name": "entity.name.function.non-terminal.reference.ocamlyacc"
+            },
+            {
+              "include": "#comments"
+            }
+          ]
+        },
+        {
+          "begin": "(%)(type)",
+          "beginCaptures": {
+            "1": {
+              "name": "keyword.other.decorator.symbol-type.ocamlyacc"
+            },
+            "2": {
+              "name": "keyword.other.symbol-type.ocamlyacc"
+            }
+          },
+          "end": "$\\s*(?!%)",
+          "name": "meta.symbol-type.ocamlyacc",
+          "patterns": [
+            {
+              "include": "#symbol-types"
+            },
+            {
+              "match": "[A-Z][A-Za-z0-9_]*",
+              "name": "entity.name.type.token.reference.ocamlyacc"
+            },
+            {
+              "match": "[a-z][A-Za-z0-9_]*",
+              "name": "entity.name.function.non-terminal.reference.ocamlyacc"
+            },
+            {
+              "include": "#comments"
+            }
+          ]
+        }
+      ]
+    },
+    "precs": {
+      "patterns": [
+        {
+          "captures": {
+            "1": {
+              "name": "keyword.other.decorator.precedence.ocamlyacc"
+            },
+            "2": {
+              "name": "keyword.other.precedence.ocamlyacc"
+            },
+            "4": {
+              "name": "entity.name.function.non-terminal.reference.ocamlyacc"
+            },
+            "5": {
+              "name": "entity.name.type.token.reference.ocamlyacc"
+            }
+          },
+          "match": "(%)(prec)\\s+(([a-z][a-zA-Z0-9_]*)|(([A-Z][a-zA-Z0-9_]*)))",
+          "name": "meta.precidence.declaration"
+        }
+      ]
+    },
+    "references": {
+      "patterns": [
+        {
+          "match": "[a-z][a-zA-Z0-9_]*",
+          "name": "entity.name.function.non-terminal.reference.ocamlyacc"
+        },
+        {
+          "match": "[A-Z][a-zA-Z0-9_]*",
+          "name": "entity.name.type.token.reference.ocamlyacc"
+        }
+      ]
+    },
+    "rule-patterns": {
+      "patterns": [
+        {
+          "begin": "((?<!\\||:)(\\||:)(?!\\||:))",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.separator.rule.ocamlyacc"
+            }
+          },
+          "end": "\\s*(?=\\||;)",
+          "name": "meta.rule-match.ocaml",
+          "patterns": [
+            {
+              "include": "#precs"
+            },
+            {
+              "include": "#semantic-actions"
+            },
+            {
+              "include": "#references"
+            },
+            {
+              "include": "#comments"
+            }
+          ]
+        }
+      ]
+    },
+    "rules": {
+      "patterns": [
+        {
+          "begin": "[a-z][a-zA-Z_]*",
+          "beginCaptures": {
+            "0": {
+              "name": "entity.name.function.non-terminal.ocamlyacc"
+            }
+          },
+          "end": ";",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.separator.rule.ocamlyacc"
+            }
+          },
+          "name": "meta.non-terminal.ocamlyacc",
+          "patterns": [
+            {
+              "include": "#rule-patterns"
+            }
+          ]
+        }
+      ]
+    },
+    "semantic-actions": {
+      "patterns": [
+        {
+          "begin": "[^\\']({)",
+          "beginCaptures": {
+            "1": {
+              "name": "punctuation.definition.action.semantic.ocamlyacc"
+            }
+          },
+          "end": "(})",
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.definition.action.semantic.ocamlyacc"
+            }
+          },
+          "name": "meta.action.semantic.ocamlyacc",
+          "patterns": [
+            {
+              "include": "source.ocaml"
+            }
+          ]
+        }
+      ]
+    },
+    "symbol-types": {
+      "patterns": [
+        {
+          "begin": "<",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.definition.type-declaration.begin.ocamlyacc"
+            }
+          },
+          "end": ">",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.definition.type-declaration.end.ocamlyacc"
+            }
+          },
+          "name": "meta.token.type-declaration.ocamlyacc",
+          "patterns": [
+            {
+              "include": "source.ocaml"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
How ocaml comments looked before the fix:
<img width="584" height="139" alt="image" src="https://github.com/user-attachments/assets/6e66ee5a-6f82-4912-8340-d1dca40d5755" />

How ocaml comments look after the fix:
<img width="584" height="139" alt="image" src="https://github.com/user-attachments/assets/392262df-8f5a-4a58-ae5e-9ca7eb5e9395" />

Screenshot of what an ocamllex file looks like:
<img width="1204" height="721" alt="image" src="https://github.com/user-attachments/assets/ee6e3166-bcf7-4c60-b169-727265ae8ff7" />
Screenshot of what an ocamlyacc file looks like:
<img width="753" height="720" alt="image" src="https://github.com/user-attachments/assets/2f4e8966-1a10-4a87-8146-a1e03a6ad78c" />

Updated the THIRD-PARTY-LICENSES.md file with the link to the original ocamllex and ocamlyacc grammar .xml files that have been converted to .json.