### PR TITLE
enhance: extract reusable CopyButton control with copy feedback

### DIFF
--- a/src/Views/CommitBaseInfo.axaml
+++ b/src/Views/CommitBaseInfo.axaml
@@ -65,12 +65,7 @@
           <StackPanel Grid.Row="0" Grid.Column="1" Orientation="Horizontal" Height="24">
             <TextBlock Text="{Binding SHA}" Margin="12,0,4,0" FontFamily="{DynamicResource Fonts.Monospace}" VerticalAlignment="Center"/>
 
-            <Button Classes="icon_button" Width="24" Cursor="Hand" Click="OnCopyCommitSHA" ToolTip.Tip="{DynamicResource Text.Copy}">
-              <Grid>
-                <Path Width="12" Height="12" Data="{StaticResource Icons.Copy}" IsVisible="{Binding #ThisControl.IsSHACopied, Mode=OneWay, Converter={x:Static BoolConverters.Not}}"/>
-                <Path Width="14" Height="14" Margin="0,2,0,0" Data="{StaticResource Icons.Check}" Fill="Green" IsVisible="{Binding #ThisControl.IsSHACopied, Mode=OneWay}"/>
-              </Grid>
-            </Button>
+            <v:CopyButton Width="24" Cursor="Hand" CopyText="{Binding SHA}" ToolTip.Tip="{DynamicResource Text.Copy}"/>
 
             <Button Classes="icon_button" Width="24" Cursor="Hand" Click="OnOpenContainsIn" IsVisible="{Binding #ThisControl.SupportsContainsIn}" ToolTip.Tip="{DynamicResource Text.CommitDetail.Info.ContainsIn}">
               <Path Width="14" Height="14" Margin="0,1,0,0" Data="{StaticResource Icons.Milestone}"/>

--- a/src/Views/CommitBaseInfo.axaml.cs
+++ b/src/Views/CommitBaseInfo.axaml.cs
@@ -5,7 +5,6 @@ using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Interactivity;
-using Avalonia.Threading;
 
 namespace SourceGit.Views
 {
@@ -47,17 +46,6 @@ namespace SourceGit.Views
             set => SetAndRaise(WebLinksProperty, ref _webLinks, value);
         }
 
-        public static readonly DirectProperty<CommitBaseInfo, bool> IsSHACopiedProperty =
-            AvaloniaProperty.RegisterDirect<CommitBaseInfo, bool>(
-                nameof(IsSHACopied),
-                static o => o.IsSHACopied);
-
-        public bool IsSHACopied
-        {
-            get => _isSHACopied;
-            private set => SetAndRaise(IsSHACopiedProperty, ref _isSHACopied, value);
-        }
-
         public static readonly DirectProperty<CommitBaseInfo, bool> SupportsContainsInProperty =
             AvaloniaProperty.RegisterDirect<CommitBaseInfo, bool>(
                 nameof(SupportsContainsIn),
@@ -80,45 +68,6 @@ namespace SourceGit.Views
             SupportsContainsIn = DataContext is ViewModels.CommitDetail;
         }
 
-        protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
-        {
-            base.OnPropertyChanged(change);
-
-            if (change.Property == ContentProperty)
-            {
-                IsSHACopied = false;
-                _iconResetTimer?.Stop();
-            }
-        }
-
-        protected override void OnLoaded(RoutedEventArgs e)
-        {
-            base.OnLoaded(e);
-
-            _iconResetTimer = new DispatcherTimer();
-            _iconResetTimer.Interval = TimeSpan.FromSeconds(1);
-            _iconResetTimer.Tag = this;
-            _iconResetTimer.Tick += static (o, _) =>
-            {
-                if (o is DispatcherTimer { Tag: CommitBaseInfo view } timer)
-                {
-                    if (view.IsSHACopied)
-                        view.IsSHACopied = false;
-
-                    timer.IsEnabled = false;
-                }
-            };
-            _iconResetTimer.IsEnabled = false;
-        }
-
-        protected override void OnUnloaded(RoutedEventArgs e)
-        {
-            _iconResetTimer.Tag = null;
-            _iconResetTimer.IsEnabled = false;
-
-            base.OnUnloaded(e);
-        }
-
         private void OnDateTimeContextMenuRequested(object sender, ContextRequestedEventArgs e)
         {
             if (sender is DateTimePresenter presenter)
@@ -137,16 +86,6 @@ namespace SourceGit.Views
                 menu.Open(presenter);
                 e.Handled = true;
             }
