### PR TITLE
feature: add Bypass pre-push hook option to push dialog

### DIFF
--- a/src/Commands/Push.cs
+++ b/src/Commands/Push.cs
@@ -5,7 +5,7 @@ namespace SourceGit.Commands
 {
     public class Push : Command
     {
-        public Push(string repo, string local, string remote, string remoteBranch, bool withTags, bool checkSubmodules, bool track, bool force)
+        public Push(string repo, string local, string remote, string remoteBranch, bool withTags, bool checkSubmodules, bool track, bool force, bool noVerify)
         {
             _remote = remote;
 
@@ -22,6 +22,8 @@ namespace SourceGit.Commands
                 builder.Append("-u ");
             if (force)
                 builder.Append("--force-with-lease ");
+            if (noVerify)
+                builder.Append("--no-verify ");
 
             builder.Append(remote).Append(' ').Append(local).Append(':').Append(remoteBranch);
             Args = builder.ToString();

--- a/src/Resources/Locales/de_DE.axaml
+++ b/src/Resources/Locales/de_DE.axaml
@@ -741,6 +741,7 @@ $1, $2, … Werte der Eingabe-Steuerelemente</x:String>
   <x:String x:Key="Text.Push.Force" xml:space="preserve">Erzwinge Push</x:String>
   <x:String x:Key="Text.Push.Local" xml:space="preserve">Lokaler Branch:</x:String>
   <x:String x:Key="Text.Push.New" xml:space="preserve">NEU</x:String>
+  <x:String x:Key="Text.Push.NoVerify" xml:space="preserve">pre-push Hook überspringen</x:String>
   <x:String x:Key="Text.Push.Remote" xml:space="preserve">Remote:</x:String>
   <x:String x:Key="Text.Push.Revision" xml:space="preserve">Revision:</x:String>
   <x:String x:Key="Text.Push.Revision.Title" xml:space="preserve">Revision zu Remote-Branch pushen</x:String>

--- a/src/Resources/Locales/el_GR.axaml
+++ b/src/Resources/Locales/el_GR.axaml
@@ -740,6 +740,7 @@
   <x:String x:Key="Text.Push.Force" xml:space="preserve">Εξαναγκασμένο push</x:String>
   <x:String x:Key="Text.Push.Local" xml:space="preserve">Τοπικός κλάδος:</x:String>
   <x:String x:Key="Text.Push.New" xml:space="preserve">ΝΕΟ</x:String>
+  <x:String x:Key="Text.Push.NoVerify" xml:space="preserve">Παράκαμψη του pre-push hook</x:String>
   <x:String x:Key="Text.Push.Remote" xml:space="preserve">Απομακρυσμένο:</x:String>
   <x:String x:Key="Text.Push.Revision" xml:space="preserve">Αναθεώρηση:</x:String>
   <x:String x:Key="Text.Push.Revision.Title" xml:space="preserve">Push αναθεώρησης σε απομακρυσμένο</x:String>

--- a/src/Resources/Locales/en_US.axaml
+++ b/src/Resources/Locales/en_US.axaml
@@ -742,6 +742,7 @@
   <x:String x:Key="Text.Push.Force" xml:space="preserve">Force push</x:String>
   <x:String x:Key="Text.Push.Local" xml:space="preserve">Local Branch:</x:String>
   <x:String x:Key="Text.Push.New" xml:space="preserve">NEW</x:String>
+  <x:String x:Key="Text.Push.NoVerify" xml:space="preserve">Bypass the pre-push hook</x:String>
   <x:String x:Key="Text.Push.Remote" xml:space="preserve">Remote:</x:String>
   <x:String x:Key="Text.Push.Revision" xml:space="preserve">Revision:</x:String>
   <x:String x:Key="Text.Push.Revision.Title" xml:space="preserve">Push Revision To Remote</x:String>

--- a/src/Resources/Locales/es_ES.axaml
+++ b/src/Resources/Locales/es_ES.axaml
@@ -746,6 +746,7 @@
   <x:String x:Key="Text.Push.Force" xml:space="preserve">Forzar push</x:String>
   <x:String x:Key="Text.Push.Local" xml:space="preserve">Rama Local:</x:String>
   <x:String x:Key="Text.Push.New" xml:space="preserve">NUEVO</x:String>
+  <x:String x:Key="Text.Push.NoVerify" xml:space="preserve">Saltar el hook de pre-push</x:String>
   <x:String x:Key="Text.Push.Remote" xml:space="preserve">Remoto:</x:String>
   <x:String x:Key="Text.Push.Revision" xml:space="preserve">Revisión:</x:String>
   <x:String x:Key="Text.Push.Revision.Title" xml:space="preserve">Push Revisión al Remoto</x:String>

--- a/src/Resources/Locales/fr_FR.axaml
+++ b/src/Resources/Locales/fr_FR.axaml
@@ -708,6 +708,7 @@
   <x:String x:Key="Text.Push.Force" xml:space="preserve">Poussage forcé</x:String>
   <x:String x:Key="Text.Push.Local" xml:space="preserve">Branche locale :</x:String>
   <x:String x:Key="Text.Push.New" xml:space="preserve">NOUVEAU</x:String>
+  <x:String x:Key="Text.Push.NoVerify" xml:space="preserve">Contourner le hook de pre-push</x:String>
   <x:String x:Key="Text.Push.Remote" xml:space="preserve">Dépôt distant :</x:String>
   <x:String x:Key="Text.Push.Revision" xml:space="preserve">Révision :</x:String>
   <x:String x:Key="Text.Push.Revision.Title" xml:space="preserve">Pousser la Révision vers le Dépôt Distant</x:String>

--- a/src/Resources/Locales/he_IL.axaml
+++ b/src/Resources/Locales/he_IL.axaml
@@ -708,6 +708,7 @@
   <x:String x:Key="Text.Push.Force" xml:space="preserve">Force push</x:String>
   <x:String x:Key="Text.Push.Local" xml:space="preserve">Branch מקומי:</x:String>
   <x:String x:Key="Text.Push.New" xml:space="preserve">חדש</x:String>
+  <x:String x:Key="Text.Push.NoVerify" xml:space="preserve">דלג על pre-push hook</x:String>
   <x:String x:Key="Text.Push.Remote" xml:space="preserve">Remote:</x:String>
   <x:String x:Key="Text.Push.Revision" xml:space="preserve">Revision:</x:String>
   <x:String x:Key="Text.Push.Revision.Title" xml:space="preserve">Push של Revision ל־Remote</x:String>

--- a/src/Resources/Locales/id_ID.axaml
+++ b/src/Resources/Locales/id_ID.axaml
@@ -741,6 +741,7 @@
   <x:String x:Key="Text.Push.Force" xml:space="preserve">Paksa push</x:String>
   <x:String x:Key="Text.Push.Local" xml:space="preserve">Branch Lokal:</x:String>
   <x:String x:Key="Text.Push.New" xml:space="preserve">BARU</x:String>
+  <x:String x:Key="Text.Push.NoVerify" xml:space="preserve">Lewati hook pre-push</x:String>
   <x:String x:Key="Text.Push.Remote" xml:space="preserve">Remote:</x:String>
   <x:String x:Key="Text.Push.Revision" xml:space="preserve">Revisi:</x:String>
   <x:String x:Key="Text.Push.Revision.Title" xml:space="preserve">Push Revisi ke Remote</x:String>

--- a/src/Resources/Locales/it_IT.axaml
+++ b/src/Resources/Locales/it_IT.axaml
@@ -653,6 +653,7 @@ ${pure_files:N} Come ${files:N}, ma senza cartelle</x:String>
   <x:String x:Key="Text.Push.Force" xml:space="preserve">Forza l'invio</x:String>
   <x:String x:Key="Text.Push.Local" xml:space="preserve">Branch Locale:</x:String>
   <x:String x:Key="Text.Push.New" xml:space="preserve">NUOVO</x:String>
+  <x:String x:Key="Text.Push.NoVerify" xml:space="preserve">Ignora l'hook di pre-push</x:String>
   <x:String x:Key="Text.Push.Remote" xml:space="preserve">Remoto:</x:String>
   <x:String x:Key="Text.Push.Revision" xml:space="preserve">Revisione:</x:String>
   <x:String x:Key="Text.Push.Revision.Title" xml:space="preserve">Invia Revisione Al Remoto</x:String>

--- a/src/Resources/Locales/ja_JP.axaml
+++ b/src/Resources/Locales/ja_JP.axaml
@@ -740,6 +740,7 @@
   <x:String x:Key="Text.Push.Force" xml:space="preserve">強制的にプッシュ</x:String>
   <x:String x:Key="Text.Push.Local" xml:space="preserve">ローカルブランチ:</x:String>
   <x:String x:Key="Text.Push.New" xml:space="preserve">新規</x:String>
+  <x:String x:Key="Text.Push.NoVerify" xml:space="preserve">プッシュ前のフックを実行しない</x:String>
   <x:String x:Key="Text.Push.Remote" xml:space="preserve">リモート:</x:String>
   <x:String x:Key="Text.Push.Revision" xml:space="preserve">リビジョン:</x:String>
   <x:String x:Key="Text.Push.Revision.Title" xml:space="preserve">リビジョンをリモートにプッシュ</x:String>

--- a/src/Resources/Locales/ko_KR.axaml
+++ b/src/Resources/Locales/ko_KR.axaml
@@ -712,6 +712,7 @@
   <x:String x:Key="Text.Push.Force" xml:space="preserve">강제 푸시</x:String>
   <x:String x:Key="Text.Push.Local" xml:space="preserve">로컬 브랜치:</x:String>
   <x:String x:Key="Text.Push.New" xml:space="preserve">신규</x:String>
+  <x:String x:Key="Text.Push.NoVerify" xml:space="preserve">pre-push 훅 건너뛰기</x:String>
   <x:String x:Key="Text.Push.Remote" xml:space="preserve">원격:</x:String>
   <x:String x:Key="Text.Push.Revision" xml:space="preserve">리비전:</x:String>
   <x:String x:Key="Text.Push.Revision.Title" xml:space="preserve">리비전을 원격에 푸시</x:String>

--- a/src/Resources/Locales/pt_BR.axaml
+++ b/src/Resources/Locales/pt_BR.axaml
@@ -464,6 +464,7 @@
   <x:String x:Key="Text.Push.CheckSubmodules" xml:space="preserve">Certifica de que submodules foram enviadas</x:String>
   <x:String x:Key="Text.Push.Force" xml:space="preserve">Forçar push</x:String>
   <x:String x:Key="Text.Push.Local" xml:space="preserve">Branch Local:</x:String>
+  <x:String x:Key="Text.Push.NoVerify" xml:space="preserve">Ignorar o hook de pre-push</x:String>
   <x:String x:Key="Text.Push.Remote" xml:space="preserve">Remoto:</x:String>
   <x:String x:Key="Text.Push.Title" xml:space="preserve">Empurrar Alterações para o Remoto</x:String>
   <x:String x:Key="Text.Push.To" xml:space="preserve">Branch Remoto:</x:String>

--- a/src/Resources/Locales/ru_RU.axaml
+++ b/src/Resources/Locales/ru_RU.axaml
@@ -746,6 +746,7 @@
   <x:String x:Key="Text.Push.Force" xml:space="preserve">Принудительно выложить</x:String>
   <x:String x:Key="Text.Push.Local" xml:space="preserve">Локальная ветка:</x:String>
   <x:String x:Key="Text.Push.New" xml:space="preserve">НОВЫЙ</x:String>
+  <x:String x:Key="Text.Push.NoVerify" xml:space="preserve">Обходной зацеп предварительного выкладывания</x:String>
   <x:String x:Key="Text.Push.Remote" xml:space="preserve">Внешний репозиторий:</x:String>
   <x:String x:Key="Text.Push.Revision" xml:space="preserve">Ревизия:</x:String>
   <x:String x:Key="Text.Push.Revision.Title" xml:space="preserve">Выложить ревизию на удалёную</x:String>

--- a/src/Resources/Locales/ta_IN.axaml
+++ b/src/Resources/Locales/ta_IN.axaml
@@ -463,6 +463,7 @@
   <x:String x:Key="Text.Push.CheckSubmodules" xml:space="preserve">துணைத் தொகுதிகள் தள்ளப்பட்டது என்பதை உறுதிசெய்</x:String>
   <x:String x:Key="Text.Push.Force" xml:space="preserve">கட்டாயமாக தள்ளு</x:String>
   <x:String x:Key="Text.Push.Local" xml:space="preserve">உள்ளக கிளை:</x:String>
+  <x:String x:Key="Text.Push.NoVerify" xml:space="preserve">pre-push hook-ஐத் தவிர்</x:String>
   <x:String x:Key="Text.Push.Remote" xml:space="preserve">தொலை:</x:String>
   <x:String x:Key="Text.Push.Title" xml:space="preserve">மாற்றங்களை தொலைக்கு தள்ளு</x:String>
   <x:String x:Key="Text.Push.To" xml:space="preserve">தொலை கிளை:</x:String>

--- a/src/Resources/Locales/uk_UA.axaml
+++ b/src/Resources/Locales/uk_UA.axaml
@@ -467,6 +467,7 @@
   <x:String x:Key="Text.Push.CheckSubmodules" xml:space="preserve">Переконатися, що підмодулі надіслано</x:String>
   <x:String x:Key="Text.Push.Force" xml:space="preserve">Примусовий push</x:String>
   <x:String x:Key="Text.Push.Local" xml:space="preserve">Локальна гілка:</x:String>
+  <x:String x:Key="Text.Push.NoVerify" xml:space="preserve">Обхід pre-push hook</x:String>
   <x:String x:Key="Text.Push.Remote" xml:space="preserve">Віддалене сховище:</x:String>
   <x:String x:Key="Text.Push.Title" xml:space="preserve">Надіслати зміни на віддалене сховище</x:String>
   <x:String x:Key="Text.Push.To" xml:space="preserve">Віддалена гілка:</x:String>

--- a/src/Resources/Locales/zh_CN.axaml
+++ b/src/Resources/Locales/zh_CN.axaml
@@ -746,6 +746,7 @@
   <x:String x:Key="Text.Push.Force" xml:space="preserve">启用强制推送</x:String>
   <x:String x:Key="Text.Push.Local" xml:space="preserve">本地分支 ：</x:String>
   <x:String x:Key="Text.Push.New" xml:space="preserve">新建</x:String>
+  <x:String x:Key="Text.Push.NoVerify" xml:space="preserve">绕过 pre-push 钩子</x:String>
   <x:String x:Key="Text.Push.Remote" xml:space="preserve">远程仓库 ：</x:String>
   <x:String x:Key="Text.Push.Revision" xml:space="preserve">修订 ：</x:String>
   <x:String x:Key="Text.Push.Revision.Title" xml:space="preserve">推送指定修订到远程仓库</x:String>

--- a/src/Resources/Locales/zh_TW.axaml
+++ b/src/Resources/Locales/zh_TW.axaml
@@ -746,6 +746,7 @@
   <x:String x:Key="Text.Push.Force" xml:space="preserve">啟用強制推送</x:String>
   <x:String x:Key="Text.Push.Local" xml:space="preserve">本機分支:</x:String>
   <x:String x:Key="Text.Push.New" xml:space="preserve">新增</x:String>
+  <x:String x:Key="Text.Push.NoVerify" xml:space="preserve">繞過 pre-push hook</x:String>
   <x:String x:Key="Text.Push.Remote" xml:space="preserve">遠端存放庫:</x:String>
   <x:String x:Key="Text.Push.Revision" xml:space="preserve">修訂:</x:String>
   <x:String x:Key="Text.Push.Revision.Title" xml:space="preserve">推送修訂到遠端存放庫</x:String>

--- a/src/ViewModels/Push.cs
+++ b/src/ViewModels/Push.cs
@@ -97,6 +97,12 @@ namespace SourceGit.ViewModels
             set;
         }
 
+        public bool NoVerify
+        {
+            get;
+            set;
+        }
+
         public Push(Repository repo, Models.Branch localBranch)
         {
             _repo = repo;
@@ -204,7 +210,8 @@ namespace SourceGit.ViewModels
                 PushAllTags,
                 _repo.Submodules.Count > 0 && CheckSubmodules,
                 _isSetTrackOptionVisible && _tracking,
-                ForcePush).Use(log).RunAsync();
+                ForcePush,
+                NoVerify).Use(log).RunAsync();
 
             log.Complete();
             return succ;

--- a/src/ViewModels/PushRevision.cs
+++ b/src/ViewModels/PushRevision.cs
@@ -45,7 +45,8 @@ namespace SourceGit.ViewModels
                 false,
                 false,
                 false,
-                Force).Use(log).RunAsync();
+                Force,
+                false).Use(log).RunAsync();
 
             log.Complete();
             return succ;

