### PR TITLE
ux: focus input-less popups

### DIFF
--- a/src/Views/PopupDataTemplates.cs
+++ b/src/Views/PopupDataTemplates.cs
@@ -1,4 +1,6 @@
-﻿using Avalonia.Controls;
+﻿using System.Linq;
+
+using Avalonia.Controls;
 using Avalonia.Controls.Templates;
 using Avalonia.Input;
 using Avalonia.VisualTree;
@@ -32,6 +34,22 @@ namespace SourceGit.Views
                         focusable.Focus(NavigationMethod.Directional);
                         if (input is TextBox box)
                             box.CaretIndex = box.CaretIndex = box.Text?.Length ?? 0;
+                        return;
+                    }
+                }
+
+                var host = ctl.GetVisualAncestors().OfType<Control>().FirstOrDefault(c => c.Name == "PopupPanel");
+                if (host == null)
+                    return;
+
+                foreach (var input in host.GetVisualDescendants())
+                {
+                    if (input is SelectableTextBlock)
+                        continue;
+
+                    if (input is Control { Focusable: true, IsVisible: true, IsEffectivelyVisible: true, IsEffectivelyEnabled: true } focusable)
+                    {
+                        focusable.Focus(NavigationMethod.Directional);
                         return;
                     }
                 }


### PR DESCRIPTION
…so Space/Enter in Discard confirmation dialog no longer stages the file behind it.

Previously the focus was left behind in the main window, which could lead to accidental staging or commit.