### PR TITLE
feat: responsive layouts and optional split views

### DIFF
--- a/src/Models/RepositoryUIStates.cs
+++ b/src/Models/RepositoryUIStates.cs
@@ -7,6 +7,12 @@ using Avalonia.Collections;
 
 namespace SourceGit.Models
 {
+    public enum RepositoryWorkspaceOrientation
+    {
+        SideBySide,
+        Stacked,
+    }
+
     public class RepositoryUIStates
     {
         public HistoryShowFlags HistoryShowFlags
@@ -44,6 +50,30 @@ namespace SourceGit.Models
             get;
             set;
         } = 120;
+
+        public int SplitPrimaryViewIndex
+        {
+            get;
+            set;
+        } = -1;
+
+        public int SecondaryViewIndex
+        {
+            get;
+            set;
+        } = -1;
+
+        public RepositoryWorkspaceOrientation WorkspaceOrientation
+        {
+            get;
+            set;
+        } = RepositoryWorkspaceOrientation.SideBySide;
+
+        public double WorkspaceSplitRatio
+        {
+            get;
+            set;
+        } = 0.5;
 
         public bool EnableTopoOrderInHistory
         {

--- a/src/Models/RepositoryUIStates.cs
+++ b/src/Models/RepositoryUIStates.cs
@@ -13,6 +13,12 @@ namespace SourceGit.Models
         Stacked,
     }
 
+    public enum RepositoryNavigationPlacement
+    {
+        Sidebar,
+        Top,
+    }
+
     public class RepositoryUIStates
     {
         public HistoryShowFlags HistoryShowFlags
@@ -74,6 +80,12 @@ namespace SourceGit.Models
             get;
             set;
         } = 0.5;
+
+        public RepositoryNavigationPlacement NavigationPlacement
+        {
+            get;
+            set;
+        } = RepositoryNavigationPlacement.Sidebar;
 
         public bool EnableTopoOrderInHistory
         {

--- a/src/Resources/Locales/en_US.axaml
+++ b/src/Resources/Locales/en_US.axaml
@@ -797,6 +797,7 @@
   <x:String x:Key="Text.Repository.Clean" xml:space="preserve">Cleanup (GC &amp; Prune)</x:String>
   <x:String x:Key="Text.Repository.CleanTips" xml:space="preserve">Run `git gc` command for this repository.</x:String>
   <x:String x:Key="Text.Repository.ClearAllCommitsFilter" xml:space="preserve">Clear all</x:String>
+  <x:String x:Key="Text.Repository.CloseSecondaryView" xml:space="preserve">Close Secondary View</x:String>
   <x:String x:Key="Text.Repository.ClearStashes" xml:space="preserve">Clear</x:String>
   <x:String x:Key="Text.Repository.Configure" xml:space="preserve">Configure this repository</x:String>
   <x:String x:Key="Text.Repository.Continue" xml:space="preserve">CONTINUE</x:String>
@@ -826,6 +827,7 @@
   <x:String x:Key="Text.Repository.Notifications.Clear" xml:space="preserve">CLEAR NOTIFICATIONS</x:String>
   <x:String x:Key="Text.Repository.OpenAsFolder" xml:space="preserve">Open as Folder</x:String>
   <x:String x:Key="Text.Repository.OpenIn" xml:space="preserve">Open in {0}</x:String>
+  <x:String x:Key="Text.Repository.OpenInSecondary" xml:space="preserve">Open in Secondary Pane</x:String>
   <x:String x:Key="Text.Repository.OpenWithExternalTools" xml:space="preserve">Open in External Tools</x:String>
   <x:String x:Key="Text.Repository.Remotes" xml:space="preserve">REMOTES</x:String>
   <x:String x:Key="Text.Repository.Remotes.Add" xml:space="preserve">Add Remote</x:String>
@@ -834,6 +836,9 @@
   <x:String x:Key="Text.Repository.Search.ByAuthor" xml:space="preserve">Author</x:String>
   <x:String x:Key="Text.Repository.Search.ByContent" xml:space="preserve">Content</x:String>
   <x:String x:Key="Text.Repository.Search.ByMessage" xml:space="preserve">Message</x:String>
+  <x:String x:Key="Text.Repository.SplitSideBySide" xml:space="preserve">Split Side by Side</x:String>
+  <x:String x:Key="Text.Repository.SplitStacked" xml:space="preserve">Split Stacked</x:String>
+  <x:String x:Key="Text.Repository.SwapViews" xml:space="preserve">Swap Views</x:String>
   <x:String x:Key="Text.Repository.Search.ByPath" xml:space="preserve">Path</x:String>
   <x:String x:Key="Text.Repository.Search.BySHA" xml:space="preserve">SHA</x:String>
   <x:String x:Key="Text.Repository.Search.InCurrentBranch" xml:space="preserve">Current Branch</x:String>

--- a/src/Resources/Locales/en_US.axaml
+++ b/src/Resources/Locales/en_US.axaml
@@ -797,8 +797,8 @@
   <x:String x:Key="Text.Repository.Clean" xml:space="preserve">Cleanup (GC &amp; Prune)</x:String>
   <x:String x:Key="Text.Repository.CleanTips" xml:space="preserve">Run `git gc` command for this repository.</x:String>
   <x:String x:Key="Text.Repository.ClearAllCommitsFilter" xml:space="preserve">Clear all</x:String>
-  <x:String x:Key="Text.Repository.CloseSecondaryView" xml:space="preserve">Close Secondary View</x:String>
   <x:String x:Key="Text.Repository.ClearStashes" xml:space="preserve">Clear</x:String>
+  <x:String x:Key="Text.Repository.CloseSecondaryView" xml:space="preserve">Close Secondary View</x:String>
   <x:String x:Key="Text.Repository.Configure" xml:space="preserve">Configure this repository</x:String>
   <x:String x:Key="Text.Repository.Continue" xml:space="preserve">CONTINUE</x:String>
   <x:String x:Key="Text.Repository.CustomActions" xml:space="preserve">Custom Actions</x:String>
@@ -823,6 +823,10 @@
   <x:String x:Key="Text.Repository.LocalBranches" xml:space="preserve">LOCAL BRANCHES</x:String>
   <x:String x:Key="Text.Repository.MoreOptions" xml:space="preserve">More options...</x:String>
   <x:String x:Key="Text.Repository.NavigateToCurrentHead" xml:space="preserve">Navigate to HEAD</x:String>
+  <x:String x:Key="Text.Repository.Navigation" xml:space="preserve">Repository navigation</x:String>
+  <x:String x:Key="Text.Repository.NavigationPlacement" xml:space="preserve">VIEW NAVIGATION</x:String>
+  <x:String x:Key="Text.Repository.NavigationPlacement.Sidebar" xml:space="preserve">Sidebar</x:String>
+  <x:String x:Key="Text.Repository.NavigationPlacement.Top" xml:space="preserve">Top</x:String>
   <x:String x:Key="Text.Repository.NewBranch" xml:space="preserve">Create Branch</x:String>
   <x:String x:Key="Text.Repository.Notifications.Clear" xml:space="preserve">CLEAR NOTIFICATIONS</x:String>
   <x:String x:Key="Text.Repository.OpenAsFolder" xml:space="preserve">Open as Folder</x:String>
@@ -836,9 +840,6 @@
   <x:String x:Key="Text.Repository.Search.ByAuthor" xml:space="preserve">Author</x:String>
   <x:String x:Key="Text.Repository.Search.ByContent" xml:space="preserve">Content</x:String>
   <x:String x:Key="Text.Repository.Search.ByMessage" xml:space="preserve">Message</x:String>
-  <x:String x:Key="Text.Repository.SplitSideBySide" xml:space="preserve">Split Side by Side</x:String>
-  <x:String x:Key="Text.Repository.SplitStacked" xml:space="preserve">Split Stacked</x:String>
-  <x:String x:Key="Text.Repository.SwapViews" xml:space="preserve">Swap Views</x:String>
   <x:String x:Key="Text.Repository.Search.ByPath" xml:space="preserve">Path</x:String>
   <x:String x:Key="Text.Repository.Search.BySHA" xml:space="preserve">SHA</x:String>
   <x:String x:Key="Text.Repository.Search.InCurrentBranch" xml:space="preserve">Current Branch</x:String>
@@ -849,7 +850,10 @@
   <x:String x:Key="Text.Repository.ShowSubmodulesAsTree" xml:space="preserve">Show Submodules as Tree</x:String>
   <x:String x:Key="Text.Repository.ShowTagsAsTree" xml:space="preserve">Show Tags as Tree</x:String>
   <x:String x:Key="Text.Repository.Skip" xml:space="preserve">SKIP</x:String>
+  <x:String x:Key="Text.Repository.SplitSideBySide" xml:space="preserve">Split Side by Side</x:String>
+  <x:String x:Key="Text.Repository.SplitStacked" xml:space="preserve">Split Stacked</x:String>
   <x:String x:Key="Text.Repository.Statistics" xml:space="preserve">Statistics</x:String>
+  <x:String x:Key="Text.Repository.SwapViews" xml:space="preserve">Swap Views</x:String>
   <x:String x:Key="Text.Repository.Submodules" xml:space="preserve">SUBMODULES</x:String>
   <x:String x:Key="Text.Repository.Submodules.Add" xml:space="preserve">Add Submodule</x:String>
   <x:String x:Key="Text.Repository.Submodules.Update" xml:space="preserve">Update Submodule</x:String>

--- a/src/ViewModels/Repository.cs
+++ b/src/ViewModels/Repository.cs
@@ -74,11 +74,67 @@ namespace SourceGit.ViewModels
             get => _selectedViewIndex;
             set
             {
+                if (!IsValidWorkspaceView(value))
+                    return;
+
+                if (IsSplitViewEnabled && value == SecondaryViewIndex)
+                {
+                    SwapWorkspaceViews();
+                    return;
+                }
+
                 if (SetProperty(ref _selectedViewIndex, value))
                 {
-                    OnPropertyChanged(nameof(IsHistoriesVisible));
-                    OnPropertyChanged(nameof(IsWorkingCopyVisible));
-                    OnPropertyChanged(nameof(IsStashesVisible));
+                    if (IsSplitViewEnabled)
+                        _uiStates.SplitPrimaryViewIndex = value;
+                    NotifyWorkspaceVisibilityChanged();
+                }
+            }
+        }
+
+        public int SecondaryViewIndex
+        {
+            get => _uiStates.SecondaryViewIndex;
+            private set
+            {
+                if (_uiStates.SecondaryViewIndex != value)
+                {
+                    _uiStates.SecondaryViewIndex = value;
+                    OnPropertyChanged();
+                    OnPropertyChanged(nameof(IsSplitViewEnabled));
+                    NotifyWorkspaceVisibilityChanged();
+                }
+            }
+        }
+
+        public bool IsSplitViewEnabled
+        {
+            get => SecondaryViewIndex >= 0;
+        }
+
+        public Models.RepositoryWorkspaceOrientation WorkspaceOrientation
+        {
+            get => _uiStates.WorkspaceOrientation;
+            private set
+            {
+                if (_uiStates.WorkspaceOrientation != value)
+                {
+                    _uiStates.WorkspaceOrientation = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
+        public double WorkspaceSplitRatio
+        {
+            get => double.IsFinite(_uiStates.WorkspaceSplitRatio) ? Math.Clamp(_uiStates.WorkspaceSplitRatio, 0.2, 0.8) : 0.5;
+            set
+            {
+                var ratio = double.IsFinite(value) ? Math.Clamp(value, 0.2, 0.8) : 0.5;
+                if (Math.Abs(_uiStates.WorkspaceSplitRatio - ratio) > 0.001)
+                {
+                    _uiStates.WorkspaceSplitRatio = ratio;
+                    OnPropertyChanged();
                 }
             }
         }
@@ -100,17 +156,70 @@ namespace SourceGit.ViewModels
 
         public bool IsHistoriesVisible
         {
-            get => SelectedViewIndex == 0;
+            get => SelectedViewIndex == 0 || SecondaryViewIndex == 0;
         }
 
         public bool IsWorkingCopyVisible
         {
-            get => SelectedViewIndex == 1;
+            get => SelectedViewIndex == 1 || SecondaryViewIndex == 1;
         }
 
         public bool IsStashesVisible
         {
-            get => SelectedViewIndex == 2;
+            get => SelectedViewIndex == 2 || SecondaryViewIndex == 2;
+        }
+
+        public void OpenViewInSecondary(int viewIndex, Models.RepositoryWorkspaceOrientation orientation)
+        {
+            if (!IsValidWorkspaceView(viewIndex) || viewIndex == SelectedViewIndex)
+                return;
+
+            if (!IsSplitViewEnabled)
+                _uiStates.SplitPrimaryViewIndex = SelectedViewIndex;
+
+            WorkspaceOrientation = orientation;
+            SecondaryViewIndex = viewIndex;
+        }
+
+        public void SetWorkspaceOrientation(Models.RepositoryWorkspaceOrientation orientation)
+        {
+            if (IsSplitViewEnabled)
+                WorkspaceOrientation = orientation;
+        }
+
+        public void CloseSecondaryView()
+        {
+            if (!IsSplitViewEnabled)
+                return;
+
+            SecondaryViewIndex = -1;
+            _uiStates.SplitPrimaryViewIndex = -1;
+        }
+
+        public void SwapWorkspaceViews()
+        {
+            if (!IsSplitViewEnabled)
+                return;
+
+            var primary = SelectedViewIndex;
+            _selectedViewIndex = SecondaryViewIndex;
+            _uiStates.SecondaryViewIndex = primary;
+            _uiStates.SplitPrimaryViewIndex = _selectedViewIndex;
+            OnPropertyChanged(nameof(SelectedViewIndex));
+            OnPropertyChanged(nameof(SecondaryViewIndex));
+            NotifyWorkspaceVisibilityChanged();
+        }
+
+        private bool IsValidWorkspaceView(int viewIndex)
+        {
+            return viewIndex == 0 || (!IsBare && viewIndex is 1 or 2);
+        }
+
+        private void NotifyWorkspaceVisibilityChanged()
+        {
+            OnPropertyChanged(nameof(IsHistoriesVisible));
+            OnPropertyChanged(nameof(IsWorkingCopyVisible));
+            OnPropertyChanged(nameof(IsStashesVisible));
         }
 
         public bool EnableTopoOrderInHistory
@@ -495,10 +604,36 @@ namespace SourceGit.ViewModels
             _workingCopy = new WorkingCopy(this) { CommitMessage = _uiStates.LastCommitMessage };
             _stashesPage = new StashesPage(this);
             _searchCommitContext = new SearchCommitContext(this);
-            _selectedViewIndex = Preferences.Instance.ShowLocalChangesByDefault ? 1 : 0;
+            RestoreWorkspaceState();
             _lastFetchTime = DateTime.Now;
             _autoFetchTimer = new Timer(AutoFetchByTimer, null, 5000, 5000);
             RefreshAll();
+        }
+
+        private void RestoreWorkspaceState()
+        {
+            var defaultView = Preferences.Instance.ShowLocalChangesByDefault && !IsBare ? 1 : 0;
+            var primary = _uiStates.SplitPrimaryViewIndex;
+            var secondary = _uiStates.SecondaryViewIndex;
+            if (!IsValidWorkspaceView(primary) ||
+                !IsValidWorkspaceView(secondary) ||
+                primary == secondary)
+            {
+                _selectedViewIndex = defaultView;
+                _uiStates.SplitPrimaryViewIndex = -1;
+                _uiStates.SecondaryViewIndex = -1;
+            }
+            else
+            {
+                _selectedViewIndex = primary;
+            }
+
+            if (!Enum.IsDefined(_uiStates.WorkspaceOrientation))
+                _uiStates.WorkspaceOrientation = Models.RepositoryWorkspaceOrientation.SideBySide;
+
+            _uiStates.WorkspaceSplitRatio = double.IsFinite(_uiStates.WorkspaceSplitRatio)
+                ? Math.Clamp(_uiStates.WorkspaceSplitRatio, 0.2, 0.8)
+                : 0.5;
         }
 
         public void Close()

--- a/src/ViewModels/Repository.cs
+++ b/src/ViewModels/Repository.cs
@@ -139,6 +139,24 @@ namespace SourceGit.ViewModels
             }
         }
 
+        public Models.RepositoryNavigationPlacement NavigationPlacement
+        {
+            get => _uiStates.NavigationPlacement;
+            private set
+            {
+                if (_uiStates.NavigationPlacement != value)
+                {
+                    _uiStates.NavigationPlacement = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
+        public void SetNavigationPlacement(Models.RepositoryNavigationPlacement placement)
+        {
+            NavigationPlacement = placement;
+        }
+
         public Histories Histories
         {
             get => _histories;
@@ -630,6 +648,9 @@ namespace SourceGit.ViewModels
 
             if (!Enum.IsDefined(_uiStates.WorkspaceOrientation))
                 _uiStates.WorkspaceOrientation = Models.RepositoryWorkspaceOrientation.SideBySide;
+
+            if (!Enum.IsDefined(_uiStates.NavigationPlacement))
+                _uiStates.NavigationPlacement = Models.RepositoryNavigationPlacement.Sidebar;
 
             _uiStates.WorkspaceSplitRatio = double.IsFinite(_uiStates.WorkspaceSplitRatio)
                 ? Math.Clamp(_uiStates.WorkspaceSplitRatio, 0.2, 0.8)

--- a/src/Views/DiffView.axaml.cs
+++ b/src/Views/DiffView.axaml.cs
@@ -43,7 +43,11 @@ namespace SourceGit.Views
             if (DataContext is ViewModels.DiffContext vm)
                 vm.CheckSettings();
 
-            ToggleHotkeyBindings(IsEffectivelyVisible);
+            var repository = this.FindAncestorOfType<Repository>();
+            if (repository != null)
+                repository.UpdateWorkspaceHotkeys();
+            else
+                ToggleHotkeyBindings(IsEffectivelyVisible);
         }
 
         private void OnGotoFirstChange(object _, RoutedEventArgs e)

--- a/src/Views/Histories.axaml
+++ b/src/Views/Histories.axaml
@@ -10,8 +10,7 @@
              x:Class="SourceGit.Views.Histories"
              x:DataType="vm:Histories"
              x:Name="ThisControl">
-  <v:HistoriesLayout UseHorizontal="{Binding Source={x:Static vm:Preferences.Instance}, Path=UseTwoColumnsLayoutInHistories}"
-                     SizeChanged="OnHistoriesSizeChanged">
+  <v:HistoriesLayout UseHorizontal="{Binding Source={x:Static vm:Preferences.Instance}, Path=UseTwoColumnsLayoutInHistories}">
     <v:HistoriesLayout.RowDefinitions>
       <RowDefinition Height="{Binding TopArea, Mode=TwoWay}" MinHeight="100"/>
       <RowDefinition Height="3"/>
@@ -34,6 +33,7 @@
                              SelectedCommits="{Binding SelectedCommits, Mode=TwoWay}"
                              ColumnHeaderHeight="24"
                              RowHeight="26"
+                             SizeChanged="OnCommitListSizeChanged"
                              LayoutUpdated="OnCommitListLayoutUpdated"
                              ContextRequested="OnCommitListContextRequested"
                              DoubleTapped="OnCommitListDoubleTapped">
@@ -100,7 +100,7 @@
         </DataGrid.Styles>
 
         <DataGrid.Columns>
-          <DataGridTemplateColumn Width="*" IsReadOnly="True">
+          <v:HistoriesDataGridColumn Name="GraphAndSubjectColumn" Width="*" IsReadOnly="True">
             <DataGridTemplateColumn.Header>
               <TextBlock Classes="table_header" Text="{DynamicResource Text.Histories.Header.GraphAndSubject}" HorizontalAlignment="Center"/>
             </DataGridTemplateColumn.Header>
@@ -147,9 +147,9 @@
                 </Border>
               </DataTemplate>
             </DataGridTemplateColumn.CellTemplate>
-          </DataGridTemplateColumn>
+          </v:HistoriesDataGridColumn>
 
-          <DataGridTemplateColumn MinWidth="80" IsReadOnly="True" IsVisible="{Binding IsAuthorColumnVisible, Mode=OneWay}">
+          <v:HistoriesDataGridColumn Name="AuthorColumn" MinWidth="80" IsReadOnly="True">
             <DataGridTemplateColumn.Header>
               <TextBlock Classes="table_header" Text="{DynamicResource Text.Histories.Header.Author}" HorizontalAlignment="Center"/>
             </DataGridTemplateColumn.Header>
@@ -175,9 +175,9 @@
                 </Grid>
               </DataTemplate>
             </DataGridTemplateColumn.CellTemplate>
-          </DataGridTemplateColumn>
+          </v:HistoriesDataGridColumn>
 
-          <DataGridTemplateColumn MinWidth="100" IsReadOnly="True" IsVisible="{Binding IsSHAColumnVisible, Mode=OneWay}">
+          <v:HistoriesDataGridColumn Name="SHAColumn" MinWidth="100" IsReadOnly="True">
             <DataGridTemplateColumn.Header>
               <TextBlock Classes="table_header" Text="{DynamicResource Text.Histories.Header.SHA}" HorizontalAlignment="Center"/>
             </DataGridTemplateColumn.Header>
@@ -192,9 +192,9 @@
                 </Border>
               </DataTemplate>
             </DataGridTemplateColumn.CellTemplate>
-          </DataGridTemplateColumn>
+          </v:HistoriesDataGridColumn>
 
-          <DataGridTemplateColumn MinWidth="160" IsReadOnly="True" IsVisible="{Binding IsAuthorTimeColumnVisible, Mode=OneWay}">
+          <v:HistoriesDataGridColumn Name="AuthorTimeColumn" MinWidth="160" IsReadOnly="True">
             <DataGridTemplateColumn.Header>
               <TextBlock Classes="table_header" Text="{DynamicResource Text.Histories.Header.AuthorTime}" HorizontalAlignment="Center"/>
             </DataGridTemplateColumn.Header>
@@ -212,9 +212,9 @@
                 </Border>
               </DataTemplate>
             </DataGridTemplateColumn.CellTemplate>
-          </DataGridTemplateColumn>
+          </v:HistoriesDataGridColumn>
 
-          <DataGridTemplateColumn MinWidth="160" IsReadOnly="True" IsVisible="{Binding IsCommitTimeColumnVisible, Mode=OneWay}">
+          <v:HistoriesDataGridColumn Name="CommitTimeColumn" MinWidth="160" IsReadOnly="True">
             <DataGridTemplateColumn.Header>
               <TextBlock Classes="table_header" Text="{DynamicResource Text.Histories.Header.CommitTime}" HorizontalAlignment="Center"/>
             </DataGridTemplateColumn.Header>
@@ -232,7 +232,7 @@
                 </Border>
               </DataTemplate>
             </DataGridTemplateColumn.CellTemplate>
-          </DataGridTemplateColumn>
+          </v:HistoriesDataGridColumn>
         </DataGrid.Columns>
       </v:HistoriesCommitList>
 

--- a/src/Views/Histories.axaml
+++ b/src/Views/Histories.axaml
@@ -10,7 +10,8 @@
              x:Class="SourceGit.Views.Histories"
              x:DataType="vm:Histories"
              x:Name="ThisControl">
-  <v:HistoriesLayout UseHorizontal="{Binding Source={x:Static vm:Preferences.Instance}, Path=UseTwoColumnsLayoutInHistories}">
+  <v:HistoriesLayout UseHorizontal="{Binding Source={x:Static vm:Preferences.Instance}, Path=UseTwoColumnsLayoutInHistories}"
+                     SizeChanged="OnHistoriesSizeChanged">
     <v:HistoriesLayout.RowDefinitions>
       <RowDefinition Height="{Binding TopArea, Mode=TwoWay}" MinHeight="100"/>
       <RowDefinition Height="3"/>

--- a/src/Views/Histories.axaml.cs
+++ b/src/Views/Histories.axaml.cs
@@ -36,19 +36,26 @@ namespace SourceGit.Views
         {
             base.OnPropertyChanged(change);
 
-            if (change.Property == UseHorizontalProperty && IsLoaded)
+            if ((change.Property == UseHorizontalProperty || change.Property == BoundsProperty) && IsLoaded)
                 RefreshLayout();
         }
 
         protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
         {
             base.OnAttachedToVisualTree(e);
-            RefreshLayout();
+            RefreshLayout(true);
         }
 
-        private void RefreshLayout()
+        private void RefreshLayout(bool force = false)
         {
-            if (UseHorizontal)
+            var useHorizontal = UseHorizontal && Bounds.Width >= 720;
+            if (!force && _hasAppliedLayout && useHorizontal == _lastUseHorizontal)
+                return;
+
+            _hasAppliedLayout = true;
+            _lastUseHorizontal = useHorizontal;
+
+            if (useHorizontal)
             {
                 var rowSpan = RowDefinitions.Count;
                 for (int i = 0; i < Children.Count; i++)
@@ -81,6 +88,8 @@ namespace SourceGit.Views
         }
 
         private bool _useHorizontal = false;
+        private bool _hasAppliedLayout;
+        private bool _lastUseHorizontal;
     }
 
     public class HistoriesCommitList : DataGrid
@@ -372,6 +381,19 @@ namespace SourceGit.Views
         public Histories()
         {
             InitializeComponent();
+        }
+
+        private void OnHistoriesSizeChanged(object _, SizeChangedEventArgs e)
+        {
+            if (!e.WidthChanged || DataContext is not ViewModels.Histories vm || CommitListContainer.Columns.Count < 5)
+                return;
+
+            var compact = e.NewSize.Width < 720;
+            var medium = e.NewSize.Width < 980;
+            CommitListContainer.Columns[1].SetCurrentValue(DataGridColumn.IsVisibleProperty, !compact && vm.IsAuthorColumnVisible);
+            CommitListContainer.Columns[2].SetCurrentValue(DataGridColumn.IsVisibleProperty, !compact && vm.IsSHAColumnVisible);
+            CommitListContainer.Columns[3].SetCurrentValue(DataGridColumn.IsVisibleProperty, !medium && vm.IsAuthorTimeColumnVisible);
+            CommitListContainer.Columns[4].SetCurrentValue(DataGridColumn.IsVisibleProperty, !medium && vm.IsCommitTimeColumnVisible);
         }
 
         public async Task GotoParent()

--- a/src/Views/Histories.axaml.cs
+++ b/src/Views/Histories.axaml.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
 using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
@@ -304,8 +306,19 @@ namespace SourceGit.Views
         private List<Models.Commit> _selectedCommits = [];
     }
 
+    public class HistoriesDataGridColumn : DataGridTemplateColumn
+    {
+        public string Name
+        {
+            get;
+            set;
+        } = string.Empty;
+    }
+
     public partial class Histories : UserControl
     {
+        private const double GraphAndSubjectMinWidth = 320;
+
         public static readonly DirectProperty<Histories, Models.Branch> CurrentBranchProperty =
             AvaloniaProperty.RegisterDirect<Histories, Models.Branch>(
                 nameof(CurrentBranch),
@@ -381,19 +394,101 @@ namespace SourceGit.Views
         public Histories()
         {
             InitializeComponent();
+            GraphAndSubjectColumn = FindColumn(nameof(GraphAndSubjectColumn));
+            AuthorColumn = FindColumn(nameof(AuthorColumn));
+            SHAColumn = FindColumn(nameof(SHAColumn));
+            AuthorTimeColumn = FindColumn(nameof(AuthorTimeColumn));
+            CommitTimeColumn = FindColumn(nameof(CommitTimeColumn));
+            GraphAndSubjectColumn.MinWidth = GraphAndSubjectMinWidth;
         }
 
-        private void OnHistoriesSizeChanged(object _, SizeChangedEventArgs e)
+        private HistoriesDataGridColumn FindColumn(string name)
         {
-            if (!e.WidthChanged || DataContext is not ViewModels.Histories vm || CommitListContainer.Columns.Count < 5)
+            return CommitListContainer.Columns.OfType<HistoriesDataGridColumn>().Single(x => x.Name == name);
+        }
+
+        protected override void OnLoaded(RoutedEventArgs e)
+        {
+            base.OnLoaded(e);
+
+            if (DataContext is ViewModels.Histories vm)
+                SubscribeToViewModel(vm);
+
+            ApplyResponsiveCommitColumns();
+        }
+
+        protected override void OnUnloaded(RoutedEventArgs e)
+        {
+            UnsubscribeFromViewModel();
+            base.OnUnloaded(e);
+        }
+
+        private void OnCommitListSizeChanged(object _, SizeChangedEventArgs e)
+        {
+            if (e.WidthChanged)
+                ApplyResponsiveCommitColumns();
+        }
+
+        private void ApplyResponsiveCommitColumns()
+        {
+            if (DataContext is not ViewModels.Histories vm || CommitListContainer.Bounds.Width <= 0)
                 return;
 
-            var compact = e.NewSize.Width < 720;
-            var medium = e.NewSize.Width < 980;
-            CommitListContainer.Columns[1].SetCurrentValue(DataGridColumn.IsVisibleProperty, !compact && vm.IsAuthorColumnVisible);
-            CommitListContainer.Columns[2].SetCurrentValue(DataGridColumn.IsVisibleProperty, !compact && vm.IsSHAColumnVisible);
-            CommitListContainer.Columns[3].SetCurrentValue(DataGridColumn.IsVisibleProperty, !medium && vm.IsAuthorTimeColumnVisible);
-            CommitListContainer.Columns[4].SetCurrentValue(DataGridColumn.IsVisibleProperty, !medium && vm.IsCommitTimeColumnVisible);
+            var authorWidth = Math.Max(AuthorColumn.MinWidth, vm.AuthorColumnWidth);
+            AuthorColumn.Width = new DataGridLength(authorWidth, DataGridLengthUnitType.Pixel);
+
+            var remaining = Math.Max(0, CommitListContainer.Bounds.Width - GraphAndSubjectMinWidth);
+            bool AdmitColumn(DataGridColumn column, bool requested, double width)
+            {
+                var visible = requested && remaining >= width;
+                if (visible)
+                    remaining -= width;
+
+                column.SetCurrentValue(DataGridColumn.IsVisibleProperty, visible);
+                return visible;
+            }
+
+            AdmitColumn(AuthorColumn, vm.IsAuthorColumnVisible, authorWidth);
+
+            if (vm.IsCommitTimeColumnVisible)
+                AdmitColumn(CommitTimeColumn, true, CommitTimeColumn.MinWidth);
+            else
+                AdmitColumn(AuthorTimeColumn, vm.IsAuthorTimeColumnVisible, AuthorTimeColumn.MinWidth);
+
+            AdmitColumn(SHAColumn, vm.IsSHAColumnVisible, SHAColumn.MinWidth);
+
+            if (vm.IsCommitTimeColumnVisible)
+                AdmitColumn(AuthorTimeColumn, vm.IsAuthorTimeColumnVisible, AuthorTimeColumn.MinWidth);
+            else
+                CommitTimeColumn.SetCurrentValue(DataGridColumn.IsVisibleProperty, false);
+        }
+
+        private void SubscribeToViewModel(ViewModels.Histories vm)
+        {
+            if (_subscribedViewModel == vm)
+                return;
+
+            UnsubscribeFromViewModel();
+            _subscribedViewModel = vm;
+            _subscribedViewModel.PropertyChanged += OnHistoriesViewModelPropertyChanged;
+        }
+
+        private void UnsubscribeFromViewModel()
+        {
+            if (_subscribedViewModel == null)
+                return;
+
+            _subscribedViewModel.PropertyChanged -= OnHistoriesViewModelPropertyChanged;
+            _subscribedViewModel = null;
+        }
+
+        private void OnHistoriesViewModelPropertyChanged(object sender, PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName is nameof(ViewModels.Histories.IsAuthorColumnVisible) or
+                nameof(ViewModels.Histories.IsSHAColumnVisible) or
+                nameof(ViewModels.Histories.IsAuthorTimeColumnVisible) or
+                nameof(ViewModels.Histories.IsCommitTimeColumnVisible))
+                ApplyResponsiveCommitColumns();
         }
 
         public async Task GotoParent()
@@ -487,7 +582,17 @@ namespace SourceGit.Views
             base.OnDataContextChanged(e);
 
             if (DataContext is ViewModels.Histories vm)
-                CommitListContainer.Columns[1].Width = new(vm.AuthorColumnWidth, DataGridLengthUnitType.Pixel);
+            {
+                if (IsLoaded)
+                    SubscribeToViewModel(vm);
+                AuthorColumn.Width = new(vm.AuthorColumnWidth, DataGridLengthUnitType.Pixel);
+            }
+            else
+            {
+                UnsubscribeFromViewModel();
+            }
+
+            ApplyResponsiveCommitColumns();
         }
 
         private void OnCommitListHeaderPointerMoved(object sender, PointerEventArgs e)
@@ -495,22 +600,26 @@ namespace SourceGit.Views
             if (sender is not Border border)
                 return;
 
-            if (DataContext is not ViewModels.Histories { IsAuthorColumnVisible: true } vm)
+            if (DataContext is not ViewModels.Histories vm)
+                return;
+
+            if (!AuthorColumn.IsVisible)
                 return;
 
             var pos = e.GetPosition(border);
             if (_resizingAuthorColumn)
             {
-                var posX = CommitListContainer.Columns[0].ActualWidth;
-                var maxW = posX + CommitListContainer.Columns[1].ActualWidth - 100;
+                var posX = GraphAndSubjectColumn.ActualWidth;
+                var otherColumnsWidth = GetVisibleMetadataWidthExceptAuthor();
+                var maxW = Math.Max(AuthorColumn.MinWidth, CommitListContainer.Bounds.Width - GraphAndSubjectMinWidth - otherColumnsWidth);
                 var delta = posX - pos.X;
-                var w = Math.Max(Math.Min(vm.AuthorColumnWidth + delta, maxW), 80);
-                CommitListContainer.Columns[1].Width = new(w, DataGridLengthUnitType.Pixel);
+                var w = Math.Clamp(vm.AuthorColumnWidth + delta, AuthorColumn.MinWidth, maxW);
+                AuthorColumn.Width = new(w, DataGridLengthUnitType.Pixel);
                 vm.AuthorColumnWidth = w;
             }
             else
             {
-                var dis = CommitListContainer.Columns[0].ActualWidth - 4 - pos.X;
+                var dis = GraphAndSubjectColumn.ActualWidth - 4 - pos.X;
                 if (dis < 4 && dis > -4)
                 {
                     if (border.Cursor != _resizingCursor)
@@ -528,8 +637,11 @@ namespace SourceGit.Views
             if (sender is not Border border)
                 return;
 
+            if (!AuthorColumn.IsVisible)
+                return;
+
             var pos = e.GetPosition(border);
-            var dis = CommitListContainer.Columns[0].ActualWidth - 4 - pos.X;
+            var dis = GraphAndSubjectColumn.ActualWidth - 4 - pos.X;
             if (dis > 4 || dis < -4)
                 return;
 
@@ -543,6 +655,18 @@ namespace SourceGit.Views
         private void OnCommitListHeaderPointerReleased(object sender, PointerReleasedEventArgs e)
         {
             _resizingAuthorColumn = false;
+        }
+
+        private double GetVisibleMetadataWidthExceptAuthor()
+        {
+            var width = 0.0;
+            if (SHAColumn.IsVisible)
+                width += SHAColumn.ActualWidth;
+            if (AuthorTimeColumn.IsVisible)
+                width += AuthorTimeColumn.ActualWidth;
+            if (CommitTimeColumn.IsVisible)
+                width += CommitTimeColumn.ActualWidth;
+            return width;
         }
 
         private void OnCommitListHeaderContextRequested(object sender, ContextRequestedEventArgs e)
@@ -636,7 +760,7 @@ namespace SourceGit.Views
 
             IsScrollToTopVisible = startY >= rowHeight;
 
-            var clipWidth = dataGrid.Columns[0].ActualWidth - 4;
+            var clipWidth = GraphAndSubjectColumn.ActualWidth - 4;
             var lastLayout = CommitGraph.Layout;
             if (lastLayout == null ||
                 Math.Abs(lastLayout.StartY - startY) > 0.01 ||
@@ -1776,5 +1900,11 @@ namespace SourceGit.Views
         private bool _isDetailsPanelExpanded = true;
         private bool _resizingAuthorColumn = false;
         private Cursor _resizingCursor = new(StandardCursorType.SizeWestEast);
+        private ViewModels.Histories _subscribedViewModel = null;
+        private HistoriesDataGridColumn GraphAndSubjectColumn { get; }
+        private HistoriesDataGridColumn AuthorColumn { get; }
+        private HistoriesDataGridColumn SHAColumn { get; }
+        private HistoriesDataGridColumn AuthorTimeColumn { get; }
+        private HistoriesDataGridColumn CommitTimeColumn { get; }
     }
 }

--- a/src/Views/Launcher.axaml
+++ b/src/Views/Launcher.axaml
@@ -11,7 +11,7 @@
                     x:Name="ThisControl"
                     Icon="/App.ico"
                     Title="{Binding Title}"
-                    MinWidth="1024" MinHeight="600">
+                    MinWidth="720" MinHeight="480">
   <Grid>
     <Grid.RowDefinitions>
       <RowDefinition Height="{Binding #ThisControl.CaptionHeight}"/>

--- a/src/Views/Launcher.axaml
+++ b/src/Views/Launcher.axaml
@@ -11,7 +11,7 @@
                     x:Name="ThisControl"
                     Icon="/App.ico"
                     Title="{Binding Title}"
-                    MinWidth="720" MinHeight="480">
+                    MinWidth="480" MinHeight="360">
   <Grid>
     <Grid.RowDefinitions>
       <RowDefinition Height="{Binding #ThisControl.CaptionHeight}"/>

--- a/src/Views/Repository.axaml
+++ b/src/Views/Repository.axaml
@@ -35,10 +35,10 @@
         <Button Classes="icon_button" Width="40" Height="34" Click="OnOpenCompactSidebar" ToolTip.Tip="Repository navigation">
           <Path Width="16" Height="16" Data="{StaticResource Icons.Menu}"/>
         </Button>
-        <Button Classes="icon_button" Width="40" Height="34" Tag="0" Click="OnCompactViewSelected" ToolTip.Tip="{DynamicResource Text.Histories}">
+        <Button Classes="icon_button" Width="40" Height="34" Tag="0" Click="OnCompactViewSelected" ContextRequested="OnRepositoryViewContextRequested" ToolTip.Tip="{DynamicResource Text.Histories}">
           <Path Width="16" Height="16" Data="{StaticResource Icons.Histories}"/>
         </Button>
-        <Button Classes="icon_button" Width="40" Height="34" Tag="1" Click="OnCompactViewSelected" ToolTip.Tip="{DynamicResource Text.WorkingCopy}">
+        <Button Classes="icon_button" Width="40" Height="34" Tag="1" Click="OnCompactViewSelected" ContextRequested="OnRepositoryViewContextRequested" ToolTip.Tip="{DynamicResource Text.WorkingCopy}">
           <Grid>
             <Path Width="16" Height="16" Data="{StaticResource Icons.Changes}"/>
             <Border MinWidth="16" Height="16" Padding="4,0" Margin="17,-12,-12,0"
@@ -50,7 +50,7 @@
             </Border>
           </Grid>
         </Button>
-        <Button Classes="icon_button" Width="40" Height="34" Tag="2" Click="OnCompactViewSelected" ToolTip.Tip="{DynamicResource Text.Stashes}">
+        <Button Classes="icon_button" Width="40" Height="34" Tag="2" Click="OnCompactViewSelected" ContextRequested="OnRepositoryViewContextRequested" ToolTip.Tip="{DynamicResource Text.Stashes}">
           <Path Width="16" Height="16" Data="{StaticResource Icons.Stashes}"/>
         </Button>
       </StackPanel>
@@ -149,7 +149,7 @@
               </ItemsPanelTemplate>
             </ListBox.ItemsPanel>
 
-            <ListBoxItem>
+            <ListBoxItem Tag="0" ContextRequested="OnRepositoryViewContextRequested">
               <Grid ColumnDefinitions="4,Auto,*,Auto">
                 <Rectangle Grid.Column="0" Classes="indicator" Width="4" Height="20" VerticalAlignment="Center"/>
                 <Path Grid.Column="1" Classes="icon" Data="{StaticResource Icons.Histories}"/>
@@ -164,7 +164,7 @@
               </Grid>
             </ListBoxItem>
 
-            <ListBoxItem IsVisible="{Binding !IsBare}">
+            <ListBoxItem Tag="1" ContextRequested="OnRepositoryViewContextRequested" IsVisible="{Binding !IsBare}">
               <Grid ColumnDefinitions="4,Auto,*,Auto,Auto,Auto">
                 <Rectangle Grid.Column="0" Classes="indicator" Width="4" Height="20" VerticalAlignment="Center"/>
                 <Path Grid.Column="1" Classes="icon" Data="{StaticResource Icons.Changes}"/>
@@ -197,7 +197,7 @@
               </Grid>
             </ListBoxItem>
 
-            <ListBoxItem IsVisible="{Binding !IsBare}">
+            <ListBoxItem Tag="2" ContextRequested="OnRepositoryViewContextRequested" IsVisible="{Binding !IsBare}">
               <Grid ColumnDefinitions="4,Auto,*,Auto,Auto">
                 <Rectangle Grid.Column="0" Classes="indicator" Width="4" Height="20" VerticalAlignment="Center"/>
                 <Path Grid.Column="1" Classes="icon" Data="{StaticResource Icons.Stashes}"/>
@@ -1063,8 +1063,22 @@
         </Grid>
       </Border>
 
-      <Grid Grid.Row="3">
-        <Border Background="{DynamicResource Brush.HistoryBG}" IsVisible="{Binding IsHistoriesVisible, Mode=OneWay}" PropertyChanged="OnRightPagePropertyChanged">
+      <Grid x:Name="WorkspaceHost" Grid.Row="3" SizeChanged="OnWorkspaceHostSizeChanged">
+        <Grid.ColumnDefinitions>
+          <ColumnDefinition Width="*"/>
+          <ColumnDefinition Width="0"/>
+          <ColumnDefinition Width="0"/>
+        </Grid.ColumnDefinitions>
+        <Grid.RowDefinitions>
+          <RowDefinition Height="*"/>
+          <RowDefinition Height="0"/>
+          <RowDefinition Height="0"/>
+        </Grid.RowDefinitions>
+
+        <Border x:Name="HistoriesPage"
+                Background="{DynamicResource Brush.HistoryBG}"
+                PointerEntered="OnWorkspacePagePointerEntered"
+                GotFocus="OnWorkspacePageGotFocus">
           <v:Histories DataContext="{Binding Histories, Mode=OneWay}"
                        CurrentBranch="{Binding CurrentBranch, Mode=OneWay}"
                        Bisect="{Binding Bisect, Mode=OneWay}"
@@ -1079,13 +1093,31 @@
           </v:Histories>
         </Border>
 
-        <Border IsVisible="{Binding IsWorkingCopyVisible, Mode=OneWay}" PropertyChanged="OnRightPagePropertyChanged">
+        <Border x:Name="WorkingCopyPage"
+                IsVisible="False"
+                PointerEntered="OnWorkspacePagePointerEntered"
+                GotFocus="OnWorkspacePageGotFocus">
           <v:WorkingCopy DataContext="{Binding WorkingCopy, Mode=OneWay}"/>
         </Border>
 
-        <Border IsVisible="{Binding IsStashesVisible, Mode=OneWay}" PropertyChanged="OnRightPagePropertyChanged">
+        <Border x:Name="StashesPage"
+                IsVisible="False"
+                PointerEntered="OnWorkspacePagePointerEntered"
+                GotFocus="OnWorkspacePageGotFocus">
           <v:StashesPage DataContext="{Binding StashesPage, Mode=OneWay}"/>
         </Border>
+
+        <GridSplitter x:Name="WorkspaceSplitter"
+                      Grid.Column="1"
+                      Width="4"
+                      MinWidth="1" MinHeight="1"
+                      HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
+                      Background="Transparent"
+                      BorderBrush="{DynamicResource Brush.Border0}"
+                      Focusable="False"
+                      ResizeBehavior="PreviousAndNext"
+                      DragCompleted="OnWorkspaceSplitterDragCompleted"
+                      IsVisible="False"/>
       </Grid>
     </Grid>
 

--- a/src/Views/Repository.axaml
+++ b/src/Views/Repository.axaml
@@ -9,17 +9,58 @@
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:Class="SourceGit.Views.Repository"
              x:DataType="vm:Repository">
-  <Grid>
+  <Grid x:Name="RootLayout" SizeChanged="OnRepositorySizeChanged">
     <Grid.ColumnDefinitions>
       <ColumnDefinition Width="{Binding Source={x:Static vm:Preferences.Instance}, Path=Layout.RepositorySidebarWidth, Mode=TwoWay}" MinWidth="200"/>
       <ColumnDefinition Width="3"/>
       <ColumnDefinition Width="*" MinWidth="200"/>
     </Grid.ColumnDefinitions>
 
+    <!-- Compact navigation rail. At tiled widths the full repository tree becomes a drawer. -->
+    <Border x:Name="CompactSidebarBackdrop"
+            Grid.Column="0" Grid.ColumnSpan="3"
+            ZIndex="90"
+            Background="#66000000"
+            IsVisible="False"
+            PointerPressed="OnCompactSidebarBackdropPressed"/>
+
+    <Border x:Name="CompactNavigationRail"
+            Grid.Column="0"
+            ZIndex="80"
+            BorderThickness="0,0,1,0"
+            BorderBrush="{DynamicResource Brush.Border0}"
+            Background="{DynamicResource Brush.Window}"
+            IsVisible="False">
+      <StackPanel Margin="0,6" Spacing="4">
+        <Button Classes="icon_button" Width="40" Height="34" Click="OnOpenCompactSidebar" ToolTip.Tip="Repository navigation">
+          <Path Width="16" Height="16" Data="{StaticResource Icons.Menu}"/>
+        </Button>
+        <Button Classes="icon_button" Width="40" Height="34" Tag="0" Click="OnCompactViewSelected" ToolTip.Tip="{DynamicResource Text.Histories}">
+          <Path Width="16" Height="16" Data="{StaticResource Icons.Histories}"/>
+        </Button>
+        <Button Classes="icon_button" Width="40" Height="34" Tag="1" Click="OnCompactViewSelected" ToolTip.Tip="{DynamicResource Text.WorkingCopy}">
+          <Grid>
+            <Path Width="16" Height="16" Data="{StaticResource Icons.Changes}"/>
+            <Border MinWidth="16" Height="16" Padding="4,0" Margin="17,-12,-12,0"
+                    HorizontalAlignment="Right" VerticalAlignment="Top"
+                    CornerRadius="8" Background="{DynamicResource Brush.Badge}"
+                    IsVisible="{Binding LocalChangesCount, Mode=OneWay, Converter={x:Static c:IntConverters.IsGreaterThanZero}}">
+              <TextBlock Text="{Binding LocalChangesCount, Mode=OneWay}" FontSize="9"
+                         Foreground="{DynamicResource Brush.BadgeFG}" HorizontalAlignment="Center"/>
+            </Border>
+          </Grid>
+        </Button>
+        <Button Classes="icon_button" Width="40" Height="34" Tag="2" Click="OnCompactViewSelected" ToolTip.Tip="{DynamicResource Text.Stashes}">
+          <Path Width="16" Height="16" Data="{StaticResource Icons.Stashes}"/>
+        </Button>
+      </StackPanel>
+    </Border>
+
     <!-- Left Panel -->
-    <Grid Grid.Column="0" RowDefinitions="Auto,*">
+    <Grid x:Name="FullSidebar" Grid.Column="0" RowDefinitions="Auto,*" ZIndex="100" Background="{DynamicResource Brush.Window}">
       <!-- Page Switcher for Left Contents (Dashboard or CommitSearch) -->
-      <StackPanel Grid.Row="0" Margin="0,6" Height="24" HorizontalAlignment="Center" Orientation="Horizontal">
+      <Grid Grid.Row="0" Margin="0,6" Height="24">
+        <StackPanel HorizontalAlignment="Center" Orientation="Horizontal">
         <RadioButton Classes="switch_button"
                      Width="48"
                      GroupName="SearchGroup"
@@ -47,13 +88,26 @@
           </ToolTip.Tip>
           <Path Width="12" Height="12" Stretch="Fill" HorizontalAlignment="Center" Data="{StaticResource Icons.Search}"/>
         </RadioButton>
-      </StackPanel>
+        </StackPanel>
+        <Button x:Name="CompactSidebarCloseButton"
+                Classes="icon_button"
+                Width="28" Height="24" Margin="0,0,6,0"
+                HorizontalAlignment="Right"
+                Click="OnCloseCompactSidebar"
+                ToolTip.Tip="Close navigation"
+                IsVisible="False">
+          <Path Width="12" Height="12" Data="{StaticResource Icons.Close}"/>
+        </Button>
+      </Grid>
 
       <!-- Dashboard -->
       <Grid Grid.Row="1" Margin="0,0,0,8" RowDefinitions="Auto,Auto,*" IsVisible="{Binding !IsSearchingCommits}">
         <!-- Page Switcher for Right Panel -->
         <Border Grid.Row="0" Margin="8,0,4,0" BorderThickness="1" BorderBrush="{DynamicResource Brush.Border2}" CornerRadius="6">
-          <ListBox Background="Transparent" Padding="4" SelectedIndex="{Binding SelectedViewIndex, Mode=TwoWay}" SelectionMode="AlwaysSelected">
+          <ListBox Background="Transparent" Padding="4"
+                   SelectedIndex="{Binding SelectedViewIndex, Mode=TwoWay}"
+                   SelectionMode="AlwaysSelected"
+                   SelectionChanged="OnRepositoryViewSelectionChanged">
             <ListBox.Styles>
               <Style Selector="Path.icon">
                 <Setter Property="Width" Value="12"/>
@@ -707,7 +761,7 @@
     </Grid>
 
     <!-- Splitter -->
-    <GridSplitter Grid.Column="1"
+    <GridSplitter x:Name="SidebarSplitter" Grid.Column="1"
                   MinWidth="1"
                   HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
                   Background="Transparent"

--- a/src/Views/Repository.axaml
+++ b/src/Views/Repository.axaml
@@ -32,27 +32,30 @@
             Background="{DynamicResource Brush.Window}"
             IsVisible="False">
       <StackPanel Margin="0,6" Spacing="4">
-        <Button Classes="icon_button" Width="40" Height="34" Click="OnOpenCompactSidebar" ToolTip.Tip="Repository navigation">
+        <Button Classes="icon_button" Width="40" Height="34" Click="OnOpenCompactSidebar" ToolTip.Tip="{DynamicResource Text.Repository.Navigation}">
           <Path Width="16" Height="16" Data="{StaticResource Icons.Menu}"/>
         </Button>
-        <Button Classes="icon_button" Width="40" Height="34" Tag="0" Click="OnCompactViewSelected" ContextRequested="OnRepositoryViewContextRequested" ToolTip.Tip="{DynamicResource Text.Histories}">
-          <Path Width="16" Height="16" Data="{StaticResource Icons.Histories}"/>
-        </Button>
-        <Button Classes="icon_button" Width="40" Height="34" Tag="1" Click="OnCompactViewSelected" ContextRequested="OnRepositoryViewContextRequested" ToolTip.Tip="{DynamicResource Text.WorkingCopy}">
-          <Grid>
-            <Path Width="16" Height="16" Data="{StaticResource Icons.Changes}"/>
-            <Border MinWidth="16" Height="16" Padding="4,0" Margin="17,-12,-12,0"
-                    HorizontalAlignment="Right" VerticalAlignment="Top"
-                    CornerRadius="8" Background="{DynamicResource Brush.Badge}"
-                    IsVisible="{Binding LocalChangesCount, Mode=OneWay, Converter={x:Static c:IntConverters.IsGreaterThanZero}}">
-              <TextBlock Text="{Binding LocalChangesCount, Mode=OneWay}" FontSize="9"
-                         Foreground="{DynamicResource Brush.BadgeFG}" HorizontalAlignment="Center"/>
-            </Border>
-          </Grid>
-        </Button>
-        <Button Classes="icon_button" Width="40" Height="34" Tag="2" Click="OnCompactViewSelected" ContextRequested="OnRepositoryViewContextRequested" ToolTip.Tip="{DynamicResource Text.Stashes}">
-          <Path Width="16" Height="16" Data="{StaticResource Icons.Stashes}"/>
-        </Button>
+        <StackPanel Spacing="4"
+                    IsVisible="{Binding NavigationPlacement, Converter={x:Static ObjectConverters.Equal}, ConverterParameter={x:Static m:RepositoryNavigationPlacement.Sidebar}}">
+          <Button Classes="icon_button" Width="40" Height="34" Tag="0" Click="OnCompactViewSelected" ContextRequested="OnRepositoryViewContextRequested" ToolTip.Tip="{DynamicResource Text.Histories}">
+            <Path Width="16" Height="16" Data="{StaticResource Icons.Histories}"/>
+          </Button>
+          <Button Classes="icon_button" Width="40" Height="34" Tag="1" Click="OnCompactViewSelected" ContextRequested="OnRepositoryViewContextRequested" ToolTip.Tip="{DynamicResource Text.WorkingCopy}" IsVisible="{Binding !IsBare}">
+            <Grid>
+              <Path Width="16" Height="16" Data="{StaticResource Icons.Changes}"/>
+              <Border MinWidth="16" Height="16" Padding="4,0" Margin="17,-12,-12,0"
+                      HorizontalAlignment="Right" VerticalAlignment="Top"
+                      CornerRadius="8" Background="{DynamicResource Brush.Badge}"
+                      IsVisible="{Binding LocalChangesCount, Mode=OneWay, Converter={x:Static c:IntConverters.IsGreaterThanZero}}">
+                <TextBlock Text="{Binding LocalChangesCount, Mode=OneWay}" FontSize="9"
+                           Foreground="{DynamicResource Brush.BadgeFG}" HorizontalAlignment="Center"/>
+              </Border>
+            </Grid>
+          </Button>
+          <Button Classes="icon_button" Width="40" Height="34" Tag="2" Click="OnCompactViewSelected" ContextRequested="OnRepositoryViewContextRequested" ToolTip.Tip="{DynamicResource Text.Stashes}" IsVisible="{Binding !IsBare}">
+            <Path Width="16" Height="16" Data="{StaticResource Icons.Stashes}"/>
+          </Button>
+        </StackPanel>
       </StackPanel>
     </Border>
 
@@ -61,40 +64,40 @@
       <!-- Page Switcher for Left Contents (Dashboard or CommitSearch) -->
       <Grid Grid.Row="0" Margin="0,6" Height="24">
         <StackPanel HorizontalAlignment="Center" Orientation="Horizontal">
-        <RadioButton Classes="switch_button"
-                     Width="48"
-                     GroupName="SearchGroup"
-                     IsChecked="{Binding !IsSearchingCommits, Mode=OneWay}">
-          <ToolTip.Tip>
-            <TextBlock>
-              <Run Text="{DynamicResource Text.Repository.Dashboard}" Foreground="{DynamicResource Brush.FG1}"/>
-              <Run Text=" "/>
-              <Run Text="{OnPlatform Ctrl+Shift+H, macOS=⌘+⇧+H}" FontSize="11" Foreground="{DynamicResource MenuFlyoutItemKeyboardAcceleratorTextForeground}"/>
-            </TextBlock>
-          </ToolTip.Tip>
-          <Path Width="12" Height="12" Stretch="Fill" HorizontalAlignment="Center" Data="{StaticResource Icons.Home}"/>
-        </RadioButton>
+          <RadioButton Classes="switch_button"
+                       Width="48"
+                       GroupName="SearchGroup"
+                       IsChecked="{Binding !IsSearchingCommits, Mode=OneWay}">
+            <ToolTip.Tip>
+              <TextBlock>
+                <Run Text="{DynamicResource Text.Repository.Dashboard}" Foreground="{DynamicResource Brush.FG1}"/>
+                <Run Text=" "/>
+                <Run Text="{OnPlatform Ctrl+Shift+H, macOS=⌘+⇧+H}" FontSize="11" Foreground="{DynamicResource MenuFlyoutItemKeyboardAcceleratorTextForeground}"/>
+              </TextBlock>
+            </ToolTip.Tip>
+            <Path Width="12" Height="12" Stretch="Fill" HorizontalAlignment="Center" Data="{StaticResource Icons.Home}"/>
+          </RadioButton>
 
-        <RadioButton Classes="switch_button"
-                     Width="48"
-                     GroupName="SearchGroup"
-                     IsChecked="{Binding IsSearchingCommits, Mode=TwoWay}">
-          <ToolTip.Tip>
-            <TextBlock>
-              <Run Text="{DynamicResource Text.Repository.Search}" Foreground="{DynamicResource Brush.FG1}"/>
-              <Run Text=" "/>
-              <Run Text="{OnPlatform Ctrl+Shift+F, macOS=⌘+⇧+F}" FontSize="11" Foreground="{DynamicResource MenuFlyoutItemKeyboardAcceleratorTextForeground}"/>
-            </TextBlock>
-          </ToolTip.Tip>
-          <Path Width="12" Height="12" Stretch="Fill" HorizontalAlignment="Center" Data="{StaticResource Icons.Search}"/>
-        </RadioButton>
+          <RadioButton Classes="switch_button"
+                       Width="48"
+                       GroupName="SearchGroup"
+                       IsChecked="{Binding IsSearchingCommits, Mode=TwoWay}">
+            <ToolTip.Tip>
+              <TextBlock>
+                <Run Text="{DynamicResource Text.Repository.Search}" Foreground="{DynamicResource Brush.FG1}"/>
+                <Run Text=" "/>
+                <Run Text="{OnPlatform Ctrl+Shift+F, macOS=⌘+⇧+F}" FontSize="11" Foreground="{DynamicResource MenuFlyoutItemKeyboardAcceleratorTextForeground}"/>
+              </TextBlock>
+            </ToolTip.Tip>
+            <Path Width="12" Height="12" Stretch="Fill" HorizontalAlignment="Center" Data="{StaticResource Icons.Search}"/>
+          </RadioButton>
         </StackPanel>
         <Button x:Name="CompactSidebarCloseButton"
                 Classes="icon_button"
                 Width="28" Height="24" Margin="0,0,6,0"
                 HorizontalAlignment="Right"
                 Click="OnCloseCompactSidebar"
-                ToolTip.Tip="Close navigation"
+                ToolTip.Tip="{DynamicResource Text.Close}"
                 IsVisible="False">
           <Path Width="12" Height="12" Data="{StaticResource Icons.Close}"/>
         </Button>
@@ -103,127 +106,13 @@
       <!-- Dashboard -->
       <Grid Grid.Row="1" Margin="0,0,0,8" RowDefinitions="Auto,Auto,*" IsVisible="{Binding !IsSearchingCommits}">
         <!-- Page Switcher for Right Panel -->
-        <Border Grid.Row="0" Margin="8,0,4,0" BorderThickness="1" BorderBrush="{DynamicResource Brush.Border2}" CornerRadius="6">
-          <ListBox Background="Transparent" Padding="4"
-                   SelectedIndex="{Binding SelectedViewIndex, Mode=TwoWay}"
-                   SelectionMode="AlwaysSelected"
-                   SelectionChanged="OnRepositoryViewSelectionChanged">
-            <ListBox.Styles>
-              <Style Selector="Path.icon">
-                <Setter Property="Width" Value="12"/>
-                <Setter Property="Height" Value="12"/>
-                <Setter Property="Margin" Value="6,0"/>
-                <Setter Property="Fill" Value="{DynamicResource Brush.FG2}"/>
-              </Style>
-              <Style Selector="TextBlock.header">
-                <Setter Property="Foreground" Value="{DynamicResource Brush.FG2}"/>
-                <Setter Property="FontWeight" Value="Bold"/>
-              </Style>
-              <Style Selector="ListBoxItem">
-                <Setter Property="Height" Value="28"/>
-                <Setter Property="Margin" Value="0"/>
-                <Setter Property="Padding" Value="0"/>
-                <Setter Property="BorderThickness" Value="0"/>
-                <Setter Property="CornerRadius" Value="0"/>
-              </Style>
-              <Style Selector="ListBoxItem:pointerover /template/ ContentPresenter#PART_ContentPresenter, ListBoxItem:selected /template/ ContentPresenter#PART_ContentPresenter">
-                <Setter Property="Background" Value="Transparent"/>
-              </Style>
-              <Style Selector="ListBoxItem:selected">
-                <Setter Property="BorderBrush" Value="{DynamicResource Brush.FG1}"/>
-              </Style>
-              <Style Selector="ListBoxItem:selected Rectangle.indicator">
-                <Setter Property="Fill" Value="{DynamicResource Brush.FG1}"/>
-              </Style>
-              <Style Selector="ListBoxItem:selected TextBlock.header">
-                <Setter Property="Foreground" Value="{DynamicResource Brush.FG1}"/>
-              </Style>
-              <Style Selector="ListBoxItem:selected Path.icon">
-                <Setter Property="Fill" Value="{DynamicResource Brush.FG1}"/>
-              </Style>
-            </ListBox.Styles>
-
-            <ListBox.ItemsPanel>
-              <ItemsPanelTemplate>
-                <StackPanel Orientation="Vertical"/>
-              </ItemsPanelTemplate>
-            </ListBox.ItemsPanel>
-
-            <ListBoxItem Tag="0" ContextRequested="OnRepositoryViewContextRequested">
-              <Grid ColumnDefinitions="4,Auto,*,Auto">
-                <Rectangle Grid.Column="0" Classes="indicator" Width="4" Height="20" VerticalAlignment="Center"/>
-                <Path Grid.Column="1" Classes="icon" Data="{StaticResource Icons.Histories}"/>
-                <TextBlock Grid.Column="2" Classes="header" Text="{DynamicResource Text.Histories}"/>
-                <Button Grid.Column="3"
-                        Classes="icon_button"
-                        Width="26" Height="26"
-                        Click="OnOpenAdvancedHistoriesOption"
-                        ToolTip.Tip="{DynamicResource Text.Repository.MoreOptions}">
-                  <Path Width="12" Height="12" Data="{StaticResource Icons.More}"/>
-                </Button>
-              </Grid>
-            </ListBoxItem>
-
-            <ListBoxItem Tag="1" ContextRequested="OnRepositoryViewContextRequested" IsVisible="{Binding !IsBare}">
-              <Grid ColumnDefinitions="4,Auto,*,Auto,Auto,Auto">
-                <Rectangle Grid.Column="0" Classes="indicator" Width="4" Height="20" VerticalAlignment="Center"/>
-                <Path Grid.Column="1" Classes="icon" Data="{StaticResource Icons.Changes}"/>
-                <TextBlock Grid.Column="2" Classes="header" Text="{DynamicResource Text.WorkingCopy}"/>
-                <Border Grid.Column="3"
-                        Height="18"
-                        Margin="6,0" Padding="9,0"
-                        CornerRadius="9"
-                        VerticalAlignment="Center"
-                        Background="{DynamicResource Brush.Badge}"
-                        IsVisible="{Binding LocalChangesCount, Mode=OneWay, Converter={x:Static c:IntConverters.IsGreaterThanZero}}">
-                  <TextBlock Text="{Binding LocalChangesCount, Mode=OneWay}"
-                             Foreground="{DynamicResource Brush.BadgeFG}"
-                             FontFamily="{DynamicResource Fonts.Monospace}"
-                             FontSize="10"/>
-                </Border>
-                <Path Grid.Column="4"
-                      Width="12" Height="12"
-                      Margin="0,0,6,0"
-                      Data="{StaticResource Icons.Info}"
-                      Fill="DarkOrange"
-                      IsVisible="{Binding InProgressContext, Converter={x:Static ObjectConverters.IsNotNull}}"/>
-                <Button Grid.Column="5"
-                        Classes="icon_button"
-                        Width="26" Height="26"
-                        Command="{Binding DiscardAllChanges}"
-                        ToolTip.Tip="{DynamicResource Text.Repository.DiscardAll}">
-                  <Path Width="12" Height="12" Data="{StaticResource Icons.Undo}"/>
-                </Button>
-              </Grid>
-            </ListBoxItem>
-
-            <ListBoxItem Tag="2" ContextRequested="OnRepositoryViewContextRequested" IsVisible="{Binding !IsBare}">
-              <Grid ColumnDefinitions="4,Auto,*,Auto,Auto">
-                <Rectangle Grid.Column="0" Classes="indicator" Width="4" Height="20" VerticalAlignment="Center"/>
-                <Path Grid.Column="1" Classes="icon" Data="{StaticResource Icons.Stashes}"/>
-                <TextBlock Grid.Column="2" Classes="header" Text="{DynamicResource Text.Stashes}"/>
-                <Border Grid.Column="3"
-                        Height="18"
-                        Margin="6,0" Padding="9,0"
-                        CornerRadius="9"
-                        VerticalAlignment="Center"
-                        Background="{DynamicResource Brush.Badge}"
-                        IsVisible="{Binding StashesCount, Mode=OneWay, Converter={x:Static c:IntConverters.IsGreaterThanZero}}">
-                  <TextBlock Text="{Binding StashesCount, Mode=OneWay}"
-                             Foreground="{DynamicResource Brush.BadgeFG}"
-                             FontFamily="{DynamicResource Fonts.Monospace}"
-                             FontSize="10"/>
-                </Border>
-                <Button Grid.Column="4"
-                        Classes="icon_button"
-                        Width="26" Height="26"
-                        Command="{Binding ClearStashes}"
-                        ToolTip.Tip="{DynamicResource Text.Repository.ClearStashes}">
-                  <Path Width="12" Height="12" Data="{StaticResource Icons.RemoveAll}"/>
-                </Button>
-              </Grid>
-            </ListBoxItem>
-          </ListBox>
+        <Border Grid.Row="0"
+                Margin="8,0,4,0"
+                BorderThickness="1"
+                BorderBrush="{DynamicResource Brush.Border2}"
+                CornerRadius="6"
+                IsVisible="{Binding NavigationPlacement, Converter={x:Static ObjectConverters.Equal}, ConverterParameter={x:Static m:RepositoryNavigationPlacement.Sidebar}}">
+          <v:RepositoryViewSwitcher Orientation="Vertical" ShowInlineActions="True"/>
         </Border>
 
         <!-- Filter Branches/Tags/Submodules -->
@@ -770,8 +659,19 @@
                   Focusable="False"/>
 
     <!-- Right -->
-    <Grid Grid.Column="2" RowDefinitions="Auto,Auto,Auto,*">
-      <Grid Grid.Row="0" Height="28" ColumnDefinitions="*,Auto,Auto" Background="{DynamicResource Brush.Conflict}" IsVisible="{Binding InProgressContext, Converter={x:Static ObjectConverters.IsNotNull}}">
+    <Grid Grid.Column="2" RowDefinitions="Auto,Auto,Auto,Auto,*">
+      <Border Grid.Row="0"
+              BorderThickness="0,0,0,1"
+              BorderBrush="{DynamicResource Brush.Border0}"
+              Background="{DynamicResource Brush.ToolBar}"
+              IsVisible="{Binding NavigationPlacement, Converter={x:Static ObjectConverters.Equal}, ConverterParameter={x:Static m:RepositoryNavigationPlacement.Top}}">
+        <v:RepositoryViewSwitcher Orientation="Horizontal"
+                                  ShowInlineActions="False"
+                                  ItemMinWidth="140"
+                                  HorizontalAlignment="Left"/>
+      </Border>
+
+      <Grid Grid.Row="1" Height="28" ColumnDefinitions="*,Auto,Auto" Background="{DynamicResource Brush.Conflict}" IsVisible="{Binding InProgressContext, Converter={x:Static ObjectConverters.IsNotNull}}">
         <ContentControl Grid.Column="0" Margin="8,0" Content="{Binding InProgressContext}">
           <ContentControl.DataTemplates>
             <DataTemplate DataType="m:Commit">
@@ -875,7 +775,7 @@
                 Click="OnAbortInProgress"/>
       </Grid>
 
-      <Grid Grid.Row="1"
+      <Grid Grid.Row="2"
             Height="28"
             ColumnDefinitions="*,Auto,Auto,Auto,Auto,Auto"
             Background="{DynamicResource Brush.Conflict}"
@@ -969,7 +869,7 @@
                 Tag="reset"/>
       </Grid>
 
-      <Border Grid.Row="2" Background="{DynamicResource Brush.ToolBar}" BorderThickness="0,0,0,1" BorderBrush="{DynamicResource Brush.Border0}">
+      <Border Grid.Row="3" Background="{DynamicResource Brush.ToolBar}" BorderThickness="0,0,0,1" BorderBrush="{DynamicResource Brush.Border0}">
         <Border.IsVisible>
           <MultiBinding Converter="{x:Static BoolConverters.And}">
             <Binding Path="SelectedViewIndex" Converter="{x:Static c:IntConverters.IsZero}"/>
@@ -1020,7 +920,7 @@
                                          VerticalAlignment="Center"
                                          Filter="{Binding Mode=OneWay}"
                                          IsFilterValid="{Binding IsValid, Mode=OneWay}"/>
-                    
+
                     <TextBlock Grid.Column="1"
                                Text="{Binding Pattern, Converter={x:Static c:StringConverters.TrimRefsPrefix}}"
                                Margin="4,0,8,0"
@@ -1051,7 +951,7 @@
                         Margin="16,0,0,0"
                         Background="Transparent"
                         IsChecked="{Binding IsHistoryFiltersCollapsed, Mode=TwoWay}"/>
-          
+
           <Button Grid.Column="3"
                   Width="20"
                   Margin="0,0,12,0"
@@ -1063,7 +963,7 @@
         </Grid>
       </Border>
 
-      <Grid x:Name="WorkspaceHost" Grid.Row="3" SizeChanged="OnWorkspaceHostSizeChanged">
+      <Grid x:Name="WorkspaceHost" Grid.Row="4" SizeChanged="OnWorkspaceHostSizeChanged">
         <Grid.ColumnDefinitions>
           <ColumnDefinition Width="*"/>
           <ColumnDefinition Width="0"/>

--- a/src/Views/Repository.axaml.cs
+++ b/src/Views/Repository.axaml.cs
@@ -10,6 +10,11 @@ namespace SourceGit.Views
 {
     public partial class Repository : UserControl
     {
+        private const double CompactLayoutThreshold = 1100;
+        private bool _isCompactLayout;
+        private bool _isCompactSidebarOpen;
+        private GridLength _expandedSidebarWidth = new(260, GridUnitType.Pixel);
+
         public Repository()
         {
             InitializeComponent();
@@ -19,6 +24,124 @@ namespace SourceGit.Views
         {
             base.OnLoaded(e);
             UpdateLeftSidebarLayout();
+            UpdateResponsiveLayout(Bounds.Width);
+        }
+
+        private void OnRepositorySizeChanged(object _, SizeChangedEventArgs e)
+        {
+            if (e.WidthChanged)
+                UpdateResponsiveLayout(e.NewSize.Width);
+        }
+
+        private void UpdateResponsiveLayout(double width)
+        {
+            if (width <= 0)
+                return;
+
+            var sidebarColumn = RootLayout.ColumnDefinitions[0];
+            var sidebarSplitterColumn = RootLayout.ColumnDefinitions[1];
+            var useCompactLayout = width < CompactLayoutThreshold;
+            if (useCompactLayout == _isCompactLayout)
+            {
+                if (_isCompactSidebarOpen)
+                    FullSidebar.Width = Math.Min(340, Math.Max(240, width - 48));
+                return;
+            }
+
+            if (useCompactLayout)
+            {
+                var current = ViewModels.Preferences.Instance.Layout.RepositorySidebarWidth;
+                if (current.IsAbsolute && current.Value >= 200)
+                    _expandedSidebarWidth = current;
+
+                _isCompactLayout = true;
+                _isCompactSidebarOpen = false;
+                sidebarColumn.MinWidth = 0;
+                sidebarColumn.MaxWidth = 48;
+                sidebarColumn.SetCurrentValue(ColumnDefinition.WidthProperty, new GridLength(48, GridUnitType.Pixel));
+                sidebarSplitterColumn.Width = new GridLength(0);
+                SidebarSplitter.IsVisible = false;
+                CompactNavigationRail.IsVisible = true;
+                FullSidebar.IsVisible = false;
+            }
+            else
+            {
+                _isCompactLayout = false;
+                _isCompactSidebarOpen = false;
+                CompactSidebarBackdrop.IsVisible = false;
+                CompactNavigationRail.IsVisible = false;
+                CompactSidebarCloseButton.IsVisible = false;
+                FullSidebar.IsVisible = true;
+                FullSidebar.Width = double.NaN;
+                FullSidebar.HorizontalAlignment = Avalonia.Layout.HorizontalAlignment.Stretch;
+                Grid.SetColumnSpan(FullSidebar, 1);
+                sidebarColumn.MinWidth = 200;
+                sidebarColumn.MaxWidth = 500;
+                sidebarColumn.SetCurrentValue(ColumnDefinition.WidthProperty, _expandedSidebarWidth);
+                sidebarSplitterColumn.Width = new GridLength(3, GridUnitType.Pixel);
+                SidebarSplitter.IsVisible = true;
+                ViewModels.Preferences.Instance.Layout.RepositorySidebarWidth = _expandedSidebarWidth;
+            }
+        }
+
+        private void OnOpenCompactSidebar(object _, RoutedEventArgs e)
+        {
+            if (_isCompactLayout)
+            {
+                _isCompactSidebarOpen = true;
+                CompactSidebarBackdrop.IsVisible = true;
+                CompactNavigationRail.IsVisible = false;
+                CompactSidebarCloseButton.IsVisible = true;
+                FullSidebar.IsVisible = true;
+                FullSidebar.Width = Math.Min(340, Math.Max(240, Bounds.Width - 48));
+                FullSidebar.HorizontalAlignment = Avalonia.Layout.HorizontalAlignment.Left;
+                Grid.SetColumnSpan(FullSidebar, 3);
+            }
+
+            e.Handled = true;
+        }
+
+        private void OnCloseCompactSidebar(object _, RoutedEventArgs e)
+        {
+            CloseCompactSidebar();
+            e.Handled = true;
+        }
+
+        private void OnCompactSidebarBackdropPressed(object _, PointerPressedEventArgs e)
+        {
+            CloseCompactSidebar();
+            e.Handled = true;
+        }
+
+        private void OnCompactViewSelected(object sender, RoutedEventArgs e)
+        {
+            if (sender is Button { Tag: string tag } &&
+                int.TryParse(tag, out var selectedView) &&
+                DataContext is ViewModels.Repository repo)
+                repo.SelectedViewIndex = selectedView;
+
+            CloseCompactSidebar();
+            e.Handled = true;
+        }
+
+        private void OnRepositoryViewSelectionChanged(object _, SelectionChangedEventArgs e)
+        {
+            CloseCompactSidebar();
+            e.Handled = true;
+        }
+
+        private void CloseCompactSidebar()
+        {
+            if (!_isCompactLayout || !_isCompactSidebarOpen)
+                return;
+
+            _isCompactSidebarOpen = false;
+            CompactSidebarBackdrop.IsVisible = false;
+            CompactSidebarCloseButton.IsVisible = false;
+            FullSidebar.IsVisible = false;
+            FullSidebar.Width = double.NaN;
+            Grid.SetColumnSpan(FullSidebar, 1);
+            CompactNavigationRail.IsVisible = true;
         }
 
         private void OnToggleFilter(object _, RoutedEventArgs e)

--- a/src/Views/Repository.axaml.cs
+++ b/src/Views/Repository.axaml.cs
@@ -158,13 +158,7 @@ namespace SourceGit.Views
             e.Handled = true;
         }
 
-        private void OnRepositoryViewSelectionChanged(object _, SelectionChangedEventArgs e)
-        {
-            CloseCompactSidebar();
-            e.Handled = true;
-        }
-
-        private void CloseCompactSidebar()
+        internal void CloseCompactSidebar()
         {
             if (!_isCompactLayout || !_isCompactSidebarOpen)
                 return;
@@ -377,89 +371,153 @@ namespace SourceGit.Views
 
         private void OnRepositoryViewContextRequested(object sender, ContextRequestedEventArgs e)
         {
-            if (DataContext is not ViewModels.Repository { IsBare: false } repo ||
+            OpenRepositoryViewContextMenu(sender, e, false);
+        }
+
+        internal void OpenRepositoryViewContextMenu(object sender, ContextRequestedEventArgs e, bool includeViewAction)
+        {
+            if (DataContext is not ViewModels.Repository repo ||
                 sender is not Control control ||
                 !int.TryParse(control.Tag?.ToString(), out var viewIndex))
                 return;
 
             var menu = new ContextMenu();
-            var openSecondary = new MenuItem
+            if (!repo.IsBare)
             {
-                Header = App.Text("Repository.OpenInSecondary"),
-                Icon = this.CreateMenuIcon("Icons.Layout"),
-                IsEnabled = viewIndex != repo.SelectedViewIndex && viewIndex != repo.SecondaryViewIndex,
-            };
-            openSecondary.Click += (_, ev) =>
-            {
-                repo.OpenViewInSecondary(viewIndex, repo.WorkspaceOrientation);
-                ev.Handled = true;
-            };
-            menu.Items.Add(openSecondary);
-            menu.Items.Add(new MenuItem { Header = "-" });
+                var openSecondary = new MenuItem
+                {
+                    Header = App.Text("Repository.OpenInSecondary"),
+                    Icon = this.CreateMenuIcon("Icons.Layout"),
+                    IsEnabled = viewIndex != repo.SelectedViewIndex && viewIndex != repo.SecondaryViewIndex,
+                };
+                openSecondary.Click += (_, ev) =>
+                {
+                    repo.OpenViewInSecondary(viewIndex, repo.WorkspaceOrientation);
+                    ev.Handled = true;
+                };
+                menu.Items.Add(openSecondary);
+                menu.Items.Add(new MenuItem { Header = "-" });
 
-            var canOpenSplit = repo.IsSplitViewEnabled || viewIndex != repo.SelectedViewIndex;
-            var sideBySide = new MenuItem
+                var canOpenSplit = repo.IsSplitViewEnabled || viewIndex != repo.SelectedViewIndex;
+                var sideBySide = new MenuItem
+                {
+                    Header = App.Text("Repository.SplitSideBySide"),
+                    Icon = repo.IsSplitViewEnabled && repo.WorkspaceOrientation == Models.RepositoryWorkspaceOrientation.SideBySide
+                        ? this.CreateMenuIcon("Icons.Check")
+                        : null,
+                    IsEnabled = canOpenSplit,
+                };
+                sideBySide.Click += (_, ev) =>
+                {
+                    if (repo.IsSplitViewEnabled)
+                        repo.SetWorkspaceOrientation(Models.RepositoryWorkspaceOrientation.SideBySide);
+                    else
+                        repo.OpenViewInSecondary(viewIndex, Models.RepositoryWorkspaceOrientation.SideBySide);
+                    ev.Handled = true;
+                };
+                menu.Items.Add(sideBySide);
+
+                var stacked = new MenuItem
+                {
+                    Header = App.Text("Repository.SplitStacked"),
+                    Icon = repo.IsSplitViewEnabled && repo.WorkspaceOrientation == Models.RepositoryWorkspaceOrientation.Stacked
+                        ? this.CreateMenuIcon("Icons.Check")
+                        : null,
+                    IsEnabled = canOpenSplit,
+                };
+                stacked.Click += (_, ev) =>
+                {
+                    if (repo.IsSplitViewEnabled)
+                        repo.SetWorkspaceOrientation(Models.RepositoryWorkspaceOrientation.Stacked);
+                    else
+                        repo.OpenViewInSecondary(viewIndex, Models.RepositoryWorkspaceOrientation.Stacked);
+                    ev.Handled = true;
+                };
+                menu.Items.Add(stacked);
+                menu.Items.Add(new MenuItem { Header = "-" });
+
+                var swap = new MenuItem
+                {
+                    Header = App.Text("Repository.SwapViews"),
+                    Icon = this.CreateMenuIcon("Icons.Layout"),
+                    IsEnabled = repo.IsSplitViewEnabled,
+                };
+                swap.Click += (_, ev) =>
+                {
+                    repo.SwapWorkspaceViews();
+                    ev.Handled = true;
+                };
+                menu.Items.Add(swap);
+
+                var close = new MenuItem
+                {
+                    Header = App.Text("Repository.CloseSecondaryView"),
+                    Icon = this.CreateMenuIcon("Icons.Close"),
+                    IsEnabled = repo.IsSplitViewEnabled,
+                };
+                close.Click += (_, ev) =>
+                {
+                    repo.CloseSecondaryView();
+                    ev.Handled = true;
+                };
+                menu.Items.Add(close);
+
+                if (includeViewAction && viewIndex is 1 or 2)
+                {
+                    menu.Items.Add(new MenuItem { Header = "-" });
+                    var action = new MenuItem
+                    {
+                        Header = App.Text(viewIndex == 1 ? "Repository.DiscardAll" : "Repository.ClearStashes"),
+                        Icon = this.CreateMenuIcon(viewIndex == 1 ? "Icons.Undo" : "Icons.RemoveAll"),
+                    };
+                    action.Click += (_, ev) =>
+                    {
+                        if (viewIndex == 1)
+                            repo.DiscardAllChanges();
+                        else
+                            repo.ClearStashes();
+                        ev.Handled = true;
+                    };
+                    menu.Items.Add(action);
+                }
+
+                menu.Items.Add(new MenuItem { Header = "-" });
+            }
+
+            var navigation = new MenuItem
             {
-                Header = App.Text("Repository.SplitSideBySide"),
-                Icon = repo.IsSplitViewEnabled && repo.WorkspaceOrientation == Models.RepositoryWorkspaceOrientation.SideBySide
+                Header = App.Text("Repository.NavigationPlacement"),
+                IsEnabled = false,
+            };
+            menu.Items.Add(navigation);
+
+            var sidebarNavigation = new MenuItem
+            {
+                Header = App.Text("Repository.NavigationPlacement.Sidebar"),
+                Icon = repo.NavigationPlacement == Models.RepositoryNavigationPlacement.Sidebar
                     ? this.CreateMenuIcon("Icons.Check")
                     : null,
-                IsEnabled = canOpenSplit,
             };
-            sideBySide.Click += (_, ev) =>
+            sidebarNavigation.Click += (_, ev) =>
             {
-                if (repo.IsSplitViewEnabled)
-                    repo.SetWorkspaceOrientation(Models.RepositoryWorkspaceOrientation.SideBySide);
-                else
-                    repo.OpenViewInSecondary(viewIndex, Models.RepositoryWorkspaceOrientation.SideBySide);
+                repo.SetNavigationPlacement(Models.RepositoryNavigationPlacement.Sidebar);
                 ev.Handled = true;
             };
-            menu.Items.Add(sideBySide);
+            menu.Items.Add(sidebarNavigation);
 
-            var stacked = new MenuItem
+            var topNavigation = new MenuItem
             {
-                Header = App.Text("Repository.SplitStacked"),
-                Icon = repo.IsSplitViewEnabled && repo.WorkspaceOrientation == Models.RepositoryWorkspaceOrientation.Stacked
+                Header = App.Text("Repository.NavigationPlacement.Top"),
+                Icon = repo.NavigationPlacement == Models.RepositoryNavigationPlacement.Top
                     ? this.CreateMenuIcon("Icons.Check")
                     : null,
-                IsEnabled = canOpenSplit,
             };
-            stacked.Click += (_, ev) =>
+            topNavigation.Click += (_, ev) =>
             {
-                if (repo.IsSplitViewEnabled)
-                    repo.SetWorkspaceOrientation(Models.RepositoryWorkspaceOrientation.Stacked);
-                else
-                    repo.OpenViewInSecondary(viewIndex, Models.RepositoryWorkspaceOrientation.Stacked);
+                repo.SetNavigationPlacement(Models.RepositoryNavigationPlacement.Top);
                 ev.Handled = true;
             };
-            menu.Items.Add(stacked);
-            menu.Items.Add(new MenuItem { Header = "-" });
-
-            var swap = new MenuItem
-            {
-                Header = App.Text("Repository.SwapViews"),
-                Icon = this.CreateMenuIcon("Icons.Layout"),
-                IsEnabled = repo.IsSplitViewEnabled,
-            };
-            swap.Click += (_, ev) =>
-            {
-                repo.SwapWorkspaceViews();
-                ev.Handled = true;
-            };
-            menu.Items.Add(swap);
-
-            var close = new MenuItem
-            {
-                Header = App.Text("Repository.CloseSecondaryView"),
-                Icon = this.CreateMenuIcon("Icons.Close"),
-                IsEnabled = repo.IsSplitViewEnabled,
-            };
-            close.Click += (_, ev) =>
-            {
-                repo.CloseSecondaryView();
-                ev.Handled = true;
-            };
-            menu.Items.Add(close);
+            menu.Items.Add(topNavigation);
             menu.Open(control);
             e.Handled = true;
         }
@@ -802,7 +860,7 @@ namespace SourceGit.Views
             e.Handled = true;
         }
 
-        private void OnOpenAdvancedHistoriesOption(object sender, RoutedEventArgs e)
+        internal void OpenAdvancedHistoriesOption(object sender, RoutedEventArgs e)
         {
             if (sender is Button button && DataContext is ViewModels.Repository { Histories: { } histories } repo)
             {

--- a/src/Views/Repository.axaml.cs
+++ b/src/Views/Repository.axaml.cs
@@ -1,4 +1,5 @@
 using System;
+using System.ComponentModel;
 
 using Avalonia;
 using Avalonia.Controls;
@@ -11,9 +12,14 @@ namespace SourceGit.Views
     public partial class Repository : UserControl
     {
         private const double CompactLayoutThreshold = 1100;
+        private const double WorkspacePaneMinWidth = 300;
+        private const double WorkspacePaneMinHeight = 160;
+        private const double WorkspaceSplitterSize = 4;
         private bool _isCompactLayout;
         private bool _isCompactSidebarOpen;
         private GridLength _expandedSidebarWidth = new(260, GridUnitType.Pixel);
+        private ViewModels.Repository _subscribedRepository;
+        private int _activeWorkspaceViewIndex = -1;
 
         public Repository()
         {
@@ -25,6 +31,34 @@ namespace SourceGit.Views
             base.OnLoaded(e);
             UpdateLeftSidebarLayout();
             UpdateResponsiveLayout(Bounds.Width);
+
+            if (DataContext is ViewModels.Repository repo)
+            {
+                SubscribeToRepository(repo);
+                _activeWorkspaceViewIndex = repo.SelectedViewIndex;
+            }
+
+            ApplyWorkspaceLayout();
+        }
+
+        protected override void OnUnloaded(RoutedEventArgs e)
+        {
+            UnsubscribeFromRepository();
+            base.OnUnloaded(e);
+        }
+
+        protected override void OnDataContextChanged(EventArgs e)
+        {
+            base.OnDataContextChanged(e);
+            UnsubscribeFromRepository();
+
+            if (IsLoaded && DataContext is ViewModels.Repository repo)
+            {
+                SubscribeToRepository(repo);
+                _activeWorkspaceViewIndex = repo.SelectedViewIndex;
+            }
+
+            ApplyWorkspaceLayout();
         }
 
         private void OnRepositorySizeChanged(object _, SizeChangedEventArgs e)
@@ -142,6 +176,292 @@ namespace SourceGit.Views
             FullSidebar.Width = double.NaN;
             Grid.SetColumnSpan(FullSidebar, 1);
             CompactNavigationRail.IsVisible = true;
+        }
+
+        private void SubscribeToRepository(ViewModels.Repository repo)
+        {
+            if (_subscribedRepository == repo)
+                return;
+
+            UnsubscribeFromRepository();
+            _subscribedRepository = repo;
+            _subscribedRepository.PropertyChanged += OnRepositoryPropertyChanged;
+        }
+
+        private void UnsubscribeFromRepository()
+        {
+            if (_subscribedRepository == null)
+                return;
+
+            _subscribedRepository.PropertyChanged -= OnRepositoryPropertyChanged;
+            _subscribedRepository = null;
+        }
+
+        private void OnRepositoryPropertyChanged(object sender, PropertyChangedEventArgs e)
+        {
+            if (DataContext is not ViewModels.Repository repo)
+                return;
+
+            if (e.PropertyName == nameof(ViewModels.Repository.SelectedViewIndex))
+                _activeWorkspaceViewIndex = repo.SelectedViewIndex;
+
+            if (e.PropertyName is nameof(ViewModels.Repository.SelectedViewIndex) or
+                nameof(ViewModels.Repository.SecondaryViewIndex) or
+                nameof(ViewModels.Repository.IsSplitViewEnabled) or
+                nameof(ViewModels.Repository.WorkspaceOrientation) or
+                nameof(ViewModels.Repository.WorkspaceSplitRatio))
+                ApplyWorkspaceLayout();
+        }
+
+        private void OnWorkspaceHostSizeChanged(object sender, SizeChangedEventArgs e)
+        {
+            if (e.WidthChanged)
+                ApplyWorkspaceLayout();
+        }
+
+        private void ApplyWorkspaceLayout()
+        {
+            if (DataContext is not ViewModels.Repository repo || WorkspaceHost.Bounds.Width <= 0)
+                return;
+
+            var pages = new[] { HistoriesPage, WorkingCopyPage, StashesPage };
+            foreach (var page in pages)
+            {
+                page.IsVisible = false;
+                Grid.SetColumn(page, 0);
+                Grid.SetColumnSpan(page, 1);
+                Grid.SetRow(page, 0);
+                Grid.SetRowSpan(page, 1);
+            }
+
+            var columns = WorkspaceHost.ColumnDefinitions;
+            var rows = WorkspaceHost.RowDefinitions;
+            for (var i = 0; i < columns.Count; i++)
+            {
+                columns[i].MinWidth = 0;
+                columns[i].Width = new GridLength(0);
+            }
+            for (var i = 0; i < rows.Count; i++)
+            {
+                rows[i].MinHeight = 0;
+                rows[i].Height = new GridLength(0);
+            }
+
+            var primaryPage = GetWorkspacePage(repo.SelectedViewIndex);
+            primaryPage.IsVisible = true;
+            columns[0].Width = new GridLength(1, GridUnitType.Star);
+            rows[0].Height = new GridLength(1, GridUnitType.Star);
+            WorkspaceSplitter.IsVisible = false;
+
+            if (repo.IsSplitViewEnabled)
+            {
+                var secondaryPage = GetWorkspacePage(repo.SecondaryViewIndex);
+                secondaryPage.IsVisible = true;
+                var ratio = repo.WorkspaceSplitRatio;
+                var useSideBySide = repo.WorkspaceOrientation == Models.RepositoryWorkspaceOrientation.SideBySide &&
+                    WorkspaceHost.Bounds.Width >= WorkspacePaneMinWidth * 2 + WorkspaceSplitterSize;
+
+                WorkspaceSplitter.IsVisible = true;
+                if (useSideBySide)
+                {
+                    columns[0].MinWidth = WorkspacePaneMinWidth;
+                    columns[0].Width = new GridLength(ratio, GridUnitType.Star);
+                    columns[1].Width = new GridLength(WorkspaceSplitterSize, GridUnitType.Pixel);
+                    columns[2].MinWidth = WorkspacePaneMinWidth;
+                    columns[2].Width = new GridLength(1 - ratio, GridUnitType.Star);
+
+                    Grid.SetColumn(secondaryPage, 2);
+                    Grid.SetColumn(WorkspaceSplitter, 1);
+                    Grid.SetRow(WorkspaceSplitter, 0);
+                    WorkspaceSplitter.Width = WorkspaceSplitterSize;
+                    WorkspaceSplitter.Height = double.NaN;
+                    WorkspaceSplitter.ResizeDirection = GridResizeDirection.Columns;
+                    WorkspaceSplitter.BorderThickness = new Thickness(1, 0, 0, 0);
+                }
+                else
+                {
+                    rows[0].MinHeight = WorkspacePaneMinHeight;
+                    rows[0].Height = new GridLength(ratio, GridUnitType.Star);
+                    rows[1].Height = new GridLength(WorkspaceSplitterSize, GridUnitType.Pixel);
+                    rows[2].MinHeight = WorkspacePaneMinHeight;
+                    rows[2].Height = new GridLength(1 - ratio, GridUnitType.Star);
+
+                    Grid.SetRow(secondaryPage, 2);
+                    Grid.SetColumn(WorkspaceSplitter, 0);
+                    Grid.SetRow(WorkspaceSplitter, 1);
+                    WorkspaceSplitter.Width = double.NaN;
+                    WorkspaceSplitter.Height = WorkspaceSplitterSize;
+                    WorkspaceSplitter.ResizeDirection = GridResizeDirection.Rows;
+                    WorkspaceSplitter.BorderThickness = new Thickness(0, 1, 0, 0);
+                }
+            }
+
+            if (_activeWorkspaceViewIndex != repo.SelectedViewIndex &&
+                _activeWorkspaceViewIndex != repo.SecondaryViewIndex)
+                _activeWorkspaceViewIndex = repo.SelectedViewIndex;
+
+            UpdateWorkspaceHotkeys();
+        }
+
+        private Border GetWorkspacePage(int viewIndex)
+        {
+            return viewIndex switch
+            {
+                1 => WorkingCopyPage,
+                2 => StashesPage,
+                _ => HistoriesPage,
+            };
+        }
+
+        private int GetWorkspaceViewIndex(object page)
+        {
+            if (page == WorkingCopyPage)
+                return 1;
+            if (page == StashesPage)
+                return 2;
+            return 0;
+        }
+
+        private void OnWorkspacePagePointerEntered(object sender, PointerEventArgs e)
+        {
+            ActivateWorkspacePage(sender);
+        }
+
+        private void OnWorkspacePageGotFocus(object sender, GotFocusEventArgs e)
+        {
+            ActivateWorkspacePage(sender);
+        }
+
+        private void ActivateWorkspacePage(object page)
+        {
+            if (page is not Border { IsVisible: true } border)
+                return;
+
+            _activeWorkspaceViewIndex = GetWorkspaceViewIndex(border);
+            UpdateWorkspaceHotkeys();
+        }
+
+        internal void UpdateWorkspaceHotkeys()
+        {
+            var pages = new[] { HistoriesPage, WorkingCopyPage, StashesPage };
+            for (var i = 0; i < pages.Length; i++)
+            {
+                var diffViewer = pages[i].FindDescendantOfType<DiffView>();
+                diffViewer?.ToggleHotkeyBindings(pages[i].IsVisible && i == _activeWorkspaceViewIndex);
+            }
+        }
+
+        private void OnWorkspaceSplitterDragCompleted(object sender, VectorEventArgs e)
+        {
+            if (DataContext is not ViewModels.Repository { IsSplitViewEnabled: true } repo)
+                return;
+
+            var columns = WorkspaceHost.ColumnDefinitions;
+            var rows = WorkspaceHost.RowDefinitions;
+            double first;
+            double second;
+            if (WorkspaceSplitter.ResizeDirection == GridResizeDirection.Columns)
+            {
+                first = columns[0].ActualWidth;
+                second = columns[2].ActualWidth;
+            }
+            else
+            {
+                first = rows[0].ActualHeight;
+                second = rows[2].ActualHeight;
+            }
+
+            if (first + second > 0)
+                repo.WorkspaceSplitRatio = first / (first + second);
+        }
+
+        private void OnRepositoryViewContextRequested(object sender, ContextRequestedEventArgs e)
+        {
+            if (DataContext is not ViewModels.Repository { IsBare: false } repo ||
+                sender is not Control control ||
+                !int.TryParse(control.Tag?.ToString(), out var viewIndex))
+                return;
+
+            var menu = new ContextMenu();
+            var openSecondary = new MenuItem
+            {
+                Header = App.Text("Repository.OpenInSecondary"),
+                Icon = this.CreateMenuIcon("Icons.Layout"),
+                IsEnabled = viewIndex != repo.SelectedViewIndex && viewIndex != repo.SecondaryViewIndex,
+            };
+            openSecondary.Click += (_, ev) =>
+            {
+                repo.OpenViewInSecondary(viewIndex, repo.WorkspaceOrientation);
+                ev.Handled = true;
+            };
+            menu.Items.Add(openSecondary);
+            menu.Items.Add(new MenuItem { Header = "-" });
+
+            var canOpenSplit = repo.IsSplitViewEnabled || viewIndex != repo.SelectedViewIndex;
+            var sideBySide = new MenuItem
+            {
+                Header = App.Text("Repository.SplitSideBySide"),
+                Icon = repo.IsSplitViewEnabled && repo.WorkspaceOrientation == Models.RepositoryWorkspaceOrientation.SideBySide
+                    ? this.CreateMenuIcon("Icons.Check")
+                    : null,
+                IsEnabled = canOpenSplit,
+            };
+            sideBySide.Click += (_, ev) =>
+            {
+                if (repo.IsSplitViewEnabled)
+                    repo.SetWorkspaceOrientation(Models.RepositoryWorkspaceOrientation.SideBySide);
+                else
+                    repo.OpenViewInSecondary(viewIndex, Models.RepositoryWorkspaceOrientation.SideBySide);
+                ev.Handled = true;
+            };
+            menu.Items.Add(sideBySide);
+
+            var stacked = new MenuItem
+            {
+                Header = App.Text("Repository.SplitStacked"),
+                Icon = repo.IsSplitViewEnabled && repo.WorkspaceOrientation == Models.RepositoryWorkspaceOrientation.Stacked
+                    ? this.CreateMenuIcon("Icons.Check")
+                    : null,
+                IsEnabled = canOpenSplit,
+            };
+            stacked.Click += (_, ev) =>
+            {
+                if (repo.IsSplitViewEnabled)
+                    repo.SetWorkspaceOrientation(Models.RepositoryWorkspaceOrientation.Stacked);
+                else
+                    repo.OpenViewInSecondary(viewIndex, Models.RepositoryWorkspaceOrientation.Stacked);
+                ev.Handled = true;
+            };
+            menu.Items.Add(stacked);
+            menu.Items.Add(new MenuItem { Header = "-" });
+
+            var swap = new MenuItem
+            {
+                Header = App.Text("Repository.SwapViews"),
+                Icon = this.CreateMenuIcon("Icons.Layout"),
+                IsEnabled = repo.IsSplitViewEnabled,
+            };
+            swap.Click += (_, ev) =>
+            {
+                repo.SwapWorkspaceViews();
+                ev.Handled = true;
+            };
+            menu.Items.Add(swap);
+
+            var close = new MenuItem
+            {
+                Header = App.Text("Repository.CloseSecondaryView"),
+                Icon = this.CreateMenuIcon("Icons.Close"),
+                IsEnabled = repo.IsSplitViewEnabled,
+            };
+            close.Click += (_, ev) =>
+            {
+                repo.CloseSecondaryView();
+                ev.Handled = true;
+            };
+            menu.Items.Add(close);
+            menu.Open(control);
+            e.Handled = true;
         }
 
         private void OnToggleFilter(object _, RoutedEventArgs e)
@@ -818,13 +1138,5 @@ namespace SourceGit.Views
             e.Handled = true;
         }
 
-        private void OnRightPagePropertyChanged(object sender, AvaloniaPropertyChangedEventArgs e)
-        {
-            if (e.Property == Border.IsVisibleProperty && sender is Border page)
-            {
-                var diffViewer = page.FindDescendantOfType<DiffView>();
-                diffViewer?.ToggleHotkeyBindings(page.IsVisible);
-            }
-        }
     }
 }

--- a/src/Views/RepositoryToolbar.axaml
+++ b/src/Views/RepositoryToolbar.axaml
@@ -7,130 +7,171 @@
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:Class="SourceGit.Views.RepositoryToolbar"
              x:DataType="vm:Repository">
-  <Grid ColumnDefinitions="*,Auto,0,*">
-    <StackPanel Grid.Column="0" Orientation="Horizontal" Margin="4,0,0,0">
-      <Button Classes="icon_button" Width="32" Click="OpenWithExternalTools" ToolTip.Tip="{DynamicResource Text.Repository.OpenWithExternalTools}">
+  <Grid SizeChanged="OnToolbarSizeChanged">
+    <Grid x:Name="FullToolbar" ColumnDefinitions="*,Auto,0,*">
+      <StackPanel Grid.Column="0" Orientation="Horizontal" Margin="4,0,0,0">
+        <Button Classes="icon_button" Width="32" Click="OpenWithExternalTools" ToolTip.Tip="{DynamicResource Text.Repository.OpenWithExternalTools}">
+          <Path Width="14" Height="14" Data="{StaticResource Icons.OpenWith}"/>
+        </Button>
+
+        <Button Classes="icon_button" Width="32" Click="OpenGitLogs" ToolTip.Tip="{DynamicResource Text.Repository.ViewLogs}">
+          <Path Width="14" Height="14" Margin="0,1,0,0" Data="{StaticResource Icons.Logs}"/>
+        </Button>
+
+        <Button Classes="icon_button" Width="32" Click="OpenStatistics" ToolTip.Tip="{DynamicResource Text.Repository.Statistics}">
+          <Path Width="13" Height="13" Data="{StaticResource Icons.Statistics}"/>
+        </Button>
+
+        <Button Classes="icon_button" Width="32" Click="OpenConfigure" ToolTip.Tip="{DynamicResource Text.Repository.Configure}">
+          <Path Width="14" Height="14" Data="{StaticResource Icons.Settings}"/>
+        </Button>
+      </StackPanel>
+
+      <StackPanel Grid.Column="1" Orientation="Horizontal">
+        <Button Classes="icon_button" Width="32" Tapped="Fetch">
+          <ToolTip.Tip>
+            <StackPanel Orientation="Vertical">
+              <TextBlock Text="{DynamicResource Text.Fetch}"/>
+              <TextBlock Classes="small italic" Margin="0,4,0,0" Text="{DynamicResource Text.CtrlClickTip}" Foreground="{DynamicResource Brush.FG2}"/>
+            </StackPanel>
+          </ToolTip.Tip>
+
+          <Path Width="14" Height="14" Data="{StaticResource Icons.Fetch}"/>
+        </Button>
+
+        <Button Classes="icon_button" Width="32" Margin="16,0,0,0" Tapped="Pull" IsVisible="{Binding !IsBare}" IsEnabled="{Binding !IsBare}">
+          <ToolTip.Tip>
+            <StackPanel Orientation="Vertical">
+              <TextBlock Text="{DynamicResource Text.Pull}"/>
+              <TextBlock Classes="small italic" Margin="0,4,0,0" Text="{DynamicResource Text.CtrlClickTip}" Foreground="{DynamicResource Brush.FG2}"/>
+            </StackPanel>
+          </ToolTip.Tip>
+
+          <Path Width="14" Height="14" Data="{StaticResource Icons.Pull}"/>
+        </Button>
+
+        <Button Classes="icon_button" Width="32" Margin="16,0,0,0" Tapped="Push">
+          <ToolTip.Tip>
+            <StackPanel Orientation="Vertical">
+              <TextBlock Text="{DynamicResource Text.Push}"/>
+              <TextBlock Classes="small italic" Margin="0,4,0,0" Text="{DynamicResource Text.CtrlClickTip}" Foreground="{DynamicResource Brush.FG2}"/>
+            </StackPanel>
+          </ToolTip.Tip>
+
+          <Path Width="14" Height="14" Data="{StaticResource Icons.Push}"/>
+        </Button>
+
+        <Button Classes="icon_button" Width="32" Margin="16,0,0,0" Tapped="StashAll" IsVisible="{Binding !IsBare}">
+          <ToolTip.Tip>
+            <StackPanel Orientation="Vertical">
+              <TextBlock Text="{DynamicResource Text.Stash}"/>
+              <TextBlock Classes="small italic" Margin="0,4,0,0" Text="{DynamicResource Text.CtrlClickTip}" Foreground="{DynamicResource Brush.FG2}"/>
+            </StackPanel>
+          </ToolTip.Tip>
+
+          <Path Width="14" Height="14" Data="{StaticResource Icons.Stashes.Add}"/>
+        </Button>
+
+        <Button Classes="icon_button" Width="32" Margin="16,0,0,0" Command="{Binding ApplyPatch}" IsVisible="{Binding !IsBare}" ToolTip.Tip="{DynamicResource Text.Apply.Title}">
+          <Path Width="14" Height="14" Data="{StaticResource Icons.ApplyPatch}"/>
+        </Button>
+
+        <Rectangle Width="1" Height="16"
+                   Margin="16,0,0,0"
+                   VerticalAlignment="Center"
+                   Fill="{DynamicResource Brush.Border2}"/>
+
+        <Button Classes="icon_button" Width="32" Margin="18,0,0,0" Click="OpenGitFlowMenu" IsVisible="{Binding !IsBare}" ToolTip.Tip="{DynamicResource Text.GitFlow}">
+          <Path Width="14" Height="14" Data="{StaticResource Icons.GitFlow}"/>
+        </Button>
+
+        <Button Classes="icon_button" Width="32" Margin="12,0,0,0" Click="OpenGitLFSMenu" IsVisible="{Binding !IsBare}" ToolTip.Tip="{DynamicResource Text.GitLFS}">
+          <Path Width="14" Height="14" Data="{StaticResource Icons.LFS}"/>
+        </Button>
+
+        <Button Classes="icon_button" Width="32" Margin="12,0,0,0" Click="StartBisect" IsVisible="{Binding !IsBare}" ToolTip.Tip="{DynamicResource Text.Bisect}">
+          <Path Width="14" Height="14" Data="{StaticResource Icons.Bisect}"/>
+        </Button>
+
+        <Button Classes="icon_button" Width="32" Margin="12,0,0,0" Click="OpenCustomActionMenu" ToolTip.Tip="{DynamicResource Text.Repository.CustomActions}">
+          <Path Width="14" Height="14" Data="{StaticResource Icons.Action}"/>
+        </Button>
+
+        <Button Classes="icon_button" Width="32" Margin="12,0,0,0" Click="Cleanup" ToolTip.Tip="{DynamicResource Text.Repository.Clean}">
+          <Path Width="14" Height="14" Margin="0,1,0,0" Data="{StaticResource Icons.Clean}"/>
+        </Button>
+      </StackPanel>
+
+      <StackPanel Grid.Column="2" Orientation="Horizontal">
+        <Button Width="0" Height="0" Click="PushDirectlyByHotKey" IsVisible="False" HotKey="{OnPlatform Ctrl+Shift+Up, macOS=⌘+Shift+Up}"/>
+        <Button Width="0" Height="0" Click="PullDirectlyByHotKey" IsVisible="False" IsEnabled="{Binding !IsBare}" HotKey="{OnPlatform Ctrl+Shift+Down, macOS=⌘+Shift+Down}"/>
+        <Button Width="0" Height="0" Click="FetchDirectlyByHotKey" IsVisible="False" HotKey="{OnPlatform Ctrl+Down, macOS=⌘+Down}"/>
+      </StackPanel>
+
+      <StackPanel Grid.Column="3" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,0,4,0">
+        <Path Width="13" Height="13" Fill="{DynamicResource Brush.FG1}" Data="{StaticResource Icons.Branch}"/>
+
+        <ContentControl Margin="6,0,0,0">
+          <ContentControl.Content>
+            <Binding Path="CurrentBranch">
+              <Binding.TargetNullValue>
+                <TextBlock Text="--"/>
+              </Binding.TargetNullValue>
+            </Binding>
+          </ContentControl.Content>
+
+          <ContentControl.DataTemplates>
+            <DataTemplate DataType="m:Branch">
+              <Border Background="Transparent" ToolTip.Tip="{Binding FriendlyName}">
+                <TextBlock Text="{Binding FriendlyName}" MaxWidth="250" TextTrimming="CharacterEllipsis"/>
+              </Border>
+            </DataTemplate>
+          </ContentControl.DataTemplates>
+        </ContentControl>
+
+        <Button Classes="icon_button" Width="32" Click="NavigateToHead" ToolTip.Tip="{DynamicResource Text.Repository.NavigateToCurrentHead}">
+          <Path Width="13" Height="13" Margin="0,2,0,0" Data="{StaticResource Icons.Target}" Fill="{DynamicResource Brush.FG1}"/>
+        </Button>
+      </StackPanel>
+    </Grid>
+
+    <Grid x:Name="CompactToolbar" ColumnDefinitions="Auto,Auto,Auto,Auto,Auto,*,Auto" IsVisible="False">
+      <Button Grid.Column="0" Classes="icon_button" Width="32" Click="OpenWithExternalTools" ToolTip.Tip="{DynamicResource Text.Repository.OpenWithExternalTools}">
         <Path Width="14" Height="14" Data="{StaticResource Icons.OpenWith}"/>
       </Button>
-
-      <Button Classes="icon_button" Width="32" Click="OpenGitLogs" ToolTip.Tip="{DynamicResource Text.Repository.ViewLogs}">
-        <Path Width="14" Height="14" Margin="0,1,0,0" Data="{StaticResource Icons.Logs}"/>
-      </Button>
-
-      <Button Classes="icon_button" Width="32" Click="OpenStatistics" ToolTip.Tip="{DynamicResource Text.Repository.Statistics}">
-        <Path Width="13" Height="13" Data="{StaticResource Icons.Statistics}"/>
-      </Button>
-
-      <Button Classes="icon_button" Width="32" Click="OpenConfigure" ToolTip.Tip="{DynamicResource Text.Repository.Configure}">
-        <Path Width="14" Height="14" Data="{StaticResource Icons.Settings}"/>
-      </Button>
-    </StackPanel>
-
-    <StackPanel Grid.Column="1" Orientation="Horizontal">
-      <Button Classes="icon_button" Width="32" Tapped="Fetch">
-        <ToolTip.Tip>
-          <StackPanel Orientation="Vertical">
-            <TextBlock Text="{DynamicResource Text.Fetch}"/>
-            <TextBlock Classes="small italic" Margin="0,4,0,0" Text="{DynamicResource Text.CtrlClickTip}" Foreground="{DynamicResource Brush.FG2}"/>
-          </StackPanel>
-        </ToolTip.Tip>
-
+      <Button Grid.Column="1" Classes="icon_button" Width="32" Tapped="Fetch" ToolTip.Tip="{DynamicResource Text.Fetch}">
         <Path Width="14" Height="14" Data="{StaticResource Icons.Fetch}"/>
       </Button>
-
-      <Button Classes="icon_button" Width="32" Margin="16,0,0,0" Tapped="Pull" IsVisible="{Binding !IsBare}" IsEnabled="{Binding !IsBare}">
-        <ToolTip.Tip>
-          <StackPanel Orientation="Vertical">
-            <TextBlock Text="{DynamicResource Text.Pull}"/>
-            <TextBlock Classes="small italic" Margin="0,4,0,0" Text="{DynamicResource Text.CtrlClickTip}" Foreground="{DynamicResource Brush.FG2}"/>
-          </StackPanel>
-        </ToolTip.Tip>
-
+      <Button Grid.Column="2" Classes="icon_button" Width="32" Tapped="Pull" IsVisible="{Binding !IsBare}" IsEnabled="{Binding !IsBare}" ToolTip.Tip="{DynamicResource Text.Pull}">
         <Path Width="14" Height="14" Data="{StaticResource Icons.Pull}"/>
       </Button>
-
-      <Button Classes="icon_button" Width="32" Margin="16,0,0,0" Tapped="Push">
-        <ToolTip.Tip>
-          <StackPanel Orientation="Vertical">
-            <TextBlock Text="{DynamicResource Text.Push}"/>
-            <TextBlock Classes="small italic" Margin="0,4,0,0" Text="{DynamicResource Text.CtrlClickTip}" Foreground="{DynamicResource Brush.FG2}"/>
-          </StackPanel>
-        </ToolTip.Tip>
-
+      <Button Grid.Column="3" Classes="icon_button" Width="32" Tapped="Push" ToolTip.Tip="{DynamicResource Text.Push}">
         <Path Width="14" Height="14" Data="{StaticResource Icons.Push}"/>
       </Button>
-
-      <Button Classes="icon_button" Width="32" Margin="16,0,0,0" Tapped="StashAll" IsVisible="{Binding !IsBare}">
-        <ToolTip.Tip>
-          <StackPanel Orientation="Vertical">
-            <TextBlock Text="{DynamicResource Text.Stash}"/>
-            <TextBlock Classes="small italic" Margin="0,4,0,0" Text="{DynamicResource Text.CtrlClickTip}" Foreground="{DynamicResource Brush.FG2}"/>
-          </StackPanel>
-        </ToolTip.Tip>
-
-        <Path Width="14" Height="14" Data="{StaticResource Icons.Stashes.Add}"/>
+      <Button Grid.Column="4" Classes="icon_button" Width="32" Click="OpenCompactOperations" ToolTip.Tip="{DynamicResource Text.Repository.MoreOptions}">
+        <Path Width="14" Height="14" Data="{StaticResource Icons.More}"/>
       </Button>
 
-      <Button Classes="icon_button" Width="32" Margin="16,0,0,0" Command="{Binding ApplyPatch}" IsVisible="{Binding !IsBare}" ToolTip.Tip="{DynamicResource Text.Apply.Title}">
-        <Path Width="14" Height="14" Data="{StaticResource Icons.ApplyPatch}"/>
-      </Button>
-
-      <Rectangle Width="1" Height="16"
-                 Margin="16,0,0,0"
-                 VerticalAlignment="Center"
-                 Fill="{DynamicResource Brush.Border2}"/>
-
-      <Button Classes="icon_button" Width="32" Margin="18,0,0,0" Click="OpenGitFlowMenu" IsVisible="{Binding !IsBare}" ToolTip.Tip="{DynamicResource Text.GitFlow}">
-        <Path Width="14" Height="14" Data="{StaticResource Icons.GitFlow}"/>
-      </Button>
-
-      <Button Classes="icon_button" Width="32" Margin="12,0,0,0" Click="OpenGitLFSMenu" IsVisible="{Binding !IsBare}" ToolTip.Tip="{DynamicResource Text.GitLFS}">
-        <Path Width="14" Height="14" Data="{StaticResource Icons.LFS}"/>
-      </Button>
-
-      <Button Classes="icon_button" Width="32" Margin="12,0,0,0" Click="StartBisect" IsVisible="{Binding !IsBare}" ToolTip.Tip="{DynamicResource Text.Bisect}">
-        <Path Width="14" Height="14" Data="{StaticResource Icons.Bisect}"/>
-      </Button>
-
-      <Button Classes="icon_button" Width="32" Margin="12,0,0,0" Click="OpenCustomActionMenu" ToolTip.Tip="{DynamicResource Text.Repository.CustomActions}">
-        <Path Width="14" Height="14" Data="{StaticResource Icons.Action}"/>
-      </Button>
-
-      <Button Classes="icon_button" Width="32" Margin="12,0,0,0" Click="Cleanup" ToolTip.Tip="{DynamicResource Text.Repository.Clean}">
-        <Path Width="14" Height="14" Margin="0,1,0,0" Data="{StaticResource Icons.Clean}"/>
-      </Button>
-    </StackPanel>
-
-    <StackPanel Grid.Column="2" Orientation="Horizontal">
-      <Button Width="0" Height="0" Click="PushDirectlyByHotKey" IsVisible="False" HotKey="{OnPlatform Ctrl+Shift+Up, macOS=⌘+Shift+Up}"/>
-      <Button Width="0" Height="0" Click="PullDirectlyByHotKey" IsVisible="False" IsEnabled="{Binding !IsBare}" HotKey="{OnPlatform Ctrl+Shift+Down, macOS=⌘+Shift+Down}"/>
-      <Button Width="0" Height="0" Click="FetchDirectlyByHotKey" IsVisible="False" HotKey="{OnPlatform Ctrl+Down, macOS=⌘+Down}"/>
-    </StackPanel>
-
-    <StackPanel Grid.Column="3" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,0,4,0">
-      <Path Width="13" Height="13" Fill="{DynamicResource Brush.FG1}" Data="{StaticResource Icons.Branch}"/>
-
-      <ContentControl Margin="6,0,0,0">
-        <ContentControl.Content>
-          <Binding Path="CurrentBranch">
-            <Binding.TargetNullValue>
-              <TextBlock Text="--"/>
-            </Binding.TargetNullValue>
-          </Binding>
-        </ContentControl.Content>
-
-        <ContentControl.DataTemplates>
-          <DataTemplate DataType="m:Branch">
-            <Border Background="Transparent" ToolTip.Tip="{Binding FriendlyName}">
-              <TextBlock Text="{Binding FriendlyName}" MaxWidth="250" TextTrimming="CharacterEllipsis"/>
-            </Border>
-          </DataTemplate>
-        </ContentControl.DataTemplates>
-      </ContentControl>
-
-      <Button Classes="icon_button" Width="32" Click="NavigateToHead" ToolTip.Tip="{DynamicResource Text.Repository.NavigateToCurrentHead}">
-        <Path Width="13" Height="13" Margin="0,2,0,0" Data="{StaticResource Icons.Target}" Fill="{DynamicResource Brush.FG1}"/>
-      </Button>
-    </StackPanel>
+      <StackPanel Grid.Column="6" Orientation="Horizontal" Margin="4,0">
+        <Path Width="13" Height="13" Fill="{DynamicResource Brush.FG1}" Data="{StaticResource Icons.Branch}"/>
+        <ContentControl Margin="5,0,0,0">
+          <ContentControl.Content>
+            <Binding Path="CurrentBranch">
+              <Binding.TargetNullValue>
+                <TextBlock Text="--"/>
+              </Binding.TargetNullValue>
+            </Binding>
+          </ContentControl.Content>
+          <ContentControl.DataTemplates>
+            <DataTemplate DataType="m:Branch">
+              <TextBlock Text="{Binding FriendlyName}" MaxWidth="100" TextTrimming="CharacterEllipsis" ToolTip.Tip="{Binding FriendlyName}"/>
+            </DataTemplate>
+          </ContentControl.DataTemplates>
+        </ContentControl>
+        <Button Classes="icon_button" Width="28" Click="NavigateToHead" ToolTip.Tip="{DynamicResource Text.Repository.NavigateToCurrentHead}">
+          <Path Width="13" Height="13" Margin="0,2,0,0" Data="{StaticResource Icons.Target}" Fill="{DynamicResource Brush.FG1}"/>
+        </Button>
+      </StackPanel>
+    </Grid>
   </Grid>
 </UserControl>

--- a/src/Views/RepositoryToolbar.axaml.cs
+++ b/src/Views/RepositoryToolbar.axaml.cs
@@ -18,6 +18,72 @@ namespace SourceGit.Views
             InitializeComponent();
         }
 
+        private void OnToolbarSizeChanged(object _, SizeChangedEventArgs e)
+        {
+            if (!e.WidthChanged)
+                return;
+
+            var compact = e.NewSize.Width < 760;
+            FullToolbar.IsVisible = !compact;
+            CompactToolbar.IsVisible = compact;
+        }
+
+        private void OpenCompactOperations(object sender, RoutedEventArgs ev)
+        {
+            if (sender is not Button button || DataContext is not ViewModels.Repository repo)
+                return;
+
+            var logs = new MenuItem { Header = App.Text("Repository.ViewLogs"), Icon = this.CreateMenuIcon("Icons.Logs") };
+            logs.Click += (_, e) => OpenGitLogs(button, e);
+            var statistics = new MenuItem { Header = App.Text("Repository.Statistics"), Icon = this.CreateMenuIcon("Icons.Statistics") };
+            statistics.Click += (_, e) => OpenStatistics(button, e);
+            var configure = new MenuItem { Header = App.Text("Repository.Configure"), Icon = this.CreateMenuIcon("Icons.Settings") };
+            configure.Click += (_, e) => OpenConfigure(button, e);
+
+            var stash = new MenuItem { Header = App.Text("Stash"), Icon = this.CreateMenuIcon("Icons.Stashes.Add") };
+            stash.Click += async (_, e) =>
+            {
+                await repo.StashAllAsync(false);
+                e.Handled = true;
+            };
+            var applyPatch = new MenuItem { Header = App.Text("Apply.Title"), Icon = this.CreateMenuIcon("Icons.ApplyPatch") };
+            applyPatch.Click += (_, e) =>
+            {
+                repo.ApplyPatch();
+                e.Handled = true;
+            };
+
+            var gitFlow = new MenuItem { Header = App.Text("GitFlow"), Icon = this.CreateMenuIcon("Icons.GitFlow") };
+            gitFlow.Click += (_, e) => OpenGitFlowMenu(button, e);
+            var gitLfs = new MenuItem { Header = App.Text("GitLFS"), Icon = this.CreateMenuIcon("Icons.LFS") };
+            gitLfs.Click += (_, e) => OpenGitLFSMenu(button, e);
+            var bisect = new MenuItem { Header = App.Text("Bisect"), Icon = this.CreateMenuIcon("Icons.Bisect") };
+            bisect.Click += (_, e) => StartBisect(button, e);
+            var customActions = new MenuItem { Header = App.Text("Repository.CustomActions"), Icon = this.CreateMenuIcon("Icons.Action") };
+            customActions.Click += (_, e) => OpenCustomActionMenu(button, e);
+            var cleanup = new MenuItem { Header = App.Text("Repository.Clean"), Icon = this.CreateMenuIcon("Icons.Clean") };
+            cleanup.Click += (_, e) => Cleanup(button, e);
+
+            var menu = new ContextMenu { Placement = PlacementMode.BottomEdgeAlignedLeft };
+            menu.Items.Add(logs);
+            menu.Items.Add(statistics);
+            menu.Items.Add(configure);
+            menu.Items.Add(new MenuItem { Header = "-" });
+            if (!repo.IsBare)
+            {
+                menu.Items.Add(stash);
+                menu.Items.Add(applyPatch);
+                menu.Items.Add(new MenuItem { Header = "-" });
+                menu.Items.Add(gitFlow);
+                menu.Items.Add(gitLfs);
+                menu.Items.Add(bisect);
+            }
+            menu.Items.Add(customActions);
+            menu.Items.Add(cleanup);
+            menu.Open(button);
+            ev.Handled = true;
+        }
+
         private void OpenWithExternalTools(object sender, RoutedEventArgs ev)
         {
             if (sender is Button button && DataContext is ViewModels.Repository repo)

--- a/src/Views/RepositoryViewSwitcher.axaml
+++ b/src/Views/RepositoryViewSwitcher.axaml
@@ -1,0 +1,144 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="using:SourceGit.ViewModels"
+             xmlns:v="using:SourceGit.Views"
+             xmlns:c="using:SourceGit.Converters"
+             mc:Ignorable="d" d:DesignWidth="600" d:DesignHeight="40"
+             x:Class="SourceGit.Views.RepositoryViewSwitcher"
+             x:DataType="vm:Repository"
+             x:Name="ThisControl">
+  <ListBox x:Name="ViewSelector"
+           Background="Transparent"
+           Padding="4"
+           SelectedIndex="{Binding SelectedViewIndex, Mode=TwoWay}"
+           SelectionMode="AlwaysSelected"
+           SelectionChanged="OnSelectionChanged">
+    <ListBox.Styles>
+      <Style Selector="Path.icon">
+        <Setter Property="Width" Value="12"/>
+        <Setter Property="Height" Value="12"/>
+        <Setter Property="Margin" Value="6,0"/>
+        <Setter Property="Fill" Value="{DynamicResource Brush.FG2}"/>
+      </Style>
+      <Style Selector="TextBlock.header">
+        <Setter Property="Foreground" Value="{DynamicResource Brush.FG2}"/>
+        <Setter Property="FontWeight" Value="Bold"/>
+      </Style>
+      <Style Selector="ListBoxItem">
+        <Setter Property="Height" Value="28"/>
+        <Setter Property="Margin" Value="0"/>
+        <Setter Property="Padding" Value="0"/>
+        <Setter Property="BorderThickness" Value="0"/>
+        <Setter Property="CornerRadius" Value="0"/>
+      </Style>
+      <Style Selector="ListBoxItem:pointerover /template/ ContentPresenter#PART_ContentPresenter, ListBoxItem:selected /template/ ContentPresenter#PART_ContentPresenter">
+        <Setter Property="Background" Value="Transparent"/>
+      </Style>
+      <Style Selector="ListBoxItem:selected">
+        <Setter Property="BorderBrush" Value="{DynamicResource Brush.FG1}"/>
+      </Style>
+      <Style Selector="ListBoxItem:selected Rectangle.indicator">
+        <Setter Property="Fill" Value="{DynamicResource Brush.FG1}"/>
+      </Style>
+      <Style Selector="ListBoxItem:selected TextBlock.header">
+        <Setter Property="Foreground" Value="{DynamicResource Brush.FG1}"/>
+      </Style>
+      <Style Selector="ListBoxItem:selected Path.icon">
+        <Setter Property="Fill" Value="{DynamicResource Brush.FG1}"/>
+      </Style>
+    </ListBox.Styles>
+
+    <ListBox.ItemsPanel>
+      <ItemsPanelTemplate>
+        <StackPanel Orientation="{Binding #ThisControl.Orientation}"/>
+      </ItemsPanelTemplate>
+    </ListBox.ItemsPanel>
+
+    <ListBoxItem Tag="0"
+                 MinWidth="{Binding #ThisControl.ItemMinWidth}"
+                 ContextRequested="OnRepositoryViewContextRequested">
+      <Grid ColumnDefinitions="4,Auto,*,Auto">
+        <Rectangle Grid.Column="0" Classes="indicator" Width="4" Height="20" VerticalAlignment="Center"/>
+        <Path Grid.Column="1" Classes="icon" Data="{StaticResource Icons.Histories}"/>
+        <TextBlock Grid.Column="2" Classes="header" Text="{DynamicResource Text.Histories}"/>
+        <Button Grid.Column="3"
+                Classes="icon_button"
+                Width="26" Height="26"
+                Click="OnOpenAdvancedHistoriesOption"
+                ToolTip.Tip="{DynamicResource Text.Repository.MoreOptions}">
+          <Path Width="12" Height="12" Data="{StaticResource Icons.More}"/>
+        </Button>
+      </Grid>
+    </ListBoxItem>
+
+    <ListBoxItem Tag="1"
+                 MinWidth="{Binding #ThisControl.ItemMinWidth}"
+                 ContextRequested="OnRepositoryViewContextRequested"
+                 IsVisible="{Binding !IsBare}">
+      <Grid ColumnDefinitions="4,Auto,*,Auto,Auto,Auto">
+        <Rectangle Grid.Column="0" Classes="indicator" Width="4" Height="20" VerticalAlignment="Center"/>
+        <Path Grid.Column="1" Classes="icon" Data="{StaticResource Icons.Changes}"/>
+        <TextBlock Grid.Column="2" Classes="header" Text="{DynamicResource Text.WorkingCopy}"/>
+        <Border Grid.Column="3"
+                Height="18"
+                Margin="6,0" Padding="9,0"
+                CornerRadius="9"
+                VerticalAlignment="Center"
+                Background="{DynamicResource Brush.Badge}"
+                IsVisible="{Binding LocalChangesCount, Mode=OneWay, Converter={x:Static c:IntConverters.IsGreaterThanZero}}">
+          <TextBlock Text="{Binding LocalChangesCount, Mode=OneWay}"
+                     Foreground="{DynamicResource Brush.BadgeFG}"
+                     FontFamily="{DynamicResource Fonts.Monospace}"
+                     FontSize="10"/>
+        </Border>
+        <Path Grid.Column="4"
+              Width="12" Height="12"
+              Margin="0,0,6,0"
+              Data="{StaticResource Icons.Info}"
+              Fill="DarkOrange"
+              IsVisible="{Binding InProgressContext, Converter={x:Static ObjectConverters.IsNotNull}}"/>
+        <Button Grid.Column="5"
+                Classes="icon_button"
+                Width="26" Height="26"
+                Command="{Binding DiscardAllChanges}"
+                IsVisible="{Binding #ThisControl.ShowInlineActions}"
+                ToolTip.Tip="{DynamicResource Text.Repository.DiscardAll}">
+          <Path Width="12" Height="12" Data="{StaticResource Icons.Undo}"/>
+        </Button>
+      </Grid>
+    </ListBoxItem>
+
+    <ListBoxItem Tag="2"
+                 MinWidth="{Binding #ThisControl.ItemMinWidth}"
+                 ContextRequested="OnRepositoryViewContextRequested"
+                 IsVisible="{Binding !IsBare}">
+      <Grid ColumnDefinitions="4,Auto,*,Auto,Auto">
+        <Rectangle Grid.Column="0" Classes="indicator" Width="4" Height="20" VerticalAlignment="Center"/>
+        <Path Grid.Column="1" Classes="icon" Data="{StaticResource Icons.Stashes}"/>
+        <TextBlock Grid.Column="2" Classes="header" Text="{DynamicResource Text.Stashes}"/>
+        <Border Grid.Column="3"
+                Height="18"
+                Margin="6,0" Padding="9,0"
+                CornerRadius="9"
+                VerticalAlignment="Center"
+                Background="{DynamicResource Brush.Badge}"
+                IsVisible="{Binding StashesCount, Mode=OneWay, Converter={x:Static c:IntConverters.IsGreaterThanZero}}">
+          <TextBlock Text="{Binding StashesCount, Mode=OneWay}"
+                     Foreground="{DynamicResource Brush.BadgeFG}"
+                     FontFamily="{DynamicResource Fonts.Monospace}"
+                     FontSize="10"/>
+        </Border>
+        <Button Grid.Column="4"
+                Classes="icon_button"
+                Width="26" Height="26"
+                Command="{Binding ClearStashes}"
+                IsVisible="{Binding #ThisControl.ShowInlineActions}"
+                ToolTip.Tip="{DynamicResource Text.Repository.ClearStashes}">
+          <Path Width="12" Height="12" Data="{StaticResource Icons.RemoveAll}"/>
+        </Button>
+      </Grid>
+    </ListBoxItem>
+  </ListBox>
+</UserControl>

--- a/src/Views/RepositoryViewSwitcher.axaml.cs
+++ b/src/Views/RepositoryViewSwitcher.axaml.cs
@@ -1,0 +1,67 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Avalonia.Layout;
+using Avalonia.VisualTree;
+
+namespace SourceGit.Views
+{
+    public partial class RepositoryViewSwitcher : UserControl
+    {
+        public static readonly StyledProperty<Orientation> OrientationProperty =
+            AvaloniaProperty.Register<RepositoryViewSwitcher, Orientation>(nameof(Orientation), Orientation.Vertical);
+
+        public Orientation Orientation
+        {
+            get => GetValue(OrientationProperty);
+            set => SetValue(OrientationProperty, value);
+        }
+
+        public static readonly StyledProperty<bool> ShowInlineActionsProperty =
+            AvaloniaProperty.Register<RepositoryViewSwitcher, bool>(nameof(ShowInlineActions), true);
+
+        public bool ShowInlineActions
+        {
+            get => GetValue(ShowInlineActionsProperty);
+            set => SetValue(ShowInlineActionsProperty, value);
+        }
+
+        public static readonly StyledProperty<double> ItemMinWidthProperty =
+            AvaloniaProperty.Register<RepositoryViewSwitcher, double>(nameof(ItemMinWidth));
+
+        public double ItemMinWidth
+        {
+            get => GetValue(ItemMinWidthProperty);
+            set => SetValue(ItemMinWidthProperty, value);
+        }
+
+        public RepositoryViewSwitcher()
+        {
+            InitializeComponent();
+            ViewSelector.AddHandler(PointerPressedEvent, OnViewSelectorPointerPressed, RoutingStrategies.Tunnel);
+        }
+
+        private void OnViewSelectorPointerPressed(object sender, PointerPressedEventArgs e)
+        {
+            if (e.GetCurrentPoint(ViewSelector).Properties.PointerUpdateKind == PointerUpdateKind.RightButtonPressed)
+                e.Handled = true;
+        }
+
+        private void OnSelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            this.FindAncestorOfType<Repository>()?.CloseCompactSidebar();
+            e.Handled = true;
+        }
+
+        private void OnRepositoryViewContextRequested(object sender, ContextRequestedEventArgs e)
+        {
+            this.FindAncestorOfType<Repository>()?.OpenRepositoryViewContextMenu(sender, e, !ShowInlineActions);
+        }
+
+        private void OnOpenAdvancedHistoriesOption(object sender, RoutedEventArgs e)
+        {
+            this.FindAncestorOfType<Repository>()?.OpenAdvancedHistoriesOption(sender, e);
+        }
+    }
+}

--- a/src/Views/StashesPage.axaml
+++ b/src/Views/StashesPage.axaml
@@ -11,9 +11,9 @@
              x:DataType="vm:StashesPage">
   <Grid SizeChanged="OnMainLayoutSizeChanged">
     <Grid.ColumnDefinitions>
-      <ColumnDefinition Width="{Binding Source={x:Static vm:Preferences.Instance}, Path=Layout.StashesLeftWidth, Mode=TwoWay}" MinWidth="300"/>
+      <ColumnDefinition Width="{Binding Source={x:Static vm:Preferences.Instance}, Path=Layout.StashesLeftWidth, Mode=TwoWay}" MinWidth="220"/>
       <ColumnDefinition Width="4"/>
-      <ColumnDefinition Width="*" MinWidth="300"/>
+      <ColumnDefinition Width="*" MinWidth="260"/>
     </Grid.ColumnDefinitions>
 
     <!-- Left -->

--- a/src/Views/StashesPage.axaml
+++ b/src/Views/StashesPage.axaml
@@ -9,15 +9,20 @@
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:Class="SourceGit.Views.StashesPage"
              x:DataType="vm:StashesPage">
-  <Grid SizeChanged="OnMainLayoutSizeChanged">
+  <Grid x:Name="MainLayout" SizeChanged="OnMainLayoutSizeChanged">
     <Grid.ColumnDefinitions>
       <ColumnDefinition Width="{Binding Source={x:Static vm:Preferences.Instance}, Path=Layout.StashesLeftWidth, Mode=TwoWay}" MinWidth="220"/>
       <ColumnDefinition Width="4"/>
       <ColumnDefinition Width="*" MinWidth="260"/>
     </Grid.ColumnDefinitions>
+    <Grid.RowDefinitions>
+      <RowDefinition Height="*"/>
+      <RowDefinition Height="0"/>
+      <RowDefinition Height="0"/>
+    </Grid.RowDefinitions>
 
     <!-- Left -->
-    <Grid Grid.Column="0" RowDefinitions="28,36,*,28,*">
+    <Grid x:Name="StashListPanel" Grid.Column="0" Grid.Row="0" RowDefinitions="28,36,*,28,*">
       <!-- Stash Bar -->
       <Grid Grid.Row="0" ColumnDefinitions="Auto,*">
         <Path Grid.Column="0" Margin="8,0,0,0" Width="14" Height="14" Fill="{DynamicResource Brush.FG2}" Data="{StaticResource Icons.Stashes}"/>
@@ -138,7 +143,7 @@
       </Border>
     </Grid>
 
-    <GridSplitter Grid.Column="1"
+    <GridSplitter x:Name="LayoutSplitter" Grid.Column="1" Grid.Row="0"
                   MinWidth=".5"
                   HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
                   Background="Transparent"
@@ -147,7 +152,7 @@
                   Focusable="False"/>
 
     <!-- Right -->
-    <Grid Grid.Column="2" Margin="0,4,4,4">
+    <Grid x:Name="DetailsPanel" Grid.Column="2" Grid.Row="0" Margin="0,4,4,4">
       <Border BorderThickness="1" BorderBrush="{DynamicResource Brush.Border2}">
         <StackPanel Orientation="Vertical" VerticalAlignment="Center">
           <Path Width="64" Height="64" Data="{StaticResource Icons.Diff}" Fill="{DynamicResource Brush.FG2}"/>

--- a/src/Views/StashesPage.axaml.cs
+++ b/src/Views/StashesPage.axaml.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.Text;
 
+using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Platform.Storage;
@@ -10,6 +11,10 @@ namespace SourceGit.Views
 {
     public partial class StashesPage : UserControl
     {
+        private const double SingleColumnThreshold = 720;
+        private bool _isSingleColumn;
+        private GridLength _expandedLeftWidth = new(300, GridUnitType.Pixel);
+
         public StashesPage()
         {
             InitializeComponent();
@@ -22,10 +27,73 @@ namespace SourceGit.Views
 
             var layout = ViewModels.Preferences.Instance.Layout;
             var width = grid.Bounds.Width;
+            if (width <= 0)
+                return;
+
+            var useSingleColumn = width < SingleColumnThreshold;
+            if (useSingleColumn != _isSingleColumn)
+                SetSingleColumnLayout(useSingleColumn);
+
+            if (useSingleColumn)
+                return;
+
             var leftWidth = Math.Max(220, width - 264);
 
             if (layout.StashesLeftWidth.Value - leftWidth > 1.0)
                 layout.StashesLeftWidth = new GridLength(leftWidth, GridUnitType.Pixel);
+        }
+
+        private void SetSingleColumnLayout(bool enabled)
+        {
+            var columns = MainLayout.ColumnDefinitions;
+            var rows = MainLayout.RowDefinitions;
+            var layout = ViewModels.Preferences.Instance.Layout;
+
+            _isSingleColumn = enabled;
+            if (enabled)
+            {
+                if (layout.StashesLeftWidth.IsAbsolute && layout.StashesLeftWidth.Value >= 220)
+                    _expandedLeftWidth = layout.StashesLeftWidth;
+
+                columns[0].MinWidth = 0;
+                columns[0].SetCurrentValue(ColumnDefinition.WidthProperty, new GridLength(1, GridUnitType.Star));
+                columns[1].Width = new GridLength(0);
+                columns[2].MinWidth = 0;
+                columns[2].Width = new GridLength(0);
+                rows[0].Height = new GridLength(2, GridUnitType.Star);
+                rows[1].Height = new GridLength(4, GridUnitType.Pixel);
+                rows[2].Height = new GridLength(3, GridUnitType.Star);
+
+                Grid.SetColumn(StashListPanel, 0);
+                Grid.SetRow(StashListPanel, 0);
+                Grid.SetColumn(LayoutSplitter, 0);
+                Grid.SetRow(LayoutSplitter, 1);
+                Grid.SetColumn(DetailsPanel, 0);
+                Grid.SetRow(DetailsPanel, 2);
+                LayoutSplitter.BorderThickness = new Thickness(0, 1, 0, 0);
+                DetailsPanel.Margin = new Thickness(4, 0, 4, 4);
+            }
+            else
+            {
+                columns[0].MinWidth = 220;
+                columns[0].SetCurrentValue(ColumnDefinition.WidthProperty, _expandedLeftWidth);
+                columns[1].Width = new GridLength(4, GridUnitType.Pixel);
+                columns[2].MinWidth = 260;
+                columns[2].Width = new GridLength(1, GridUnitType.Star);
+                rows[0].Height = new GridLength(1, GridUnitType.Star);
+                rows[1].Height = new GridLength(0);
+                rows[2].Height = new GridLength(0);
+
+                Grid.SetColumn(StashListPanel, 0);
+                Grid.SetRow(StashListPanel, 0);
+                Grid.SetColumn(LayoutSplitter, 1);
+                Grid.SetRow(LayoutSplitter, 0);
+                Grid.SetColumn(DetailsPanel, 2);
+                Grid.SetRow(DetailsPanel, 0);
+                LayoutSplitter.BorderThickness = new Thickness(1, 0, 0, 0);
+                DetailsPanel.Margin = new Thickness(0, 4, 4, 4);
+                layout.StashesLeftWidth = _expandedLeftWidth;
+            }
         }
 
         private async void OnStashListKeyDown(object sender, KeyEventArgs e)

--- a/src/Views/StashesPage.axaml.cs
+++ b/src/Views/StashesPage.axaml.cs
@@ -22,7 +22,7 @@ namespace SourceGit.Views
 
             var layout = ViewModels.Preferences.Instance.Layout;
             var width = grid.Bounds.Width;
-            var leftWidth = Math.Max(width - 304, 300);
+            var leftWidth = Math.Max(220, width - 264);
 
             if (layout.StashesLeftWidth.Value - leftWidth > 1.0)
                 layout.StashesLeftWidth = new GridLength(leftWidth, GridUnitType.Pixel);

--- a/src/Views/Welcome.axaml
+++ b/src/Views/Welcome.axaml
@@ -12,7 +12,7 @@
   <Grid RowDefinitions="*,Auto" Margin="8">
     <Grid.ColumnDefinitions>
       <ColumnDefinition Width="1*"/>
-      <ColumnDefinition Width="2*" MinWidth="600"/>
+      <ColumnDefinition Width="2*" MinWidth="420"/>
       <ColumnDefinition Width="1*"/>
     </Grid.ColumnDefinitions>
 

--- a/src/Views/WorkingCopy.axaml
+++ b/src/Views/WorkingCopy.axaml
@@ -8,15 +8,20 @@
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="600"
              x:Class="SourceGit.Views.WorkingCopy"
              x:DataType="vm:WorkingCopy">
-  <Grid SizeChanged="OnMainLayoutSizeChanged">
+  <Grid x:Name="MainLayout" SizeChanged="OnMainLayoutSizeChanged">
     <Grid.ColumnDefinitions>
       <ColumnDefinition Width="{Binding Source={x:Static vm:Preferences.Instance}, Path=Layout.WorkingCopyLeftWidth, Mode=TwoWay}" MinWidth="220"/>
       <ColumnDefinition Width="4"/>
       <ColumnDefinition Width="*" MinWidth="260"/>
     </Grid.ColumnDefinitions>
+    <Grid.RowDefinitions>
+      <RowDefinition Height="*"/>
+      <RowDefinition Height="0"/>
+      <RowDefinition Height="0"/>
+    </Grid.RowDefinitions>
 
     <!-- Left -->
-    <Grid Grid.Column="0">
+    <Grid x:Name="ChangesPanel" Grid.Column="0" Grid.Row="0">
       <Grid.RowDefinitions>
         <RowDefinition Height="36"/>
         <RowDefinition Height="*" MinHeight="100"/>
@@ -194,7 +199,7 @@
       </Grid>
     </Grid>
 
-    <GridSplitter Grid.Column="1"
+    <GridSplitter x:Name="LayoutSplitter" Grid.Column="1" Grid.Row="0"
                   MinWidth="1"
                   HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
                   Background="Transparent"
@@ -203,7 +208,7 @@
                   Focusable="False"/>
 
     <!-- Right -->
-    <Grid Grid.Column="2" Margin="0,4,4,4">
+    <Grid x:Name="DetailsPanel" Grid.Column="2" Grid.Row="0" Margin="0,4,4,4">
       <Grid.RowDefinitions>
         <RowDefinition Height="*" MinHeight="160"/>
         <RowDefinition Height="4"/>

--- a/src/Views/WorkingCopy.axaml
+++ b/src/Views/WorkingCopy.axaml
@@ -10,9 +10,9 @@
              x:DataType="vm:WorkingCopy">
   <Grid SizeChanged="OnMainLayoutSizeChanged">
     <Grid.ColumnDefinitions>
-      <ColumnDefinition Width="{Binding Source={x:Static vm:Preferences.Instance}, Path=Layout.WorkingCopyLeftWidth, Mode=TwoWay}" MinWidth="300"/>
+      <ColumnDefinition Width="{Binding Source={x:Static vm:Preferences.Instance}, Path=Layout.WorkingCopyLeftWidth, Mode=TwoWay}" MinWidth="220"/>
       <ColumnDefinition Width="4"/>
-      <ColumnDefinition Width="*" MinWidth="300"/>
+      <ColumnDefinition Width="*" MinWidth="260"/>
     </Grid.ColumnDefinitions>
 
     <!-- Left -->
@@ -205,10 +205,10 @@
     <!-- Right -->
     <Grid Grid.Column="2" Margin="0,4,4,4">
       <Grid.RowDefinitions>
-        <RowDefinition Height="*" MinHeight="400"/>
+        <RowDefinition Height="*" MinHeight="160"/>
         <RowDefinition Height="4"/>
-        <RowDefinition Height="128" MinHeight="100"/>
-        <RowDefinition Height="36"/>
+        <RowDefinition Height="112" MinHeight="72"/>
+        <RowDefinition Height="Auto" MinHeight="36"/>
       </Grid.RowDefinitions>
 
       <!-- Select Change Detail -->
@@ -247,7 +247,7 @@
       <v:CommitMessageToolBox Grid.Row="2" ShowAdvancedOptions="True" CommitMessage="{Binding CommitMessage, Mode=TwoWay}"/>
 
       <!-- Commit Options -->
-      <Grid Grid.Row="3" Margin="0,6,0,0" ColumnDefinitions="Auto,Auto,Auto,Auto,*,Auto,Auto,Auto">
+      <WrapPanel Grid.Row="3" Margin="0,6,0,0" Orientation="Horizontal" HorizontalAlignment="Right">
         <CheckBox Grid.Column="0"
                   Height="24"
                   Margin="1,0,0,0"
@@ -444,7 +444,7 @@
             </MultiBinding>
           </Button.IsVisible>
         </Button>
-      </Grid>
+      </WrapPanel>
     </Grid>
   </Grid>
 </UserControl>

--- a/src/Views/WorkingCopy.axaml.cs
+++ b/src/Views/WorkingCopy.axaml.cs
@@ -25,7 +25,7 @@ namespace SourceGit.Views
 
             var layout = ViewModels.Preferences.Instance.Layout;
             var width = grid.Bounds.Width;
-            var leftWidth = Math.Max(width - 304, 300);
+            var leftWidth = Math.Max(220, width - 264);
 
             if (layout.WorkingCopyLeftWidth.Value - leftWidth > 1.0)
                 layout.WorkingCopyLeftWidth = new GridLength(leftWidth, GridUnitType.Pixel);

--- a/src/Views/WorkingCopy.axaml.cs
+++ b/src/Views/WorkingCopy.axaml.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Text;
 
+using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Interactivity;
@@ -13,6 +14,10 @@ namespace SourceGit.Views
 {
     public partial class WorkingCopy : UserControl
     {
+        private const double SingleColumnThreshold = 720;
+        private bool _isSingleColumn;
+        private GridLength _expandedLeftWidth = new(300, GridUnitType.Pixel);
+
         public WorkingCopy()
         {
             InitializeComponent();
@@ -25,10 +30,73 @@ namespace SourceGit.Views
 
             var layout = ViewModels.Preferences.Instance.Layout;
             var width = grid.Bounds.Width;
+            if (width <= 0)
+                return;
+
+            var useSingleColumn = width < SingleColumnThreshold;
+            if (useSingleColumn != _isSingleColumn)
+                SetSingleColumnLayout(useSingleColumn);
+
+            if (useSingleColumn)
+                return;
+
             var leftWidth = Math.Max(220, width - 264);
 
             if (layout.WorkingCopyLeftWidth.Value - leftWidth > 1.0)
                 layout.WorkingCopyLeftWidth = new GridLength(leftWidth, GridUnitType.Pixel);
+        }
+
+        private void SetSingleColumnLayout(bool enabled)
+        {
+            var columns = MainLayout.ColumnDefinitions;
+            var rows = MainLayout.RowDefinitions;
+            var layout = ViewModels.Preferences.Instance.Layout;
+
+            _isSingleColumn = enabled;
+            if (enabled)
+            {
+                if (layout.WorkingCopyLeftWidth.IsAbsolute && layout.WorkingCopyLeftWidth.Value >= 220)
+                    _expandedLeftWidth = layout.WorkingCopyLeftWidth;
+
+                columns[0].MinWidth = 0;
+                columns[0].SetCurrentValue(ColumnDefinition.WidthProperty, new GridLength(1, GridUnitType.Star));
+                columns[1].Width = new GridLength(0);
+                columns[2].MinWidth = 0;
+                columns[2].Width = new GridLength(0);
+                rows[0].Height = new GridLength(2, GridUnitType.Star);
+                rows[1].Height = new GridLength(4, GridUnitType.Pixel);
+                rows[2].Height = new GridLength(3, GridUnitType.Star);
+
+                Grid.SetColumn(ChangesPanel, 0);
+                Grid.SetRow(ChangesPanel, 0);
+                Grid.SetColumn(LayoutSplitter, 0);
+                Grid.SetRow(LayoutSplitter, 1);
+                Grid.SetColumn(DetailsPanel, 0);
+                Grid.SetRow(DetailsPanel, 2);
+                LayoutSplitter.BorderThickness = new Thickness(0, 1, 0, 0);
+                DetailsPanel.Margin = new Thickness(4, 0, 4, 4);
+            }
+            else
+            {
+                columns[0].MinWidth = 220;
+                columns[0].SetCurrentValue(ColumnDefinition.WidthProperty, _expandedLeftWidth);
+                columns[1].Width = new GridLength(4, GridUnitType.Pixel);
+                columns[2].MinWidth = 260;
+                columns[2].Width = new GridLength(1, GridUnitType.Star);
+                rows[0].Height = new GridLength(1, GridUnitType.Star);
+                rows[1].Height = new GridLength(0);
+                rows[2].Height = new GridLength(0);
+
+                Grid.SetColumn(ChangesPanel, 0);
+                Grid.SetRow(ChangesPanel, 0);
+                Grid.SetColumn(LayoutSplitter, 1);
+                Grid.SetRow(LayoutSplitter, 0);
+                Grid.SetColumn(DetailsPanel, 2);
+                Grid.SetRow(DetailsPanel, 0);
+                LayoutSplitter.BorderThickness = new Thickness(1, 0, 0, 0);
+                DetailsPanel.Margin = new Thickness(0, 4, 4, 4);
+                layout.WorkingCopyLeftWidth = _expandedLeftWidth;
+            }
         }
 
         private async void OnOpenAssumeUnchanged(object sender, RoutedEventArgs e)


### PR DESCRIPTION
- Add responsive layouts for narrow and tiled windows.
- Allow History, Local Changes, and Stashes to be displayed in a persistent secondary pane.
- Support side-by-side and stacked split orientations.
- Allow repository view navigation to be placed in the sidebar or at the top.

Current View Tiled:
<img width="923" height="976" alt="image" src="https://github.com/user-attachments/assets/515be813-1fd0-42f1-859a-4d0f2b2b5732" />

After:

Stacked View Tiled:
<img width="955" height="982" alt="image" src="https://github.com/user-attachments/assets/e297147f-27f1-41f6-a5be-40420225c653" />
Side-by-side View Tiled:
<img width="959" height="972" alt="image" src="https://github.com/user-attachments/assets/bf06e3fa-bcdc-4698-bf23-b40eeda4e95b" />
