### PR TITLE
feature: add "Commit & Force Push" action when amending a commit

### DIFF
--- a/src/Resources/Locales/en_US.axaml
+++ b/src/Resources/Locales/en_US.axaml
@@ -999,11 +999,13 @@
   <x:String x:Key="Text.WorkingCopy.ClearCommitHistories" xml:space="preserve">Clear History</x:String>
   <x:String x:Key="Text.WorkingCopy.ClearCommitHistories.Confirm" xml:space="preserve">Are you sure you want to clear all commit message history? This action cannot be undone.</x:String>
   <x:String x:Key="Text.WorkingCopy.Commit" xml:space="preserve">COMMIT</x:String>
+  <x:String x:Key="Text.WorkingCopy.CommitAndForcePush" xml:space="preserve">COMMIT &amp; FORCE PUSH</x:String>
   <x:String x:Key="Text.WorkingCopy.CommitAndPush" xml:space="preserve">COMMIT &amp; PUSH</x:String>
   <x:String x:Key="Text.WorkingCopy.CommitMessageHelper" xml:space="preserve">Template/History</x:String>
   <x:String x:Key="Text.WorkingCopy.CommitTip" xml:space="preserve">Trigger click event</x:String>
   <x:String x:Key="Text.WorkingCopy.CommitToEdit" xml:space="preserve">Commit (Edit)</x:String>
   <x:String x:Key="Text.WorkingCopy.CommitWithAutoStage" xml:space="preserve">Stage all changes and commit</x:String>
+  <x:String x:Key="Text.WorkingCopy.ConfirmCommitAndForcePush" xml:space="preserve">This operation will amend the last commit and force push it to the remote branch. The remote branch history will be rewritten. Do you want to continue?</x:String>
   <x:String x:Key="Text.WorkingCopy.ConfirmCommitWithDetachedHead">You are creating commit on a detached HEAD. Do you want to continue?</x:String>
   <x:String x:Key="Text.WorkingCopy.ConfirmCommitWithFilter">You have staged {0} file(s) but only {1} file(s) displayed ({2} files are filtered out). Do you want to continue?</x:String>
   <x:String x:Key="Text.WorkingCopy.Conflicts" xml:space="preserve">CONFLICTS DETECTED</x:String>

--- a/src/Views/WorkingCopy.axaml
+++ b/src/Views/WorkingCopy.axaml
@@ -418,32 +418,95 @@
           </Button.IsEnabled>
         </Button>
 
-        <Button Grid.Column="7"
-                Classes="flat"
-                Content="{DynamicResource Text.WorkingCopy.CommitAndPush}"
-                Height="28"
-                Margin="8,0,0,0"
-                Padding="8,0"
-                Click="OnCommitWithPush"
-                HotKey="{OnPlatform Ctrl+Alt+Enter, macOS=⌘+Alt+Enter}"
-                ToolTip.Tip="{OnPlatform Ctrl+Alt+Enter, macOS=⌘+⌥+Enter}"
-                ToolTip.Placement="Top"
-                ToolTip.VerticalOffset="0">
-          <Button.IsEnabled>
+        <SplitButton Grid.Column="7"
+                     Content="{DynamicResource Text.WorkingCopy.CommitAndPush}"
+                     Height="28"
+                     Margin="8,0,0,0"
+                     Padding="8,0"
+                     Click="OnCommitWithPush"
+                     HotKey="{OnPlatform Ctrl+Alt+Enter, macOS=⌘+Alt+Enter}"
+                     ToolTip.Tip="{OnPlatform Ctrl+Alt+Enter, macOS=⌘+⌥+Enter}"
+                     ToolTip.Placement="Top"
+                     ToolTip.VerticalOffset="0">
+          <SplitButton.Styles>
+            <Style Selector="SplitButton">
+              <Setter Property="MinHeight" Value="24"/>
+              <Setter Property="Template">
+                <ControlTemplate>
+                  <Grid ColumnDefinitions="*,1,Auto">
+                    <Button x:Name="PART_PrimaryButton"
+                            Grid.Column="0"
+                            Classes="flat"
+                            MinWidth="32"
+                            HorizontalAlignment="Stretch"
+                            VerticalAlignment="Stretch"
+                            Content="{TemplateBinding Content}"
+                            ContentTemplate="{TemplateBinding ContentTemplate}"
+                            Command="{TemplateBinding Command}"
+                            CommandParameter="{TemplateBinding CommandParameter}"
+                            CornerRadius="3,0,0,3"
+                            Padding="{TemplateBinding Padding}"
+                            Focusable="False"
+                            KeyboardNavigation.IsTabStop="False" />
+
+                    <Button x:Name="PART_SecondaryButton"
+                            Grid.Column="2"
+                            Classes="flat"
+                            Width="32"
+                            CornerRadius="0,3,3,0"
+                            Padding="0"
+                            Focusable="False"
+                            HorizontalAlignment="Stretch"
+                            VerticalAlignment="Stretch"
+                            KeyboardNavigation.IsTabStop="False">
+                      <Path Height="12" Width="12"
+                            Margin="0,4,0,0"
+                            Fill="{DynamicResource Brush.FG1}"
+                            Data="{DynamicResource Icons.Down}"/>
+                    </Button>
+                  </Grid>
+                </ControlTemplate>
+              </Setter>
+
+              <Style Selector="^:disabled /template/ Button">
+                <Setter Property="BorderThickness" Value="1"/>
+                <Setter Property="BorderBrush" Value="{DynamicResource Brush.Border2}"/>
+                <Setter Property="Background" Value="Transparent"/>
+              </Style>
+
+              <Style Selector="^:disabled AccessText">
+                <Setter Property="Foreground" Value="{DynamicResource Brush.FG2}"/>
+              </Style>
+
+              <Style Selector="^:disabled Path">
+                <Setter Property="Fill" Value="{DynamicResource Brush.FG2}"/>
+              </Style>
+            </Style>
+          </SplitButton.Styles>
+
+          <SplitButton.IsEnabled>
             <MultiBinding Converter="{x:Static BoolConverters.And}">
               <Binding Path="IsCommitting" Converter="{x:Static BoolConverters.Not}"/>
               <Binding Path="CommitMessage" Converter="{x:Static c:StringConverters.IsNotNullOrWhitespace}"/>
             </MultiBinding>