--- a/src/Views/Push.axaml
+++ b/src/Views/Push.axaml
@@ -19,7 +19,7 @@
                  Text="{DynamicResource Text.Push.Title}"/>
     </StackPanel>
 
-    <Grid Margin="0,16,0,0" RowDefinitions="32,32,32,Auto,Auto,32,32" ColumnDefinitions="130,*">
+    <Grid Margin="0,16,0,0" RowDefinitions="32,32,32,Auto,Auto,32,32,32" ColumnDefinitions="130,*">
       <TextBlock Grid.Row="0" Grid.Column="0"
                  HorizontalAlignment="Right" VerticalAlignment="Center"
                  Margin="0,0,8,0"
@@ -94,6 +94,11 @@
                 Content="{DynamicResource Text.Push.Force}"
                 IsChecked="{Binding ForcePush, Mode=TwoWay}"
                 ToolTip.Tip="--force-with-lease"/>
+
+      <CheckBox Grid.Row="7" Grid.Column="1"
+                Content="{DynamicResource Text.Push.NoVerify}"
+                IsChecked="{Binding NoVerify, Mode=TwoWay}"
+                ToolTip.Tip="--no-verify"/>
     </Grid>
   </StackPanel>
 </UserControl>


### PR DESCRIPTION
## Description

Adds a `Bypass pre-push hook` checkbox to the **Push Changes To Remote** dialog that passes `--no-verify` to `git push`, skipping pre-push hooks.

- `src/Commands/Push.cs` — new `noVerify` argument; appends `--no-verify` to the command line
- `src/ViewModels/Push.cs` — `NoVerify` property wired into the push command
- `src/Views/Push.axaml` — new checkbox (tooltip `--no-verify`)
- `src/ViewModels/PushRevision.cs` — passes `false` for the new argument (behavior unchanged)
- localization — `Text.Push.NoVerify` added to all 16 locales

## Screenshot
<img width="544" height="323" alt="image" src="https://github.com/user-attachments/assets/4f4c8032-1749-4fc5-886e-9e857140f528" />


Closes #2629