### PR TITLE
  ux: add tooltip to copy button in Launcher notification

### DIFF
--- a/src/Views/LauncherPage.axaml
+++ b/src/Views/LauncherPage.axaml
@@ -166,7 +166,7 @@
                         <Path Grid.Column="0" Width="14" Height="14" Data="{StaticResource Icons.Info}" Fill="Green" IsVisible="{Binding !IsError}"/>
                         <TextBlock Grid.Column="1" Margin="8,0,0,0" FontWeight="Bold" FontSize="14" Text="{DynamicResource Text.Launcher.Error}" IsVisible="{Binding IsError}"/>
                         <TextBlock Grid.Column="1" Margin="8,0,0,0" FontWeight="Bold" FontSize="14" Text="{DynamicResource Text.Launcher.Info}" IsVisible="{Binding !IsError}"/>
-                        <v:CopyButton Grid.Column="2" Width="16" Height="16" CopyText="{Binding Message}"/>
+                        <v:CopyButton Grid.Column="2" Width="16" Height="16" CopyText="{Binding Message}" ToolTip.Tip="{DynamicResource Text.Copy}"/>
                         <Button Grid.Column="3" Classes="icon_button" Width="16" Height="16" Margin="8,0,0,0" Click="OnDismissNotification">
                           <Path Width="10" Height="10" Data="{StaticResource Icons.Close}"/>
                         </Button>


### PR DESCRIPTION
## What

Shows a transient checkmark icon as visual feedback when the user copies a notification message, then resets back to the copy icon after one second.

## Changes

- Make `Notification` observable (`ObservableObject`) and add an `IsCopied` property.
- Toggle between the copy icon and a green checkmark in the launcher notification item based on `IsCopied`.
- Add a `DispatcherTimer` in `LauncherPage` to reset `IsCopied` one second after copying.
- Add a tooltip to the copy button.