### PR TITLE
fix: split shell exec pattern for terminal file picker on Windows

### DIFF
--- a/src/Views/Preferences.axaml.cs
+++ b/src/Views/Preferences.axaml.cs
@@ -341,7 +341,11 @@ namespace SourceGit.Views
             {
                 options = new FilePickerOpenOptions()
                 {
-                    FileTypeFilter = [new FilePickerFileType(shell.Name) { Patterns = [shell.Exec] }],
+                    FileTypeFilter = [new FilePickerFileType(shell.Name)
+                    {
+                        Patterns = shell.Exec.Split('|',
+                            StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                    }],
                     AllowMultiple = false,
                 };
             }


### PR DESCRIPTION
On Windows, the shell/terminal file picker in Preferences could not display `pwsh.exe` / `powershell.exe` when the user tried to manually select the PowerShell executable.

## Root cause

`ShellOrTerminal.Exec` for PowerShell is `"pwsh.exe|powershell.exe"`, using `|` as a separator for alternative executable names. The file picker (`SelectShellOrTerminal` in `src/Views/Preferences.axaml.cs`) passed the entire string as a single glob pattern to `FilePickerFileType.Patterns`:

```csharp
Patterns = [shell.Exec]
```

Avalonia's Win32 implementation joins the patterns with `;` and hands the result to the native file dialog, which treats `|` as a literal character rather than an alternative separator. Since no file is literally named `pwsh.exe|powershell.exe`, the dialog showed nothing in the target directory.

The other Windows terminals (`bash.exe`, `cmd.exe`, `wt.exe`) use a single executable name and are unaffected.

## Fix

Split `Exec` on `|` so each alternative becomes its own pattern entry. For PowerShell this produces `["pwsh.exe", "powershell.exe"]`, which the Win32 dialog matches as `pwsh.exe;powershell.exe`.

```csharp
Patterns = shell.Exec.Split('|', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
```

No behavior change for terminals with a single executable name.