-        }
-
-        private async void OnCopyCommitSHA(object sender, RoutedEventArgs e)
-        {
-            if (sender is Button { DataContext: Models.Commit commit })
-                await this.CopyTextAsync(commit.SHA);
-
-            IsSHACopied = true;
-            _iconResetTimer?.Start();
-            e.Handled = true;
         }
 
         private void OnOpenWebLink(object sender, RoutedEventArgs e)
@@ -323,7 +262,5 @@ namespace SourceGit.Views
         private Models.CommitSignInfo _signInfo = null;
         private bool _supportsContainsIn = false;
         private List<Models.CommitLink> _webLinks = null;
-        private bool _isSHACopied = false;
-        private DispatcherTimer _iconResetTimer = null;
     }
 }

--- a/src/Views/CopyButton.cs
+++ b/src/Views/CopyButton.cs
@@ -13,13 +13,16 @@ namespace SourceGit.Views
     {
         protected override Type StyleKeyOverride => typeof(Button);
 
-        public static readonly StyledProperty<string> CopyTextProperty =
-            AvaloniaProperty.Register<CopyButton, string>(nameof(CopyText), string.Empty);
+        public static readonly DirectProperty<CopyButton, string> CopyTextProperty =
+            AvaloniaProperty.RegisterDirect<CopyButton, string>(
+                nameof(CopyText),
+                static o => o.CopyText,
+                static (o, v) => o.CopyText = v);
 
         public string CopyText
         {
-            get => GetValue(CopyTextProperty);
-            set => SetValue(CopyTextProperty, value);
+            get => _copyText;
+            set => SetAndRaise(CopyTextProperty, ref _copyText, value);
         }
 
         public static readonly DirectProperty<CopyButton, bool> IsCopiedProperty =
@@ -115,6 +118,7 @@ namespace SourceGit.Views
 
         private readonly Path _copyIcon;
         private readonly Path _checkIcon;
+        private string _copyText = string.Empty;
         private bool _isCopied = false;
         private DispatcherTimer _resetTimer = null;
     }

--- a/src/Views/CopyButton.cs
+++ b/src/Views/CopyButton.cs
@@ -78,12 +78,8 @@ namespace SourceGit.Views
 
         protected override void OnUnloaded(RoutedEventArgs e)
         {
-            if (_resetTimer != null)
-            {
-                _resetTimer.Tag = null;
-                _resetTimer.IsEnabled = false;
-            }
-
+            _resetTimer.Tag = null;
+            _resetTimer.IsEnabled = false;
             base.OnUnloaded(e);
         }
 
@@ -109,9 +105,10 @@ namespace SourceGit.Views
             base.OnClick();
 
             var text = CopyText;
-            if (!string.IsNullOrEmpty(text))
-                await this.CopyTextAsync(text);
+            if (string.IsNullOrEmpty(text))
+                return;
 
+            await this.CopyTextAsync(text);
             IsCopied = true;
             _resetTimer?.Start();
         }

