### PR TITLE
ux: preview the selected file when navigating file search results

### DIFF
--- a/src/ViewModels/CommitDetail.cs
+++ b/src/ViewModels/CommitDetail.cs
@@ -662,8 +662,7 @@ namespace SourceGit.ViewModels
             var suggestion = new List<string>();
             foreach (var file in _revisionFiles)
             {
-                if (file.Contains(_revisionFileSearchFilter, StringComparison.OrdinalIgnoreCase) &&
-                    file.Length != _revisionFileSearchFilter.Length)
+                if (file.Contains(_revisionFileSearchFilter, StringComparison.OrdinalIgnoreCase))
                     suggestion.Add(file);
 
                 if (suggestion.Count >= 100)

--- a/src/Views/RevisionFileTreeView.axaml
+++ b/src/Views/RevisionFileTreeView.axaml
@@ -8,7 +8,8 @@
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:Class="SourceGit.Views.RevisionFileTreeView"
              x:Name="ThisControl">
-  <v:RevisionFileRowsListBox ItemsSource="{Binding #ThisControl.Rows}"
+  <v:RevisionFileRowsListBox x:Name="RowsList"
+                             ItemsSource="{Binding #ThisControl.Rows}"
                              Background="Transparent"
                              SelectionMode="Single"
                              SelectionChanged="OnRowsSelectionChanged"

--- a/src/Views/RevisionFileTreeView.axaml.cs
+++ b/src/Views/RevisionFileTreeView.axaml.cs
@@ -268,7 +268,6 @@ namespace SourceGit.Views
 
         public async Task SetSearchResultAsync(string file)
         {
-            Rows.Clear();
             _searchResult.Clear();
 
             var rows = new List<ViewModels.RevisionFileTreeNode>();
@@ -324,7 +323,27 @@ namespace SourceGit.Views
                 MakeRows(rows, _searchResult, 0);
             }
 
-            Rows.AddRange(rows);
+            _disableSelectionChangingEvent = true;
+            try
+            {
+                Rows.Clear();
+                Rows.AddRange(rows);
+            }
+            finally
+            {
+                _disableSelectionChangingEvent = false;
+            }
+
+            if (!string.IsNullOrEmpty(file))
+            {
+                var target = rows.Find(x => !x.IsFolder);
+                if (target != null)
+                {
+                    RowsList.SelectedItem = target;
+                    RowsList.ScrollIntoView(target);
+                }
+            }
+
             GC.Collect();
         }
 

--- a/src/Views/RevisionFiles.axaml
+++ b/src/Views/RevisionFiles.axaml
@@ -63,6 +63,7 @@
                            ItemsSource="{Binding RevisionFileSearchSuggestion}"
                            MaxHeight="400"
                            Focusable="True"
+                           SelectionChanged="OnSearchSuggestionSelectionChanged"
                            KeyDown="OnSearchSuggestionBoxKeyDown">
                 <ListBox.Styles>
                   <Style Selector="ListBoxItem">

--- a/src/Views/RevisionFiles.axaml.cs
+++ b/src/Views/RevisionFiles.axaml.cs
@@ -50,6 +50,12 @@ namespace SourceGit.Views
                 await FileTree.SetSearchResultAsync(null);
         }
 
+        private async void OnSearchSuggestionSelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if (sender is ListBox { SelectedItem: string content } && !string.IsNullOrEmpty(content))
+                await FileTree.SetSearchResultAsync(content);
+        }
+
         private async void OnSearchSuggestionBoxKeyDown(object _, KeyEventArgs e)
         {
             if (DataContext is not ViewModels.CommitDetail vm)
@@ -62,9 +68,9 @@ namespace SourceGit.Views
             }
             else if (e.Key == Key.Enter && SearchSuggestionBox.SelectedItem is string content)
             {
-                vm.RevisionFileSearchFilter = content;
-                TxtSearchRevisionFiles.CaretIndex = content.Length;
-                await FileTree.SetSearchResultAsync(vm.RevisionFileSearchFilter);
+                await FileTree.SetSearchResultAsync(content);
+                vm.CancelRevisionFileSuggestions();
+                TxtSearchRevisionFiles.Focus();
                 e.Handled = true;
             }
         }
@@ -77,9 +83,9 @@ namespace SourceGit.Views
             var content = (sender as StackPanel)?.DataContext as string;
             if (!string.IsNullOrEmpty(content))
             {
-                vm.RevisionFileSearchFilter = content;
-                TxtSearchRevisionFiles.CaretIndex = content.Length;
-                await FileTree.SetSearchResultAsync(vm.RevisionFileSearchFilter);
+                await FileTree.SetSearchResultAsync(content);
+                vm.CancelRevisionFileSuggestions();
+                TxtSearchRevisionFiles.Focus();
             }
 
             e.Handled = true;


### PR DESCRIPTION
## Summary

Improves the file search experience in the commit details **Files** tab. Previously, picking a result from the search dropdown only wrote the full path back into the search box and filtered the file tree down to a single file — but the tree node was not selected, so the file content was not shown until the user clicked the file again in the tree.

With this change:

- Navigating the search dropdown with the arrow keys **previews the selected file directly** in the file tree and the content viewer (the tree node is now selected automatically).
- The search keyword is **no longer overwritten** when picking a suggestion, so multiple similarly-named files can be reviewed without re-searching.

## Related issues

I'm aware of the earlier discussions in #730, #775, and especially #962 ("Searching file view does not filter view directly"). The main concern raised there was performance / lazy-loading when filtering the whole tree. This PR deliberately keeps the existing dropdown approach and only ever renders a **single file** in the tree, so it does not introduce the large-repository / UI-freeze concern discussed in those issues.

## Changes

- `Views/RevisionFileTreeView.axaml(.cs)`: select the matched node after rebuilding the tree so the content viewer loads it.
- `Views/RevisionFiles.axaml(.cs)`: hook the dropdown `SelectionChanged` to live-preview the selected item; stop overwriting the search filter; close the dropdown and return focus to the search box on click/Enter.
- `ViewModels/CommitDetail.cs`: drop the exact-path exclusion in the matcher (it was only needed for the old overwrite-the-filter behavior).

5 files changed, 37 insertions(+), 11 deletions(-).
