### PR TITLE
show parent folder name on tabs for repositories with duplicate names

### DIFF
--- a/src/ViewModels/EditRepositoryNode.cs
+++ b/src/ViewModels/EditRepositoryNode.cs
@@ -48,6 +48,7 @@ namespace SourceGit.ViewModels
             {
                 Preferences.Instance.SortByRenamedNode(_node);
                 Welcome.Instance.Refresh();
+                App.GetLauncher().RefreshTabDisplayNames();
             }
 
             return Task.FromResult(true);

--- a/src/ViewModels/Launcher.cs
+++ b/src/ViewModels/Launcher.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Text;
 
@@ -244,6 +245,7 @@ namespace SourceGit.ViewModels
 
             CloseRepositoryInTab(page);
             Pages.RemoveAt(removeIdx);
+            RefreshTabDisplayNames();
             GC.Collect();
         }
 
@@ -266,6 +268,7 @@ namespace SourceGit.ViewModels
 
             _activeWorkspace.ActiveIdx = 0;
             _ignoreIndexChange = false;
+            RefreshTabDisplayNames();
             GC.Collect();
         }
 
@@ -281,6 +284,7 @@ namespace SourceGit.ViewModels
             }
 
             _ignoreIndexChange = false;
+            RefreshTabDisplayNames();
             GC.Collect();
         }
 
@@ -371,6 +375,8 @@ namespace SourceGit.ViewModels
                 PostActivePageChanged();
             else
                 ActivePage = page;
+
+            RefreshTabDisplayNames();
         }
 
         public void OpenSubRepository(LauncherPage ownerPage, string fullpath)
@@ -437,6 +443,50 @@ namespace SourceGit.ViewModels
             Pages.Insert(idxOfOwner + 1, page);
             _activeWorkspace.Repositories.Insert(idxOfOwner + 1, normalizedPath);
             ActivePage = page;
+
+            RefreshTabDisplayNames();
+        }
+
+        public void RefreshTabDisplayNames()
+        {
+            var nameUsages = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+            foreach (var page in Pages)
+            {
+                if (page.Node is not { IsRepository: true })
+                    continue;
+
+                nameUsages.TryGetValue(page.Node.Name, out var count);
+                nameUsages[page.Node.Name] = count + 1;
+            }
+
+            foreach (var page in Pages)
+            {
+                if (page.Node is not { IsRepository: true } node)
+                    continue;
+
+                nameUsages.TryGetValue(node.Name, out var count);
+                if (count > 1)
+                {
+                    var parent = GetParentFolderName(node.Id);
+                    page.DisplayName = string.IsNullOrEmpty(parent) ? node.Name : $"{node.Name} ({parent})";
+                }
+                else
+                {
+                    page.DisplayName = node.Name;
+                }
+            }
+        }
+
+        private static string GetParentFolderName(string repoPath)
+        {
+            var normalized = repoPath.Replace('\\', '/').TrimEnd('/');
+            var idx = normalized.LastIndexOf('/');
+            if (idx < 0)
+                return string.Empty;
+
+            var parent = normalized.Substring(0, idx).TrimEnd('/');
+            idx = parent.LastIndexOf('/');
+            return idx < 0 ? parent : parent.Substring(idx + 1);
         }
 
         private void DispatchNotification(Models.Notification notification)

--- a/src/ViewModels/LauncherPage.cs
+++ b/src/ViewModels/LauncherPage.cs
@@ -31,6 +31,12 @@ namespace SourceGit.ViewModels
             set => SetProperty(ref _popup, value);
         }
 
+        public string DisplayName
+        {
+            get => _displayName;
+            set => SetProperty(ref _displayName, value);
+        }
+
         public AvaloniaList<Models.Notification> Notifications
         {
             get;
@@ -50,6 +56,7 @@ namespace SourceGit.ViewModels
         {
             _node = node;
             _data = repo;
+            _displayName = node.Name;
         }
 
         public void ClearNotifications()
@@ -124,6 +131,7 @@ namespace SourceGit.ViewModels
 
         private RepositoryNode _node = null;
         private object _data = null;
+        private string _displayName = string.Empty;
         private Models.DirtyState _dirtyState = Models.DirtyState.None;
         private Popup _popup = null;
     }

--- a/src/Views/LauncherTabBar.axaml
+++ b/src/Views/LauncherTabBar.axaml
@@ -110,7 +110,7 @@
                                VerticalAlignment="Center"
                                FontSize="{Binding Source={x:Static vm:Preferences.Instance}, Path=DefaultFontSize, Converter={x:Static c:DoubleConverters.Decrease}}"
                                TextAlignment="Center"
-                               Text="{Binding Node.Name}"
+                               Text="{Binding DisplayName}"
                                IsHitTestVisible="False"/>
                   </Grid>
 


### PR DESCRIPTION
## Description

When multiple repositories with the same name are opened at the same time, their tabs are indistinguishable — you can only tell them apart by switching through them one by one.

This PR makes the tab bar disambiguate duplicate names by appending the parent folder name:

- unique name: `repo`
- duplicated name: `repo (parent-folder)`

## Implementation

- Add a `DisplayName` property to `LauncherPage` (initialized to the node name) and bind the tab text to it instead of `Node.Name`.
- Add `Launcher.RefreshTabDisplayNames()`, which counts repository tab names and appends the parent folder (from the repository path) only when a name is used by more than one open tab.
- Refresh display names whenever the tab set can change: opening a repository/sub-repository, closing a tab / other tabs / tabs on the right, and renaming a repository node in preferences.

No behavior change for uniquely-named tabs.