### PR TITLE
[Enhancement] Add new graph-highlighting option "Selected Commits (only first-parent)"

### DIFF
--- a/src/Models/CommitGraph.cs
+++ b/src/Models/CommitGraph.cs
@@ -13,6 +13,7 @@ namespace SourceGit.Models
         All = 0,
         CurrentBranchOnly,
         SelectedCommitsOnly,
+        SelectedCommitsOnlyFirstParent,
         CurrentBranchAndSelectedCommits,
     }
 
@@ -156,6 +157,7 @@ namespace SourceGit.Models
 
                     if (!isHighlighted &&
                         (highlighting == CommitGraphHighlighting.SelectedCommitsOnly ||
+                         highlighting == CommitGraphHighlighting.SelectedCommitsOnlyFirstParent ||
                          highlighting == CommitGraphHighlighting.CurrentBranchAndSelectedCommits))
                     {
                         isHighlighted = highlightExtraCommits.Remove(commit.SHA);
@@ -200,6 +202,9 @@ namespace SourceGit.Models
                 // Deal with other parents (the first parent has been processed)
                 if (!firstParentOnlyEnabled)
                 {
+                    if (highlighting == CommitGraphHighlighting.SelectedCommitsOnlyFirstParent)
+                        isHighlighted = false;
+
                     for (int j = 1; j < commit.Parents.Count; j++)
                     {
                         var parentHash = commit.Parents[j];

--- a/src/Models/CommitGraph.cs
+++ b/src/Models/CommitGraph.cs
@@ -159,11 +159,9 @@ namespace SourceGit.Models
                          highlighting == CommitGraphHighlighting.CurrentBranchAndSelectedCommits))
                     {
                         isHighlighted = highlightExtraCommits.Remove(commit.SHA);
-                        if (isHighlighted)
-                        {
-                            foreach (var p in commit.Parents)
-                                highlightExtraCommits.Add(p);
-                        }
+                        // Highlight first parent, other parents are dealt with later
+                        if (isHighlighted && commit.Parents.Count > 0)
+                            highlightExtraCommits.Add(commit.Parents[0]);
                     }
                 }
                 commit.IsHighlightedInGraph = isHighlighted;

--- a/src/Models/CommitGraph.cs
+++ b/src/Models/CommitGraph.cs
@@ -146,28 +146,21 @@ namespace SourceGit.Models
                     {
                         isHighlighted = true;
                     }
-                    else if (highlighting == CommitGraphHighlighting.CurrentBranchOnly)
+
+                    if (!isHighlighted &&
+                        (highlighting == CommitGraphHighlighting.CurrentBranchOnly ||
+                         highlighting == CommitGraphHighlighting.CurrentBranchAndSelectedCommits))
                     {
                         isHighlighted = commit.IsMerged;
                     }
