### PR TITLE
Use standardized data directories on linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,11 +72,11 @@ You can download the latest stable from [Releases](https://github.com/sourcegit-
 
 This software creates a folder, which is platform-dependent, to store user settings, downloaded avatars and crash logs.
 
-| OS      | PATH                                      |
-|---------|-------------------------------------------|
-| Windows | `%APPDATA%\SourceGit`                     |
-| Linux   | `~/.sourcegit`                            |
-| macOS   | `~/Library/Application Support/SourceGit` |
+| OS      | PATH                                             |
+|---------|--------------------------------------------------|
+| Windows | `%APPDATA%\SourceGit`                            |
+| Linux   | `~/.local/share/SourceGit`, `~/.cache/SourceGit` |
+| macOS   | `~/Library/Application Support/SourceGit`        |
 
 > [!TIP]
 > * You can open this data storage directory from the main menu `Open Data Storage Directory`.

--- a/src/App.axaml.cs
+++ b/src/App.axaml.cs
@@ -24,6 +24,8 @@ namespace SourceGit
         public static void Main(string[] args)
         {
             Native.OS.SetupDataDir();
+            Native.OS.SetupConfigDir();
+            Native.OS.SetupCacheDir();
 
             AppDomain.CurrentDomain.UnhandledException += (_, e) =>
             {

--- a/src/App.axaml.cs
+++ b/src/App.axaml.cs
@@ -24,7 +24,6 @@ namespace SourceGit
         public static void Main(string[] args)
         {
             Native.OS.SetupDataDir();
-            Native.OS.SetupConfigDir();
             Native.OS.SetupCacheDir();
 
             AppDomain.CurrentDomain.UnhandledException += (_, e) =>

--- a/src/Models/AvatarManager.cs
+++ b/src/Models/AvatarManager.cs
@@ -44,7 +44,7 @@ namespace SourceGit.Models
 
         public void Start()
         {
-            _storePath = Path.Combine(Native.OS.DataDir, "avatars");
+            _storePath = Path.Combine(Native.OS.CacheDir, "avatars");
             if (!Directory.Exists(_storePath))
                 Directory.CreateDirectory(_storePath);
 

--- a/src/Models/AvatarManager.cs
+++ b/src/Models/AvatarManager.cs
@@ -45,8 +45,6 @@ namespace SourceGit.Models
         public void Start()
         {
             _storePath = Path.Combine(Native.OS.CacheDir, "avatars");
-            if (!Directory.Exists(_storePath))
-                Directory.CreateDirectory(_storePath);
 
             LoadDefaultAvatar("noreply@github.com", "github.png");
             LoadDefaultAvatar("unrealbot@epicgames.com", "unreal.png");
@@ -87,6 +85,9 @@ namespace SourceGit.Models
                         url = $"https://avatars.githubusercontent.com/{githubUser}";
                     }
 
+                    if (!Directory.Exists(_storePath))
+                        Directory.CreateDirectory(_storePath);
+                    
                     var localFile = Path.Combine(_storePath, md5);
                     Bitmap img = null;
                     try

--- a/src/Native/Linux.cs
+++ b/src/Native/Linux.cs
@@ -46,6 +46,18 @@ namespace SourceGit.Native
                     return portableDir;
             }
 
+            var homeDir = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+            var dataDir = GetXdgDir("XDG_DATA_HOME");
+
+            if (!Directory.Exists(dataDir)) {
+                foreach (var oldDataDir in new[] { "~/.SourceGit", "~/.config/SourceGit" }) {
+                    if (!Directory.Exists(Path.Combine(homeDir, oldDataDir))) continue;
+
+                    Directory.Move(oldDataDir, dataDir!);
+                    break;
+                }
+            }
+
             return GetXdgDir("XDG_DATA_HOME");
         }
 

--- a/src/Native/Linux.cs
+++ b/src/Native/Linux.cs
@@ -46,9 +46,15 @@ namespace SourceGit.Native
                     return portableDir;
             }
 
-            // Runtime data dir: ~/.sourcegit
+            // Persistent data dir
+            // https://specifications.freedesktop.org/basedir/latest/
             var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
-            return Path.Combine(home, ".sourcegit");
+            
+            string xdg_data = Environment.GetEnvironmentVariable("XDG_DATA_HOME");
+            if (xdg_data == null || !Path.IsPathRooted(xdg_data) || !Directory.Exists(xdg_data))
+                xdg_data = Path.Combine(home, ".local/share/SourceGit");
+            
+            return xdg_data;
         }
 
         public string FindGitExecutable()

--- a/src/Native/Linux.cs
+++ b/src/Native/Linux.cs
@@ -50,7 +50,7 @@ namespace SourceGit.Native
             var dataDir = GetXdgDir("XDG_DATA_HOME");
 
             if (!Directory.Exists(dataDir)) {
-                foreach (var oldDataDir in new[] { "~/.SourceGit", "~/.config/SourceGit" }) {
+                foreach (var oldDataDir in new[] { ".SourceGit", ".config/SourceGit" }) {
                     if (!Directory.Exists(Path.Combine(homeDir, oldDataDir))) continue;
 
                     Directory.Move(oldDataDir, dataDir!);

--- a/src/Native/Linux.cs
+++ b/src/Native/Linux.cs
@@ -46,17 +46,42 @@ namespace SourceGit.Native
                     return portableDir;
             }
 
-            // Persistent data dir
-            // https://specifications.freedesktop.org/basedir/latest/
-            var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
-            
-            string xdg_data = Environment.GetEnvironmentVariable("XDG_DATA_HOME");
-            if (xdg_data == null || !Path.IsPathRooted(xdg_data) || !Directory.Exists(xdg_data))
-                xdg_data = Path.Combine(home, ".local/share/SourceGit");
-            
-            return xdg_data;
+            return GetXdgDir("XDG_DATA_HOME");
         }
 
+        public string GetConfigDir()
+        {
+            return GetXdgDir("XDG_CONFIG_HOME");
+        }
+
+        public string GetCacheDir()
+        {
+            
+            return GetXdgDir("XDG_CACHE_HOME");
+        }
+
+        // Directories according to the XDG user directory standard
+        // https://specifications.freedesktop.org/basedir/latest/
+        private string GetXdgDir(string name)
+        {
+            string fallback;
+            
+            switch(name)
+            {
+                default:
+                case "XDG_DATA_HOME": fallback = ".local/share/SourceGit"; break;
+                case "XDG_CONFIG_HOME": fallback = ".config/SourceGit"; break;
+                case "XDG_CACHE_HOME": fallback = ".cache/SourceGit"; break;
+            }
+            
+            var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+            string dir = Environment.GetEnvironmentVariable(name);
+            if (dir == null || !Path.IsPathRooted(dir))
+                dir = Path.Combine(home, fallback);
+            
+            return dir;
+        }
+        
         public string FindGitExecutable()
         {
             return FindExecutable("git");

--- a/src/Native/Linux.cs
+++ b/src/Native/Linux.cs
@@ -53,6 +53,7 @@ namespace SourceGit.Native
                 foreach (var oldDataDir in new[] { ".SourceGit", ".config/SourceGit" }) {
                     if (!Directory.Exists(Path.Combine(homeDir, oldDataDir))) continue;
 
+                    Directory.Delete(Path.Combine(oldDataDir, "avatars"), true);
                     Directory.Move(oldDataDir, dataDir!);
                     break;
                 }

--- a/src/Native/Linux.cs
+++ b/src/Native/Linux.cs
@@ -69,7 +69,7 @@ namespace SourceGit.Native
 
         // Directories according to the XDG user directory standard
         // https://specifications.freedesktop.org/basedir/latest/
-        private string GetXdgDir(string name)
+        private static string GetXdgDir(string name)
         {
             string fallback;
             

--- a/src/Native/Linux.cs
+++ b/src/Native/Linux.cs
@@ -49,11 +49,6 @@ namespace SourceGit.Native
             return GetXdgDir("XDG_DATA_HOME");
         }
 
-        public string GetConfigDir()
-        {
-            return GetXdgDir("XDG_CONFIG_HOME");
-        }
-
         public string GetCacheDir()
         {
             

--- a/src/Native/MacOS.cs
+++ b/src/Native/MacOS.cs
@@ -54,6 +54,16 @@ namespace SourceGit.Native
                 "SourceGit");
         }
 
+        public string GetConfigDir()
+        {
+            return GetDataDir();
+        }
+
+        public string GetCacheDir()
+        {
+            return GetDataDir();
+        }
+
         public string FindGitExecutable()
         {
             var gitPathVariants = new List<string>() {

--- a/src/Native/MacOS.cs
+++ b/src/Native/MacOS.cs
@@ -54,11 +54,6 @@ namespace SourceGit.Native
                 "SourceGit");
         }
 
-        public string GetConfigDir()
-        {
-            return GetDataDir();
-        }
-
         public string GetCacheDir()
         {
             return GetDataDir();

--- a/src/Native/OS.cs
+++ b/src/Native/OS.cs
@@ -20,7 +20,6 @@ namespace SourceGit.Native
             void SetupWindow(Window window);
 
             string GetDataDir();
-            string GetConfigDir();
             string GetCacheDir();
             string FindGitExecutable();
             string FindTerminal(Models.ShellOrTerminal shell);
@@ -33,12 +32,6 @@ namespace SourceGit.Native
         }
 
         public static string DataDir
-        {
-            get;
-            private set;
-        } = string.Empty;
-        
-        public static string ConfigDir
         {
             get;
             private set;
@@ -152,13 +145,6 @@ namespace SourceGit.Native
             DataDir = _backend.GetDataDir();
             if (!Directory.Exists(DataDir))
                 Directory.CreateDirectory(DataDir);
-        }
-        
-        public static void SetupConfigDir()
-        {
-            ConfigDir = _backend.GetConfigDir();
-            if (!Directory.Exists(ConfigDir))
-                Directory.CreateDirectory(ConfigDir);
         }
         
         public static void SetupCacheDir()

--- a/src/Native/OS.cs
+++ b/src/Native/OS.cs
@@ -149,9 +149,8 @@ namespace SourceGit.Native
         
         public static void SetupCacheDir()
         {
-            CacheDir = _backend.GetCacheDir();
-            if (!Directory.Exists(CacheDir))
-                Directory.CreateDirectory(CacheDir);
+            // cache directory is created when placing data in it
+            return;
         }
 
         public static void SetupApp(AppBuilder builder)

--- a/src/Native/OS.cs
+++ b/src/Native/OS.cs
@@ -20,6 +20,8 @@ namespace SourceGit.Native
             void SetupWindow(Window window);
 
             string GetDataDir();
+            string GetConfigDir();
+            string GetCacheDir();
             string FindGitExecutable();
             string FindTerminal(Models.ShellOrTerminal shell);
             List<Models.ExternalTool> FindExternalTools();
@@ -31,6 +33,18 @@ namespace SourceGit.Native
         }
 
         public static string DataDir
+        {
+            get;
+            private set;
+        } = string.Empty;
+        
+        public static string ConfigDir
+        {
+            get;
+            private set;
+        } = string.Empty;
+        
+        public static string CacheDir
         {
             get;
             private set;
@@ -138,6 +152,20 @@ namespace SourceGit.Native
             DataDir = _backend.GetDataDir();
             if (!Directory.Exists(DataDir))
                 Directory.CreateDirectory(DataDir);
+        }
+        
+        public static void SetupConfigDir()
+        {
+            ConfigDir = _backend.GetConfigDir();
+            if (!Directory.Exists(ConfigDir))
+                Directory.CreateDirectory(ConfigDir);
+        }
+        
+        public static void SetupCacheDir()
+        {
+            CacheDir = _backend.GetCacheDir();
+            if (!Directory.Exists(CacheDir))
+                Directory.CreateDirectory(CacheDir);
         }
 
         public static void SetupApp(AppBuilder builder)

--- a/src/Native/Windows.cs
+++ b/src/Native/Windows.cs
@@ -54,6 +54,16 @@ namespace SourceGit.Native
                 "SourceGit");
         }
 
