### PR TITLE
feature: add `Open Directory` option to repository tab context menu

### DIFF
--- a/TRANSLATION.md
+++ b/TRANSLATION.md
@@ -48,7 +48,7 @@ This document shows the translation status of each locale file in the repository
 
 </details>
 
-### ![fr__FR](https://img.shields.io/badge/fr__FR-95.03%25-yellow)
+### ![fr__FR](https://img.shields.io/badge/fr__FR-95.04%25-yellow)
 
 <details>
 <summary>Missing keys in fr_FR.axaml</summary>
@@ -107,7 +107,7 @@ This document shows the translation status of each locale file in the repository
 
 </details>
 
-### ![he__IL](https://img.shields.io/badge/he__IL-95.03%25-yellow)
+### ![he__IL](https://img.shields.io/badge/he__IL-95.04%25-yellow)
 
 <details>
 <summary>Missing keys in he_IL.axaml</summary>
@@ -181,7 +181,7 @@ This document shows the translation status of each locale file in the repository
 
 </details>
 
-### ![it__IT](https://img.shields.io/badge/it__IT-88.61%25-yellow)
+### ![it__IT](https://img.shields.io/badge/it__IT-88.62%25-yellow)
 
 <details>
 <summary>Missing keys in it_IT.axaml</summary>
@@ -325,7 +325,7 @@ This document shows the translation status of each locale file in the repository
 
 </details>
 
-### ![ko__KR](https://img.shields.io/badge/ko__KR-96.49%25-yellow)
+### ![ko__KR](https://img.shields.io/badge/ko__KR-96.50%25-yellow)
 
 <details>
 <summary>Missing keys in ko_KR.axaml</summary>
@@ -369,7 +369,7 @@ This document shows the translation status of each locale file in the repository
 
 </details>
 
-### ![pt__BR](https://img.shields.io/badge/pt__BR-62.51%25-red)
+### ![pt__BR](https://img.shields.io/badge/pt__BR-62.55%25-red)
 
 <details>
 <summary>Missing keys in pt_BR.axaml</summary>
@@ -771,7 +771,7 @@ This document shows the translation status of each locale file in the repository
 
 </details>
 
-### ![ta__IN](https://img.shields.io/badge/ta__IN-64.17%25-red)
+### ![ta__IN](https://img.shields.io/badge/ta__IN-64.20%25-red)
 
 <details>
 <summary>Missing keys in ta_IN.axaml</summary>
@@ -1147,7 +1147,7 @@ This document shows the translation status of each locale file in the repository
 
 </details>
 
-### ![uk__UA](https://img.shields.io/badge/uk__UA-64.95%25-red)
+### ![uk__UA](https://img.shields.io/badge/uk__UA-64.98%25-red)
 
 <details>
 <summary>Missing keys in uk_UA.axaml</summary>

--- a/src/Resources/Locales/de_DE.axaml
+++ b/src/Resources/Locales/de_DE.axaml
@@ -640,6 +640,7 @@ $1, $2, … Werte der Eingabe-Steuerelemente</x:String>
   <x:String x:Key="Text.PageTabBar.Tab.CopyPath" xml:space="preserve">Kopiere Repository-Pfad</x:String>
   <x:String x:Key="Text.PageTabBar.Tab.Edit" xml:space="preserve">Bearbeiten</x:String>
   <x:String x:Key="Text.PageTabBar.Tab.MoveToWorkspace" xml:space="preserve">In Arbeitsumgebung verschieben</x:String>
+  <x:String x:Key="Text.PageTabBar.Tab.OpenDirectory" xml:space="preserve">Ordner öffnen</x:String>
   <x:String x:Key="Text.PageTabBar.Tab.Refresh" xml:space="preserve">Aktualisieren</x:String>
   <x:String x:Key="Text.PageTabBar.Welcome.Title" xml:space="preserve">Repositorys</x:String>
   <x:String x:Key="Text.Paste" xml:space="preserve">Einfügen</x:String>

--- a/src/Resources/Locales/el_GR.axaml
+++ b/src/Resources/Locales/el_GR.axaml
@@ -639,6 +639,7 @@
   <x:String x:Key="Text.PageTabBar.Tab.CopyPath" xml:space="preserve">Αντιγραφή διαδρομής αποθετηρίου</x:String>
   <x:String x:Key="Text.PageTabBar.Tab.Edit" xml:space="preserve">Επεξεργασία</x:String>
   <x:String x:Key="Text.PageTabBar.Tab.MoveToWorkspace" xml:space="preserve">Μετακίνηση σε χώρο εργασίας</x:String>
