### PR TITLE
ux: allow interrupting in-progress push operation in dialog

### DIFF
--- a/src/ViewModels/LauncherPage.cs
+++ b/src/ViewModels/LauncherPage.cs
@@ -107,8 +107,14 @@ namespace SourceGit.ViewModels
 
         public void CancelPopup()
         {
-            if (_popup == null || _popup.InProgress)
+            if (_popup == null)
                 return;
+
+            if (_popup.InProgress)
+            {
+                _popup.Cancel();
+                return;
+            }
 
             _popup?.Cleanup();
             Popup = null;

--- a/src/ViewModels/Popup.cs
+++ b/src/ViewModels/Popup.cs
@@ -34,7 +34,7 @@ namespace SourceGit.ViewModels
                 ProgressDescription = desc;
         }
 
-        public void Cleanup()
+        public virtual void Cleanup()
         {
             _log?.Unsubscribe(this);
         }
@@ -42,6 +42,18 @@ namespace SourceGit.ViewModels
         public virtual bool CanStartDirectly()
         {
             return true;
+        }
+
+        /// <summary>
+        /// Indicates the in-progress operation of this popup can be interrupted.
+        /// </summary>
+        public virtual bool CanCancel => false;
+
+        /// <summary>
+        /// Interrupts the in-progress operation of this popup.
+        /// </summary>
+        public virtual void Cancel()
+        {
         }
 
         public virtual Task<bool> Sure()

--- a/src/ViewModels/Push.cs
+++ b/src/ViewModels/Push.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace SourceGit.ViewModels
@@ -190,6 +191,9 @@ namespace SourceGit.ViewModels
         {
             using var lockWatcher = _repo.LockWatcher();
 
+            _cts?.Cancel();
+            _cts = new CancellationTokenSource();
+
             var remoteBranchName = _selectedRemoteBranch.Name;
             ProgressDescription = $"Push {_selectedLocalBranch.Name} -> {_selectedRemote.Name}/{remoteBranchName} ...";
 
@@ -204,10 +208,24 @@ namespace SourceGit.ViewModels
                 PushAllTags,
                 _repo.Submodules.Count > 0 && CheckSubmodules,
                 _isSetTrackOptionVisible && _tracking,
-                ForcePush).Use(log).RunAsync();
+                ForcePush).Use(log).WithCancellation(_cts.Token).RunAsync();
 
             log.Complete();
             return succ;
+        }
+
+        public override bool CanCancel => true;
+
+        public override void Cancel()
+        {
+            _cts?.Cancel();
+        }
+
+        public override void Cleanup()
+        {
+            base.Cleanup();
+            _cts?.Dispose();
+            _cts = null;
         }
 
         private void AutoSelectBranchByRemote()
@@ -266,5 +284,6 @@ namespace SourceGit.ViewModels
         private Models.Branch _selectedRemoteBranch = null;
         private bool _isSetTrackOptionVisible = false;
         private bool _tracking = true;
+        private CancellationTokenSource _cts = null;
     }
 }

--- a/src/Views/LauncherPage.axaml
+++ b/src/Views/LauncherPage.axaml
@@ -113,8 +113,8 @@
                     <v:PopupRunningStatus Margin="12,8"
                                           Focusable="False"
                                           Description="{Binding ProgressDescription}"
-                                          IsVisible="{Binding InProgress}"
-                                          IsHitTestVisible="False"/>
+                                          CanCancel="{Binding CanCancel}"
+                                          IsVisible="{Binding InProgress}"/>
                   </StackPanel>
                 </DataTemplate>
               </ContentControl.DataTemplates>

--- a/src/Views/PopupRunningStatus.axaml
+++ b/src/Views/PopupRunningStatus.axaml
@@ -13,6 +13,15 @@
     <StackPanel Orientation="Horizontal" Margin="0,8">
       <ContentPresenter x:Name="Icon" Width="12" Height="12"/>
       <TextBlock Margin="6,0,0,0" FontSize="14" FontWeight="Bold" Text="{DynamicResource Text.Running}"/>
