### PR TITLE
feat: indicate history filters with no matching branch/tag

### DIFF
--- a/src/Converters/FilterModeConverters.cs
+++ b/src/Converters/FilterModeConverters.cs
@@ -1,4 +1,6 @@
-﻿using Avalonia.Data.Converters;
+﻿using System.Collections.Generic;
+
+using Avalonia.Data.Converters;
 using Avalonia.Media;
 
 namespace SourceGit.Converters
@@ -9,6 +11,24 @@ namespace SourceGit.Converters
             new FuncValueConverter<Models.FilterMode, IBrush>(v =>
             {
                 return v switch
+                {
+                    Models.FilterMode.Included => Brushes.Green,
+                    Models.FilterMode.Excluded => Brushes.Red,
+                    _ => Brushes.Transparent,
+                };
+            });
+
+        public static readonly IMultiValueConverter ToBorderBrushWithMatchState =
+            new FuncMultiValueConverter<object, IBrush>(values =>
+            {
+                var list = new List<object>(values);
+                if (list.Count < 2 || list[0] is not Models.FilterMode mode)
+                    return Brushes.Transparent;
+
+                if (list[1] is true)
+                    return Brushes.Gray;
+
+                return mode switch
                 {
                     Models.FilterMode.Included => Brushes.Green,
                     Models.FilterMode.Excluded => Brushes.Red,

--- a/src/Models/HistoryFilter.cs
+++ b/src/Models/HistoryFilter.cs
@@ -1,4 +1,6 @@
-﻿using CommunityToolkit.Mvvm.ComponentModel;
+﻿using System.Text.Json.Serialization;
+
+using CommunityToolkit.Mvvm.ComponentModel;
 
 namespace SourceGit.Models
 {
@@ -43,6 +45,13 @@ namespace SourceGit.Models
             get => Type != FilterType.Tag;
         }
 
+        [JsonIgnore]
+        public bool HasNoMatch
+        {
+            get => _hasNoMatch;
+            set => SetProperty(ref _hasNoMatch, value);
+        }
+
         public HistoryFilter()
         {
         }
@@ -56,5 +65,6 @@ namespace SourceGit.Models
 
         private string _pattern = string.Empty;
         private FilterMode _mode = FilterMode.None;
+        private bool _hasNoMatch = false;
     }
 }

--- a/src/ViewModels/Repository.cs
+++ b/src/ViewModels/Repository.cs
@@ -1168,6 +1168,7 @@ namespace SourceGit.ViewModels
                     CurrentBranch = branches.Find(x => x.IsCurrent);
                     LocalBranchTrees = builder.Locals;
                     RemoteBranchTrees = builder.Remotes;
+                    UpdateBranchHistoryFilterMatchState();
 
                     var localBranchesCount = 0;
                     foreach (var b in branches)
@@ -1214,6 +1215,7 @@ namespace SourceGit.ViewModels
 
                     Tags = tags;
                     VisibleTags = BuildVisibleTags();
+                    UpdateTagHistoryFilterMatchState();
                 });
             }, token);
         }
@@ -1788,6 +1790,10 @@ namespace SourceGit.ViewModels
             UpdateBranchTreeFilterMode(LocalBranchTrees, map);
             UpdateBranchTreeFilterMode(RemoteBranchTrees, map);
             UpdateTagFilterMode(map);
+
+            UpdateBranchHistoryFilterMatchState();
+            UpdateTagHistoryFilterMatchState();
+
             RefreshCommits();
         }
 