+  <x:String x:Key="Text.PageTabBar.Tab.OpenDirectory" xml:space="preserve">Άνοιγμα φακέλου</x:String>
   <x:String x:Key="Text.PageTabBar.Tab.Refresh" xml:space="preserve">Ανανέωση</x:String>
   <x:String x:Key="Text.PageTabBar.Welcome.Title" xml:space="preserve">Αποθετήρια</x:String>
   <x:String x:Key="Text.Paste" xml:space="preserve">Επικόλληση</x:String>

--- a/src/Resources/Locales/en_US.axaml
+++ b/src/Resources/Locales/en_US.axaml
@@ -640,6 +640,7 @@
   <x:String x:Key="Text.PageTabBar.Tab.CopyPath" xml:space="preserve">Copy Repository Path</x:String>
   <x:String x:Key="Text.PageTabBar.Tab.Edit" xml:space="preserve">Edit</x:String>
   <x:String x:Key="Text.PageTabBar.Tab.MoveToWorkspace" xml:space="preserve">Move to Workspace</x:String>
+  <x:String x:Key="Text.PageTabBar.Tab.OpenDirectory" xml:space="preserve">Open Directory</x:String>
   <x:String x:Key="Text.PageTabBar.Tab.Refresh" xml:space="preserve">Refresh</x:String>
   <x:String x:Key="Text.PageTabBar.Welcome.Title" xml:space="preserve">Repositories</x:String>
   <x:String x:Key="Text.Paste" xml:space="preserve">Paste</x:String>

--- a/src/Resources/Locales/es_ES.axaml
+++ b/src/Resources/Locales/es_ES.axaml
@@ -644,6 +644,7 @@
   <x:String x:Key="Text.PageTabBar.Tab.CopyPath" xml:space="preserve">Copiar Ruta del Repositorio</x:String>
   <x:String x:Key="Text.PageTabBar.Tab.Edit" xml:space="preserve">Editar</x:String>
   <x:String x:Key="Text.PageTabBar.Tab.MoveToWorkspace" xml:space="preserve">Mover al Espacio de trabajo</x:String>
+  <x:String x:Key="Text.PageTabBar.Tab.OpenDirectory" xml:space="preserve">Abrir directorio</x:String>
   <x:String x:Key="Text.PageTabBar.Tab.Refresh" xml:space="preserve">Actualizar</x:String>
   <x:String x:Key="Text.PageTabBar.Welcome.Title" xml:space="preserve">Repositorios</x:String>
   <x:String x:Key="Text.Paste" xml:space="preserve">Pegar</x:String>

--- a/src/Resources/Locales/fr_FR.axaml
+++ b/src/Resources/Locales/fr_FR.axaml
@@ -608,6 +608,7 @@
   <x:String x:Key="Text.PageTabBar.Tab.CopyPath" xml:space="preserve">Copier le chemin vers le dépôt</x:String>
   <x:String x:Key="Text.PageTabBar.Tab.Edit" xml:space="preserve">Éditer</x:String>
   <x:String x:Key="Text.PageTabBar.Tab.MoveToWorkspace" xml:space="preserve">Se déplacer vers l'espace de travail</x:String>
+  <x:String x:Key="Text.PageTabBar.Tab.OpenDirectory" xml:space="preserve">Ouvrir le dossier</x:String>
   <x:String x:Key="Text.PageTabBar.Tab.Refresh" xml:space="preserve">Actualiser</x:String>
   <x:String x:Key="Text.PageTabBar.Welcome.Title" xml:space="preserve">Dépôts</x:String>
   <x:String x:Key="Text.Paste" xml:space="preserve">Coller</x:String>

--- a/src/Resources/Locales/he_IL.axaml
+++ b/src/Resources/Locales/he_IL.axaml
@@ -608,6 +608,7 @@
   <x:String x:Key="Text.PageTabBar.Tab.CopyPath" xml:space="preserve">העתק נתיב המאגר</x:String>
   <x:String x:Key="Text.PageTabBar.Tab.Edit" xml:space="preserve">ערוך</x:String>
   <x:String x:Key="Text.PageTabBar.Tab.MoveToWorkspace" xml:space="preserve">העבר לסביבת עבודה</x:String>