+      <Button Classes="flat"
+              Width="100" Height="28"
+              Margin="12,0,0,0"
+              Padding="0"
+              HorizontalContentAlignment="Center"
+              VerticalContentAlignment="Center"
+              Content="{DynamicResource Text.Cancel}"
+              Click="OnCancelRequested"
+              IsVisible="{Binding #ThisControl.CanCancel}"/>
     </StackPanel>
 
     <TextBlock HorizontalAlignment="Stretch"

--- a/src/Views/PopupRunningStatus.axaml.cs
+++ b/src/Views/PopupRunningStatus.axaml.cs
@@ -19,6 +19,18 @@ namespace SourceGit.Views
             set => SetAndRaise(DescriptionProperty, ref _description, value);
         }
 
+        public static readonly DirectProperty<PopupRunningStatus, bool> CanCancelProperty =
+            AvaloniaProperty.RegisterDirect<PopupRunningStatus, bool>(
+                nameof(CanCancel),
+                static o => o.CanCancel,
+                static (o, v) => o.CanCancel = v);
+
+        public bool CanCancel
+        {
+            get => _canCancel;
+            set => SetAndRaise(CanCancelProperty, ref _canCancel, value);
+        }
+
         public PopupRunningStatus()
         {
             InitializeComponent();
@@ -52,6 +64,14 @@ namespace SourceGit.Views
             }
         }
 
+        private void OnCancelRequested(object sender, RoutedEventArgs e)
+        {
+            if (DataContext is ViewModels.Popup popup)
+                popup.Cancel();
+
+            e.Handled = true;
+        }
+
         private void StartAnim()
         {
             Icon.Content = new Path() { Classes = { "waiting" } };
@@ -67,6 +87,7 @@ namespace SourceGit.Views
         }
 
         private string _description = string.Empty;
+        private bool _canCancel = false;
         private bool _isUnloading = false;
     }
 }


### PR DESCRIPTION
Resolve #2603

## Problem

When the remote server is unreachable (e.g. corporate VPN down), the `Push Changes to Remote` dialog blocks for minutes on the hung `git push` process with no way to interrupt it — the dialog is not closable while the operation is in progress.

## Solution

Add an opt-in cancellation mechanism for popups and wire it up for the Push dialog:

- **`Popup`** base class gains `CanCancel` (default `false`) and `Cancel()`, and `Cleanup()` becomes virtual.
- **`Push`** overrides `CanCancel => true` and `Cancel()` → cancels a `CancellationTokenSource` whose token is passed to the push command via the existing `.WithCancellation(token)` extension. `Command.ExecAsync()` already kills the git process tree on cancellation, and returns `true` when cancelled — so the dialog closes itself once the operation is interrupted.
- **`PopupRunningStatus`** shows a **CANCEL** button next to the running indicator, visible only when the popup opts in (`CanCancel`).
- **`LauncherPage.CancelPopup()`** now forwards to `popup.Cancel()` when a cancellable popup is in progress, so **ESC** and **mask-click** also interrupt the running push.

## Behavior

1. Push is running (hung on unreachable remote)
2. User clicks **CANCEL** (or presses ESC / clicks outside)
3. `git push` process tree is killed
4. Dialog closes immediately

## Notes

- Changes are opt-in: no other dialog is affected (button only appears for popups with `CanCancel == true`).
- `PushTag` / `PushRevision` follow the same pattern and can opt in later if desired.

Tested: `dotnet build` clean (0 warnings / 0 errors). Windows `win-x64` NativeAOT publish successful.


## Screenshot
<img width="550" height="344" alt="Captura de ecrã 2026-08-17 215930" src="https://github.com/user-attachments/assets/de3887fa-2685-41a1-ab0b-e04f23ed81a2" />