+        public string GetConfigDir()
+        {
+            return GetDataDir();
+        }
+
+        public string GetCacheDir()
+        {
+            return GetDataDir();
+        }
+
         public string FindGitExecutable()
         {
             var reg = Microsoft.Win32.RegistryKey.OpenBaseKey(

--- a/src/Native/Windows.cs
+++ b/src/Native/Windows.cs
@@ -54,11 +54,6 @@ namespace SourceGit.Native
                 "SourceGit");
         }
 
-        public string GetConfigDir()
-        {
-            return GetDataDir();
-        }
-
         public string GetCacheDir()
         {
             return GetDataDir();


### PR DESCRIPTION
This pull request moves the data directory for linux users to the filesystem location where they will expect it.
General data in `~/.local/share/`, cached git username avatars in `~/.cache/`. Only the former is migrated.

I considered moving the config file to `~/.config/` but I find the "Open Data Storage Directory" function in the menu useful, and I was torn on whether I should point that to the config directory. Currently the data directory does not hold much, just the avatar caches, the config file, and a lock file (which should probably rather go to `/run/user/...`, but that depends on its exact purpose), but perhaps more things would be held in this directory, so I didnt want to risk making them less accessible.

Detailed reasons for implementing this changes can be read here: https://github.com/sourcegit-scm/sourcegit/pull/2088#issuecomment-5089628776

This PR is to supersede #2088 . Linux related functionality is handled in the separate Linux.cs file, with respect to the AppImage portable data function.