+  <x:String x:Key="Text.PageTabBar.Tab.OpenDirectory" xml:space="preserve">פתח תיקייה</x:String>
   <x:String x:Key="Text.PageTabBar.Tab.Refresh" xml:space="preserve">רענן</x:String>
   <x:String x:Key="Text.PageTabBar.Welcome.Title" xml:space="preserve">מאגרים</x:String>
   <x:String x:Key="Text.Paste" xml:space="preserve">הדבק</x:String>

--- a/src/Resources/Locales/id_ID.axaml
+++ b/src/Resources/Locales/id_ID.axaml
@@ -640,6 +640,7 @@
   <x:String x:Key="Text.PageTabBar.Tab.CopyPath" xml:space="preserve">Salin Jalur Repositori</x:String>
   <x:String x:Key="Text.PageTabBar.Tab.Edit" xml:space="preserve">Sunting</x:String>
   <x:String x:Key="Text.PageTabBar.Tab.MoveToWorkspace" xml:space="preserve">Pindahkan ke Workspace</x:String>
+  <x:String x:Key="Text.PageTabBar.Tab.OpenDirectory" xml:space="preserve">Buka Direktori</x:String>
   <x:String x:Key="Text.PageTabBar.Tab.Refresh" xml:space="preserve">Segarkan</x:String>
   <x:String x:Key="Text.PageTabBar.Welcome.Title" xml:space="preserve">Repositori</x:String>
   <x:String x:Key="Text.Paste" xml:space="preserve">Tempel</x:String>

--- a/src/Resources/Locales/it_IT.axaml
+++ b/src/Resources/Locales/it_IT.axaml
@@ -559,6 +559,7 @@ ${pure_files:N} Come ${files:N}, ma senza cartelle</x:String>
   <x:String x:Key="Text.PageTabBar.Tab.CopyPath" xml:space="preserve">Copia Percorso Repository</x:String>
   <x:String x:Key="Text.PageTabBar.Tab.Edit" xml:space="preserve">Modifica</x:String>
   <x:String x:Key="Text.PageTabBar.Tab.MoveToWorkspace" xml:space="preserve">Sposta nel Workspace</x:String>
+  <x:String x:Key="Text.PageTabBar.Tab.OpenDirectory" xml:space="preserve">Apri Cartella</x:String>
   <x:String x:Key="Text.PageTabBar.Tab.Refresh" xml:space="preserve">Aggiorna</x:String>
   <x:String x:Key="Text.PageTabBar.Welcome.Title" xml:space="preserve">Repository</x:String>
   <x:String x:Key="Text.Paste" xml:space="preserve">Incolla</x:String>

--- a/src/Resources/Locales/ja_JP.axaml
+++ b/src/Resources/Locales/ja_JP.axaml
@@ -639,6 +639,7 @@
   <x:String x:Key="Text.PageTabBar.Tab.CopyPath" xml:space="preserve">リポジトリへのパスをコピー</x:String>
   <x:String x:Key="Text.PageTabBar.Tab.Edit" xml:space="preserve">編集</x:String>
   <x:String x:Key="Text.PageTabBar.Tab.MoveToWorkspace" xml:space="preserve">ワークスペースに移動</x:String>
+  <x:String x:Key="Text.PageTabBar.Tab.OpenDirectory" xml:space="preserve">ディレクトリを開く</x:String>
   <x:String x:Key="Text.PageTabBar.Tab.Refresh" xml:space="preserve">再読み込み</x:String>
   <x:String x:Key="Text.PageTabBar.Welcome.Title" xml:space="preserve">リポジトリ</x:String>
   <x:String x:Key="Text.Paste" xml:space="preserve">貼り付け</x:String>

--- a/src/Resources/Locales/ko_KR.axaml
+++ b/src/Resources/Locales/ko_KR.axaml
@@ -611,6 +611,7 @@
   <x:String x:Key="Text.PageTabBar.Tab.CopyPath" xml:space="preserve">저장소 경로 복사</x:String>
   <x:String x:Key="Text.PageTabBar.Tab.Edit" xml:space="preserve">편집</x:String>
   <x:String x:Key="Text.PageTabBar.Tab.MoveToWorkspace" xml:space="preserve">작업 공간으로 이동</x:String>