@@ -1813,6 +1819,78 @@ namespace SourceGit.ViewModels
             {
                 foreach (var item in list.TagItems)
                     item.FilterMode = map.GetValueOrDefault(item.Tag.Name, Models.FilterMode.None);
+            }
+        }
+
+        private void UpdateBranchHistoryFilterMatchState()
+        {
+            var branchPaths = new HashSet<string>(StringComparer.Ordinal);
+            CollectBranchPaths(LocalBranchTrees, branchPaths);
+            CollectBranchPaths(RemoteBranchTrees, branchPaths);
+
+            foreach (var filter in _uiStates.HistoryFilters)
+            {
+                switch (filter.Type)
+                {
+                    case Models.FilterType.LocalBranch:
+                    case Models.FilterType.RemoteBranch:
+                        filter.HasNoMatch = !branchPaths.Contains(filter.Pattern);
+                        break;
+                    case Models.FilterType.LocalBranchFolder:
+                    case Models.FilterType.RemoteBranchFolder:
+                        var prefix = filter.Pattern + "/";
+                        var hasChild = false;
+                        foreach (var p in branchPaths)
+                        {
+                            if (p.StartsWith(prefix, StringComparison.Ordinal))
+                            {
+                                hasChild = true;
+                                break;
+                            }
+                        }
+                        filter.HasNoMatch = !hasChild;
+                        break;
+                }
+            }
+        }
+
+        private void UpdateTagHistoryFilterMatchState()
+        {
+            var tagNames = new HashSet<string>(StringComparer.Ordinal);
+            if (VisibleTags is TagCollectionAsTree tree)
+                CollectTagNamesRecursive(tree.Tree, tagNames);
+            else if (VisibleTags is TagCollectionAsList list)
+            {
+                foreach (var item in list.TagItems)
+                    tagNames.Add(item.Tag.Name);
+            }
+
+            foreach (var filter in _uiStates.HistoryFilters)
+            {
+                if (filter.Type == Models.FilterType.Tag)
+                    filter.HasNoMatch = !tagNames.Contains(filter.Pattern);
+            }
+        }
+
+        private void CollectBranchPaths(List<BranchTreeNode> nodes, HashSet<string> set)
+        {
+            foreach (var node in nodes)
+            {
+                if (node.IsBranch)
+                    set.Add(node.Path);
+                else
+                    CollectBranchPaths(node.Children, set);
+            }
+        }
+
+        private static void CollectTagNamesRecursive(List<TagTreeNode> nodes, HashSet<string> set)
+        {
+            foreach (var node in nodes)
+            {
+                if (node.IsFolder)
+                    CollectTagNamesRecursive(node.Children, set);
+                else
+                    set.Add(node.FullPath);
             }
         }
 

--- a/src/Views/Repository.axaml
+++ b/src/Views/Repository.axaml
@@ -952,8 +952,13 @@
                         Margin="0,0,6,0"
                         CornerRadius="12"
                         BorderThickness="1"
-                        BorderBrush="{Binding Mode, Converter={x:Static c:FilterModeConverters.ToBorderBrush}}"
                         VerticalAlignment="Center">
+                  <Border.BorderBrush>
+                    <MultiBinding Converter="{x:Static c:FilterModeConverters.ToBorderBrushWithMatchState}">
+                      <Binding Path="Mode"/>
+                      <Binding Path="HasNoMatch"/>
+                    </MultiBinding>
+                  </Border.BorderBrush>
                   <Grid Margin="8,0">
                     <Grid.ColumnDefinitions>
                       <ColumnDefinition Width="Auto"/>


### PR DESCRIPTION
## What
When a history filter (Include/Exclude on a local branch, remote branch, branch folder, or tag)
no longer has a matching branch/tag in the current repository state, its chip now shows a
distinct color instead of the usual green (Included) / red (Excluded).

## Why
There was previously no way to tell whether a filter chip was still meaningfully applied.
A filter becomes unmatched when its target branch/tag is deleted/renamed outside of SourceGit
(e.g. another terminal, `fetch --prune`). Users may still want to keep such rules in case a
branch/tag with the same name reappears later, so unmatched filters are only flagged, never
auto-removed.

## How
- `Models.HistoryFilter` gains a runtime-only `HasNoMatch` flag (not persisted).
- `ViewModels.Repository` recomputes `HasNoMatch` whenever branches or tags are (re)loaded
  (`RefreshBranches`/`RefreshTags`, including on first repository open) and whenever filters
  themselves change (`RefreshHistoryFilters`), so the state is always accurate without
  requiring the user to trigger a filter change first.
- Filter chip border color now factors in both `Mode` and `HasNoMatch` via a new multi-value
  converter.

## Out of scope
- No automatic removal of unmatched filters.
- No extra git queries — matching is done against already-loaded in-memory branch/tag data.
