### PR TITLE
fix: build setsid as universal binary to fix Intel Mac crash

### DIFF
--- a/build/scripts/package.osx-app.sh
+++ b/build/scripts/package.osx-app.sh
@@ -13,6 +13,6 @@ cp resources/app/App.icns SourceGit.app/Contents/Resources/App.icns
 sed "s/SOURCE_GIT_VERSION/$VERSION/g" resources/app/App.plist > SourceGit.app/Contents/Info.plist
 rm -rf SourceGit.app/Contents/MacOS/SourceGit.dsym
 rm -f SourceGit.app/Contents/MacOS/*.pdb
-clang ../tools/setsid-macos/setsid.c -o SourceGit.app/Contents/MacOS/setsid -mmacosx-version-min=13.0
+clang ../tools/setsid-macos/setsid.c -o SourceGit.app/Contents/MacOS/setsid -mmacosx-version-min=13.0 -arch x86_64 -arch arm64
 
 zip "sourcegit_$VERSION.$RUNTIME.zip" -r SourceGit.app


### PR DESCRIPTION
Fixes #2681

## Summary

- `package.osx-app.sh` compiled `setsid.c` without `-arch` flags, so it defaulted to the build machine's architecture
- Since CI runs on `macos-latest` (Apple Silicon), both `osx-x64` and `osx-arm64` packages shipped an ARM64-only `setsid` binary
- Intel Macs fail with `Bad CPU type in executable` when SourceGit tries to launch `setsid` for any cancellable git operation (Fetch, etc.)

## Fix

Added `-arch x86_64 -arch arm64` to the `clang` invocation in `build/scripts/package.osx-app.sh` to produce a universal (fat) binary that runs natively on both Intel and Apple Silicon.

```diff
-clang ../tools/setsid-macos/setsid.c -o SourceGit.app/Contents/MacOS/setsid -mmacosx-version-min=13.0
+clang ../tools/setsid-macos/setsid.c -o SourceGit.app/Contents/MacOS/setsid -mmacosx-version-min=13.0 -arch x86_64 -arch arm64
```

## Test plan

- [ ] Verify `file SourceGit.app/Contents/MacOS/setsid` reports a universal binary with both `x86_64` and `arm64` slices after packaging
- [ ] Confirm Fetch and other cancellable git operations work on an Intel Mac without the "Bad CPU type" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)