+  <x:String x:Key="Text.PageTabBar.Tab.OpenDirectory" xml:space="preserve">디렉터리 열기</x:String>
   <x:String x:Key="Text.PageTabBar.Tab.Refresh" xml:space="preserve">새로 고침</x:String>
   <x:String x:Key="Text.PageTabBar.Welcome.Title" xml:space="preserve">저장소</x:String>
   <x:String x:Key="Text.Paste" xml:space="preserve">붙여넣기</x:String>

--- a/src/Resources/Locales/pt_BR.axaml
+++ b/src/Resources/Locales/pt_BR.axaml
@@ -390,6 +390,7 @@
   <x:String x:Key="Text.PageTabBar.Tab.CloseRight" xml:space="preserve">Fechar Abas à Direita</x:String>
   <x:String x:Key="Text.PageTabBar.Tab.CopyPath" xml:space="preserve">Copiar Caminho do Repositório</x:String>
   <x:String x:Key="Text.PageTabBar.Tab.Edit" xml:space="preserve">Editar</x:String>
+  <x:String x:Key="Text.PageTabBar.Tab.OpenDirectory" xml:space="preserve">Abrir Diretório</x:String>
   <x:String x:Key="Text.PageTabBar.Welcome.Title" xml:space="preserve">Repositórios</x:String>
   <x:String x:Key="Text.Paste" xml:space="preserve">Colar</x:String>
   <x:String x:Key="Text.Period.DaysAgo" xml:space="preserve">{0} dias atrás</x:String>

--- a/src/Resources/Locales/ru_RU.axaml
+++ b/src/Resources/Locales/ru_RU.axaml
@@ -644,6 +644,7 @@
   <x:String x:Key="Text.PageTabBar.Tab.CopyPath" xml:space="preserve">Копировать путь репозитория</x:String>
   <x:String x:Key="Text.PageTabBar.Tab.Edit" xml:space="preserve">Редактировать...</x:String>
   <x:String x:Key="Text.PageTabBar.Tab.MoveToWorkspace" xml:space="preserve">Переместить в рабочее пространство</x:String>
+  <x:String x:Key="Text.PageTabBar.Tab.OpenDirectory" xml:space="preserve">Открыть папку</x:String>
   <x:String x:Key="Text.PageTabBar.Tab.Refresh" xml:space="preserve">Обновить</x:String>
   <x:String x:Key="Text.PageTabBar.Welcome.Title" xml:space="preserve">Репозитории</x:String>
   <x:String x:Key="Text.Paste" xml:space="preserve">Вставить</x:String>

--- a/src/Resources/Locales/ta_IN.axaml
+++ b/src/Resources/Locales/ta_IN.axaml
@@ -385,6 +385,7 @@
   <x:String x:Key="Text.PageTabBar.Tab.CloseRight" xml:space="preserve">வலதுபுறத்தில் உள்ள தாவல்களை மூடு</x:String>
   <x:String x:Key="Text.PageTabBar.Tab.CopyPath" xml:space="preserve">களஞ்சிய பாதை நகலெடு</x:String>
   <x:String x:Key="Text.PageTabBar.Tab.Edit" xml:space="preserve">திருத்து</x:String>
+  <x:String x:Key="Text.PageTabBar.Tab.OpenDirectory" xml:space="preserve">கோப்புறையைத் திற</x:String>
   <x:String x:Key="Text.PageTabBar.Welcome.Title" xml:space="preserve">களஞ்சியங்கள்</x:String>
   <x:String x:Key="Text.Paste" xml:space="preserve">ஒட்டு</x:String>
   <x:String x:Key="Text.Period.DaysAgo" xml:space="preserve">{0} நாட்களுக்கு முன்பு</x:String>

--- a/src/Resources/Locales/uk_UA.axaml
+++ b/src/Resources/Locales/uk_UA.axaml
@@ -389,6 +389,7 @@
   <x:String x:Key="Text.PageTabBar.Tab.CloseRight" xml:space="preserve">Закрити вкладки праворуч</x:String>
   <x:String x:Key="Text.PageTabBar.Tab.CopyPath" xml:space="preserve">Копіювати шлях до сховища</x:String>
   <x:String x:Key="Text.PageTabBar.Tab.Edit" xml:space="preserve">Редагувати</x:String>