-                    else if (highlighting == CommitGraphHighlighting.SelectedCommitsOnly)
+
+                    if (!isHighlighted &&
+                        (highlighting == CommitGraphHighlighting.SelectedCommitsOnly ||
+                         highlighting == CommitGraphHighlighting.CurrentBranchAndSelectedCommits))
                     {
                         isHighlighted = highlightExtraCommits.Remove(commit.SHA);
                         if (isHighlighted)
                         {
-                            foreach (var p in commit.Parents)
-                                highlightExtraCommits.Add(p);
-                        }
-                    }
-                    else
-                    {
-                        if (commit.IsMerged)
-                        {
-                            isHighlighted = true;
-                        }
-                        else if (highlightExtraCommits.Remove(commit.SHA))
-                        {
-                            isHighlighted = true;
                             foreach (var p in commit.Parents)
                                 highlightExtraCommits.Add(p);
                         }

--- a/src/Models/CommitGraph.cs
+++ b/src/Models/CommitGraph.cs
@@ -70,7 +70,7 @@ namespace SourceGit.Models
         public List<Link> Links { get; } = [];
         public List<Dot> Dots { get; } = [];
 
-        public static CommitGraph Generate(List<Commit> commits, bool recalculateMergeState, bool firstParentOnlyEnabled, CommitGraphHighlighting highlighting, HashSet<string> highlightExtraCommits)
+        public static CommitGraph Generate(List<Commit> commits, bool firstParentOnlyEnabled, CommitGraphHighlighting highlighting, HashSet<string> highlightExtraCommits)
         {
             const double unitWidth = 12;
             const double halfWidth = 6;
@@ -82,28 +82,10 @@ namespace SourceGit.Models
             var ended = new List<PathHelper>();
             var offsetY = -halfHeight;
             var colorPicker = new ColorPicker();
-            var merged = new HashSet<string>();
 
             foreach (var commit in commits)
             {
                 PathHelper major = null;
-
-                // Update merge state of this commit.
-                if (recalculateMergeState)
-                {
-                    if (commit.IsMerged)
-                    {
-                        merged.Remove(commit.SHA);
-                        foreach (var p in commit.Parents)
-                            merged.Add(p);
-                    }
-                    else if (merged.Remove(commit.SHA))
-                    {
-                        commit.IsMerged = true;
-                        foreach (var p in commit.Parents)
-                            merged.Add(p);
-                    }
-                }
 
                 // Update current y offset
                 offsetY += unitHeight;

--- a/src/Resources/Locales/en_US.axaml
+++ b/src/Resources/Locales/en_US.axaml
@@ -518,6 +518,7 @@
   <x:String x:Key="Text.Histories.HighlightsInGraph.CurrentBranchOnly" xml:space="preserve">Current Branch Only</x:String>
   <x:String x:Key="Text.Histories.HighlightsInGraph.CurrentBranchAndSelectedCommits" xml:space="preserve">Current Branch &amp; Selected Commits</x:String>
   <x:String x:Key="Text.Histories.HighlightsInGraph.SelectedCommitsOnly" xml:space="preserve">Selected Commits Only</x:String>
+  <x:String x:Key="Text.Histories.HighlightsInGraph.SelectedCommitsOnlyFirstParent" xml:space="preserve">Selected Commits (only first-parent)</x:String>
   <x:String x:Key="Text.Histories.Selected" xml:space="preserve">SELECTED {0} COMMITS</x:String>
   <x:String x:Key="Text.Histories.ShowColumns" xml:space="preserve">SHOW COLUMNS</x:String>
   <x:String x:Key="Text.Histories.Tips" xml:space="preserve">Hold 'Ctrl' or 'Shift' to select multiple commits.</x:String>

--- a/src/ViewModels/Histories.cs
+++ b/src/ViewModels/Histories.cs
@@ -75,7 +75,8 @@ namespace SourceGit.ViewModels
             get => _commits;
             set
             {
-                GenerateGraph(value, true);
+                RecalculateMergeState(value);
+                GenerateGraph(value);
                 if (SetProperty(ref _commits, value))
                     PostCommitsChanged();
             }
@@ -510,7 +511,28 @@ namespace SourceGit.ViewModels
                 GenerateGraph(_commits);
         }
 
-        private void GenerateGraph(List<Models.Commit> commits, bool commitsChanged = false)
+        private void RecalculateMergeState(List<Models.Commit> commits)
+        {
+            var merged = new HashSet<string>();
+
+            foreach (var commit in commits)
+            {
+                if (commit.IsMerged)
+                {
+                    merged.Remove(commit.SHA);
+                    foreach (var p in commit.Parents)
+                        merged.Add(p);
+                }
+                else if (merged.Remove(commit.SHA))
+                {
+                    commit.IsMerged = true;
+                    foreach (var p in commit.Parents)
+                        merged.Add(p);
+                }
+            }
+        }
+
+        private void GenerateGraph(List<Models.Commit> commits)
         {
             var firstParentOnly = _repo.UIStates.HistoryShowFlags.HasFlag(Models.HistoryShowFlags.FirstParentOnly);
             var highlighting = _repo.UIStates.GraphHighlighting;
@@ -522,7 +544,7 @@ namespace SourceGit.ViewModels
                     extraHeads.Add(c.SHA);
             }
 
-            Graph = Models.CommitGraph.Generate(commits, commitsChanged, firstParentOnly, highlighting, extraHeads);
+            Graph = Models.CommitGraph.Generate(commits, firstParentOnly, highlighting, extraHeads);
         }
 
         private Repository _repo = null;

--- a/src/ViewModels/Histories.cs
+++ b/src/ViewModels/Histories.cs
@@ -517,15 +517,11 @@ namespace SourceGit.ViewModels
 
             foreach (var commit in commits)
             {
+                if (merged.Remove(commit.SHA))
+                    commit.IsMerged = true;
+
                 if (commit.IsMerged)
                 {
-                    merged.Remove(commit.SHA);
-                    foreach (var p in commit.Parents)
-                        merged.Add(p);
-                }
-                else if (merged.Remove(commit.SHA))
-                {
-                    commit.IsMerged = true;
                     foreach (var p in commit.Parents)
                         merged.Add(p);
                 }

--- a/src/Views/Repository.axaml.cs
+++ b/src/Views/Repository.axaml.cs
@@ -487,6 +487,16 @@ namespace SourceGit.Views
                     ev.Handled = true;
                 };
 
+                var selectedCommitsOnlyFirstParent = new MenuItem();
+                selectedCommitsOnlyFirstParent.Header = App.Text("Histories.HighlightsInGraph.SelectedCommitsOnlyFirstParent");
+                if (histories.GraphHighlighting == Models.CommitGraphHighlighting.SelectedCommitsOnlyFirstParent)
+                    selectedCommitsOnlyFirstParent.Icon = this.CreateMenuIcon("Icons.Check");
+                selectedCommitsOnlyFirstParent.Click += (_, ev) =>
+                {
+                    histories.GraphHighlighting = Models.CommitGraphHighlighting.SelectedCommitsOnlyFirstParent;
+                    ev.Handled = true;
+                };
+
                 var currentBranchAndSelectedCommits = new MenuItem();
                 currentBranchAndSelectedCommits.Header = App.Text("Histories.HighlightsInGraph.CurrentBranchAndSelectedCommits");
                 if (histories.GraphHighlighting == Models.CommitGraphHighlighting.CurrentBranchAndSelectedCommits)
@@ -516,6 +526,7 @@ namespace SourceGit.Views
                 menu.Items.Add(all);
                 menu.Items.Add(currentBranchOnly);
                 menu.Items.Add(selectedCommitsOnly);
+                menu.Items.Add(selectedCommitsOnlyFirstParent);
                 menu.Items.Add(currentBranchAndSelectedCommits);
                 menu.Open(button);
             }


### PR DESCRIPTION
This PR does some refactoring of the graph-highlighting code and adds a new highlighting-option variant "Selected Commits (only first-parent)".

The new highlighting-option is similar to the existing highlighting-option "Selected Commits Only", but restricted to only ever highlighting the first-parent when going backwards in history from the selected commit(s). This feature was first discussed in comments on a related issue [here](https://github.com/sourcegit-scm/sourcegit/issues/2336#issuecomment-4477907019).

I find it very helpful to restrict the highlighting to first-parent, while still drawing the other parents. I've implemented it in the easiest way I could find, which was to only apply it to "selected commits" in a new option variant. (It would be possible, but a bit more involved, to instead implement it as a separate "perpendicular" option that could be applied to the "All" and "Current branch" variants as well...)

NOTE: This new highlighting-option is somewhat related to the Git-option `--first-parent` (which is applied by SourceGit's show-flag "First-parent only"), but it's not the same! The new option only restricts the highlighting of non-first-parents, while the existing show-flag hides them entirely. (Also, the option and flag can be used simultaneously without issues.)