### PR TITLE
docs: document OrcaRouter as an OpenAI-compatible service

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,12 @@ For `OpenAI`:
 
 * `Server` must be `https://api.openai.com/v1`
 
+For `OrcaRouter`:
+
+* `Server` should be `https://api.orcarouter.ai/v1`
+* `API Key` should be an OrcaRouter API key (prefixed with `sk-orca-`)
+* A good starting `Model` is `orcarouter/auto`, which routes each request to the best available model
+
 For other AI service:
 
 * The `Server` should fill in a URL equivalent to OpenAI's `https://api.openai.com/v1`. For example, when using `Ollama`, it should be `http://localhost:11434/v1` instead of `http://localhost:11434/api/generate`


### PR DESCRIPTION
SourceGit's AI commit-message generator works with any OpenAI-compatible HTTP API, and the README currently documents `OpenAI` and `Ollama` as named examples. This PR adds [OrcaRouter](https://www.orcarouter.ai) to that same section so users can connect it as a first-class service instead of treating it as an anonymous custom `Server` URL.

Changes:
- Added a named `OrcaRouter` entry in the README's OpenAI section, mirroring the existing OpenAI/Ollama bullet style.
- Documented the exact `Server` (`https://api.orcarouter.ai/v1`) — this is an OpenAI-compatible endpoint, so it plugs directly into SourceGit's existing `Server` + `API Key` service configuration with no code changes.
- Documented the `sk-orca-` API key prefix and a starting `Model` of `orcarouter/auto`, which routes each request to the best available model for the workload.

OrcaRouter is an OpenAI-compatible AI gateway built for both models and agents. Like OpenRouter, it exposes a provider/model namespace across many models — but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Adding it as a named provider means SourceGit users can use that stack directly, without treating OrcaRouter as an anonymous custom base URL. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

Verification: the endpoint was live-tested before writing this — `GET https://api.orcarouter.ai/v1/models` returns 200 and includes `orcarouter/auto`, and `POST /v1/chat/completions` with `orcarouter/auto` returns 200, both matching the configuration documented here.

Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter

I'm an engineer on the OrcaRouter team.