--- a/src/Views/CopyButton.cs
+++ b/src/Views/CopyButton.cs
@@ -1,0 +1,124 @@
+using System;
+
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Shapes;
+using Avalonia.Interactivity;
+using Avalonia.Media;
+using Avalonia.Threading;
+
+namespace SourceGit.Views
+{
+    public class CopyButton : Button
+    {
+        protected override Type StyleKeyOverride => typeof(Button);
+
+        public static readonly StyledProperty<string> CopyTextProperty =
+            AvaloniaProperty.Register<CopyButton, string>(nameof(CopyText), string.Empty);
+
+        public string CopyText
+        {
+            get => GetValue(CopyTextProperty);
+            set => SetValue(CopyTextProperty, value);
+        }
+
+        public static readonly DirectProperty<CopyButton, bool> IsCopiedProperty =
+            AvaloniaProperty.RegisterDirect<CopyButton, bool>(
+                nameof(IsCopied),
+                static o => o.IsCopied);
+
+        public bool IsCopied
+        {
+            get => _isCopied;
+            private set => SetAndRaise(IsCopiedProperty, ref _isCopied, value);
+        }
+
+        public CopyButton()
+        {
+            Classes.Add("icon_button");
+
+            _copyIcon = new Path() { Width = 12, Height = 12 };
+            _checkIcon = new Path()
+            {
+                Width = 14,
+                Height = 14,
+                Margin = new Thickness(0, 2, 0, 0),
+                Fill = Brushes.Green,
+                IsVisible = false,
+            };
+
+            var grid = new Grid();
+            grid.Children.Add(_copyIcon);
+            grid.Children.Add(_checkIcon);
+            Content = grid;
+        }
+
+        protected override void OnLoaded(RoutedEventArgs e)
+        {
+            base.OnLoaded(e);
+
+            if (this.FindResource("Icons.Copy") is Geometry copyGeo)
+                _copyIcon.Data = copyGeo;
+            if (this.FindResource("Icons.Check") is Geometry checkGeo)
+                _checkIcon.Data = checkGeo;
+
+            _resetTimer = new DispatcherTimer();
+            _resetTimer.Interval = TimeSpan.FromSeconds(1);
+            _resetTimer.Tag = this;
+            _resetTimer.Tick += static (o, _) =>
+            {
+                if (o is DispatcherTimer { Tag: CopyButton btn } timer)
+                {
+                    btn.IsCopied = false;
+                    timer.IsEnabled = false;
+                }
+            };
+            _resetTimer.IsEnabled = false;
+        }
+
+        protected override void OnUnloaded(RoutedEventArgs e)
+        {
+            if (_resetTimer != null)
+            {
+                _resetTimer.Tag = null;
+                _resetTimer.IsEnabled = false;
+            }
+
+            base.OnUnloaded(e);
+        }
+
+        protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
+        {
+            base.OnPropertyChanged(change);
+
+            if (change.Property == IsCopiedProperty)
+            {
+                _copyIcon.IsVisible = !_isCopied;
+                _checkIcon.IsVisible = _isCopied;
+            }
+            else if (change.Property == CopyTextProperty)
+            {
+                // Reset the copied state when CopyText changes (e.g. switching to a different commit)
+                IsCopied = false;
+                _resetTimer?.Stop();
+            }
+        }
+
+        protected override async void OnClick()
+        {
+            base.OnClick();
+
+            var text = CopyText;
+            if (!string.IsNullOrEmpty(text))
+                await this.CopyTextAsync(text);
+
+            IsCopied = true;
+            _resetTimer?.Start();
+        }
+
+        private readonly Path _copyIcon;
+        private readonly Path _checkIcon;
+        private bool _isCopied = false;
+        private DispatcherTimer _resetTimer = null;
+    }
+}

--- a/src/Views/LauncherPage.axaml
+++ b/src/Views/LauncherPage.axaml
@@ -166,9 +166,7 @@
                         <Path Grid.Column="0" Width="14" Height="14" Data="{StaticResource Icons.Info}" Fill="Green" IsVisible="{Binding !IsError}"/>
                         <TextBlock Grid.Column="1" Margin="8,0,0,0" FontWeight="Bold" FontSize="14" Text="{DynamicResource Text.Launcher.Error}" IsVisible="{Binding IsError}"/>
                         <TextBlock Grid.Column="1" Margin="8,0,0,0" FontWeight="Bold" FontSize="14" Text="{DynamicResource Text.Launcher.Info}" IsVisible="{Binding !IsError}"/>
-                        <Button Grid.Column="2" Classes="icon_button" Width="16" Height="16" Click="OnCopyNotification">
-                          <Path Width="12" Height="12" Data="{StaticResource Icons.Copy}"/>
-                        </Button>
+                        <v:CopyButton Grid.Column="2" Width="16" Height="16" CopyText="{Binding Message}"/>
                         <Button Grid.Column="3" Classes="icon_button" Width="16" Height="16" Margin="8,0,0,0" Click="OnDismissNotification">
                           <Path Width="10" Height="10" Data="{StaticResource Icons.Close}"/>
                         </Button>

--- a/src/Views/LauncherPage.axaml.cs
+++ b/src/Views/LauncherPage.axaml.cs
@@ -72,14 +72,6 @@ namespace SourceGit.Views
             OnPopupCancel(sender, e);
         }
 
-        private async void OnCopyNotification(object sender, RoutedEventArgs e)
-        {
-            if (sender is Button { DataContext: Models.Notification notice })
-                await this.CopyTextAsync(notice.Message);
-
-            e.Handled = true;
-        }
-
         private void OnDismissNotification(object sender, RoutedEventArgs e)
         {
             if (sender is Button { DataContext: Models.Notification notice } &&


### PR DESCRIPTION
## What
Extracts the "copy + show checkmark for 1s" logic into a reusable
`CopyButton` control (`src/Views/CopyButton.cs`), and uses it in:
- `CommitBaseInfo` (copy commit SHA)
- `LauncherPage` (copy notification message)

## Why
Both places previously implemented very similar copy-feedback logic
(a `DispatcherTimer` + two icons toggled by an `IsCopied` flag)
separately. `CopyButton` consolidates this into one control driven by
a `CopyText` property, so no changes to data models are needed.

## Note
This overlaps with #2666, which adds the same copy-feedback UX to
`LauncherPage` via `Notification.IsCopied`. Left a comment there to
discuss which approach to land on.