-          </Button.IsEnabled>
+          </SplitButton.IsEnabled>
 
-          <Button.IsVisible>
+          <SplitButton.IsVisible>
             <MultiBinding Converter="{x:Static BoolConverters.And}">
               <Binding Path="HasRemotes"/>
-              <Binding Path="UseAmend" Converter="{x:Static BoolConverters.Not}"/>
               <Binding Path="InProgressContext" Converter="{x:Static ObjectConverters.IsNull}"/>
             </MultiBinding>
-          </Button.IsVisible>
-        </Button>
+          </SplitButton.IsVisible>
+
+          <SplitButton.Flyout>
+            <MenuFlyout Placement="BottomEdgeAlignedLeft">
+              <MenuItem Header="{DynamicResource Text.WorkingCopy.CommitAndPush}"
+                        Click="OnCommitWithPush"/>
+              <MenuItem Header="{DynamicResource Text.WorkingCopy.CommitAndForcePush}"
+                        Click="OnCommitWithForcePush"/>
+            </MenuFlyout>
+          </SplitButton.Flyout>
+        </SplitButton>
       </Grid>
     </Grid>
   </Grid>

--- a/src/Views/WorkingCopy.axaml.cs
+++ b/src/Views/WorkingCopy.axaml.cs
@@ -296,6 +296,17 @@ namespace SourceGit.Views
             e.Handled = true;
         }
 
+        private async void OnCommitWithForcePush(object _, RoutedEventArgs e)
+        {
+            if (App.GetLauncher() is { CommandPalette: { } } launcher)
+                return;
+
+            if (DataContext is ViewModels.WorkingCopy vm)
+                await vm.CommitAsync(false, false, true);
+
+            e.Handled = true;
+        }
+
         private ContextMenu CreateContextMenuForUnstagedChanges(ViewModels.WorkingCopy vm, string selectedSingleFolder)
         {
             var repo = vm.Repository;


### PR DESCRIPTION
Closes #2575

### Description

Implements the requested `Commit & Force Push` action in the **Local Changes** panel, making the amend workflow consistent with the existing `Commit & Push` workflow.

- The **Commit & Push** button is now a **SplitButton** with a dropdown offering two actions:
  - `Commit & Push` — unchanged behavior
  - `Commit & Force Push`
- Selecting `Commit & Force Push` first shows a confirmation dialog warning that the remote branch history will be rewritten.
- After confirmation, the commit is created and pushed via the existing push machinery with `--force-with-lease`, so concurrent remote changes by other users are never overwritten blindly (per the issue's safety requirement).

### Notes

- The dropdown is visible whenever the repository has remotes, so the action works both with and without the **Amend** checkbox — it matters most when **Amend** is enabled, since rewriting an already-pushed commit requires a force push.
- New localization keys were added to `en_US.axaml`; all other locales fall back to it via `ResourceInclude`.

### Testing

- `dotnet build src/SourceGit.csproj -c Debug` — 0 warnings, 0 errors
- `dotnet publish src/SourceGit.csproj -c Release -r win-x64` — Native AOT publish succeeds
- Smoke-tested the published Windows x64 build

### Screenshot
<img width="888" height="173" alt="image" src="https://github.com/user-attachments/assets/0c05b0a6-4cbf-49c1-9d1c-46258c7fbb86" />