+  <x:String x:Key="Text.PageTabBar.Tab.OpenDirectory" xml:space="preserve">Відкрити папку</x:String>
   <x:String x:Key="Text.PageTabBar.Welcome.Title" xml:space="preserve">Сховища</x:String>
   <x:String x:Key="Text.Paste" xml:space="preserve">Вставити</x:String>
   <x:String x:Key="Text.Period.DaysAgo" xml:space="preserve">{0} днів тому</x:String>

--- a/src/Resources/Locales/zh_CN.axaml
+++ b/src/Resources/Locales/zh_CN.axaml
@@ -644,6 +644,7 @@
   <x:String x:Key="Text.PageTabBar.Tab.CopyPath" xml:space="preserve">复制仓库路径</x:String>
   <x:String x:Key="Text.PageTabBar.Tab.Edit" xml:space="preserve">编辑</x:String>
   <x:String x:Key="Text.PageTabBar.Tab.MoveToWorkspace" xml:space="preserve">移至工作区</x:String>
+  <x:String x:Key="Text.PageTabBar.Tab.OpenDirectory" xml:space="preserve">打开目录</x:String>
   <x:String x:Key="Text.PageTabBar.Tab.Refresh" xml:space="preserve">刷新</x:String>
   <x:String x:Key="Text.PageTabBar.Welcome.Title" xml:space="preserve">新标签页</x:String>
   <x:String x:Key="Text.Paste" xml:space="preserve">粘贴</x:String>

--- a/src/Resources/Locales/zh_TW.axaml
+++ b/src/Resources/Locales/zh_TW.axaml
@@ -644,6 +644,7 @@
   <x:String x:Key="Text.PageTabBar.Tab.CopyPath" xml:space="preserve">複製存放庫路徑</x:String>
   <x:String x:Key="Text.PageTabBar.Tab.Edit" xml:space="preserve">編輯</x:String>
   <x:String x:Key="Text.PageTabBar.Tab.MoveToWorkspace" xml:space="preserve">移至工作區</x:String>
+  <x:String x:Key="Text.PageTabBar.Tab.OpenDirectory" xml:space="preserve">開啟目錄</x:String>
   <x:String x:Key="Text.PageTabBar.Tab.Refresh" xml:space="preserve">重新整理</x:String>
   <x:String x:Key="Text.PageTabBar.Welcome.Title" xml:space="preserve">新分頁</x:String>
   <x:String x:Key="Text.Paste" xml:space="preserve">貼上</x:String>

--- a/src/Views/LauncherTabBar.axaml.cs
+++ b/src/Views/LauncherTabBar.axaml.cs
@@ -323,6 +323,17 @@ namespace SourceGit.Views
                         ev.Handled = true;
                     };
                     menu.Items.Add(copyPath);
+                    var openDirectory = new MenuItem();
+                    openDirectory.Header = App.Text("PageTabBar.Tab.OpenDirectory");
+                    openDirectory.Icon = this.CreateMenuIcon("Icons.Folder.Open");
+                    openDirectory.Click += (_, ev) =>
+                    {
+                        var dir = new DirectoryInfo(repo.FullPath).FullName;
+                        if (Directory.Exists(dir))
+                            Native.OS.OpenInFileManager(dir);
+                        ev.Handled = true;
+                    };
+                    menu.Items.Add(openDirectory);
                     menu.Items.Add(new MenuItem() { Header = "-" });
 
                     var edit = new MenuItem();


### PR DESCRIPTION
Closes #2638

**What
Adds an "Open Directory" item to the right-click context menu of repository tabs in the tab bar. It opens the repository's working directory in the system file explorer.

**How
src/Views/LauncherTabBar.axaml.cs: inserts a new openDirectory menu item in OnTabContextRequested (between CopyPath and the separator), using the existing Icons.Folder.Open icon and Native.OS.OpenInFileManager helper with new DirectoryInfo(repo.FullPath).FullName.
Adds the Text.PageTabBar.Tab.OpenDirectory resource key to all 16 locale files.
Regenerates TRANSLATION.md (translation status and locale sorting) via build/scripts/localization-check.js.

**Verified
dotnet build -c Debug: 0 warnings, 0 errors
dotnet format --verify-no-changes: pass
Locale files contain the new key, sorted per the localization script

**Screenshot
<img width="262" height="229" alt="image" src="https://github.com/user-attachments/assets/d8368c9e-d601-444c-9dcb-5d28f7164cc5" />
