### PR TITLE
feat: support custom HTTP headers in AI service configuration

### DIFF
--- a/src/AI/Service.cs
+++ b/src/AI/Service.cs
@@ -1,7 +1,10 @@
 ﻿using System;
 using System.ClientModel;
+using System.ClientModel.Primitives;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text.Json.Serialization;
+using System.Threading.Tasks;
 using Azure.AI.OpenAI;
 using CommunityToolkit.Mvvm.ComponentModel;
 using OpenAI;
@@ -66,6 +69,45 @@ namespace SourceGit.AI
             set;
         } = string.Empty;
 
+        /// <summary>
+        /// Custom HTTP headers sent with every request to this service.
+        /// Needed by some OpenAI-compatible providers (e.g. OpenCode Go requires `x-opencode-session`).
+        /// </summary>
+        public Dictionary<string, string> ExtraHeaders
+        {
+            get;
+            set;
+        } = new (StringComparer.OrdinalIgnoreCase);
+
+        /// <summary>
+        /// Text representation of <see cref="ExtraHeaders"/> for UI editing. One `Name: Value` pair per line.
+        /// Lines without a colon or with an empty/invalid name are ignored.
+        /// </summary>
+        [JsonIgnore]
+        public string ExtraHeadersText
+        {
+            get => string.Join('\n', ExtraHeaders.Select(kv => $"{kv.Key}: {kv.Value}"));
+            set
+            {
+                var parsed = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+                foreach (var line in value.Split('\n'))
+                {
+                    var idx = line.IndexOf(':');
+                    if (idx <= 0)
+                        continue;
+
+                    var name = line.Substring(0, idx).Trim();
+                    var headerValue = line.Substring(idx + 1).Trim();
+                    if (name.Length == 0 || headerValue.Length == 0 || name.Any(char.IsWhiteSpace))
+                        continue;
+
+                    parsed[name] = headerValue;
+                }
+
+                ExtraHeaders = parsed;
+            }
+        }
+
         public void FetchAvailableModels()
         {
             if (!_autoFetchAvailableModels)
@@ -92,9 +134,50 @@ namespace SourceGit.AI
         private OpenAIClient GetOpenAIClient()
         {
             var credential = new ApiKeyCredential(ReadApiKeyFromEnv ? Environment.GetEnvironmentVariable(ApiKey) : ApiKey);
-            return Server.Contains("openai.azure.com/", StringComparison.Ordinal)
-                ? new AzureOpenAIClient(new Uri(Server), credential)
-                : new OpenAIClient(credential, new() { Endpoint = new Uri(Server) });
+            if (Server.Contains("openai.azure.com/", StringComparison.Ordinal))
+            {
+                var azureOptions = new AzureOpenAIClientOptions();
+                ApplyExtraHeaders(azureOptions);
+                return new AzureOpenAIClient(new Uri(Server), credential, azureOptions);
+            }
+
+            var options = new OpenAIClientOptions() { Endpoint = new Uri(Server) };
+            ApplyExtraHeaders(options);
+            return new OpenAIClient(credential, options);
+        }
+
+        private void ApplyExtraHeaders(ClientPipelineOptions options)
+        {
+            if (ExtraHeaders.Count > 0)
+                options.AddPolicy(new ExtraHeadersPolicy(ExtraHeaders), PipelinePosition.PerCall);
+        }
+
+        private sealed class ExtraHeadersPolicy : PipelinePolicy
+        {
+            public ExtraHeadersPolicy(Dictionary<string, string> headers)
+            {
+                _headers = headers;
+            }
+
+            public override void Process(PipelineMessage message, IReadOnlyList<PipelinePolicy> pipeline, int currentIndex)
+            {
+                Apply(message);
+                ProcessNext(message, pipeline, currentIndex);
+            }
+
+            public override async ValueTask ProcessAsync(PipelineMessage message, IReadOnlyList<PipelinePolicy> pipeline, int currentIndex)
+            {
+                Apply(message);
+                await ProcessNextAsync(message, pipeline, currentIndex);
+            }
+
+            private void Apply(PipelineMessage message)
+            {
+                foreach (var header in _headers)
+                    message.Request.Headers.Set(header.Key, header.Value);
+            }
+
+            private readonly Dictionary<string, string> _headers;
         }
 
         private string _name = string.Empty;

--- a/src/Resources/Locales/en_US.axaml
+++ b/src/Resources/Locales/en_US.axaml
@@ -660,6 +660,7 @@
   <x:String x:Key="Text.Preferences.AI" xml:space="preserve">AI</x:String>
   <x:String x:Key="Text.Preferences.AI.AdditionalPrompt" xml:space="preserve">Additional Prompt (Use `-` to list your requirements)</x:String>
   <x:String x:Key="Text.Preferences.AI.ApiKey" xml:space="preserve">API Key</x:String>
+  <x:String x:Key="Text.Preferences.AI.ExtraHeaders" xml:space="preserve">Extra Headers (one `Name: Value` per line)</x:String>
   <x:String x:Key="Text.Preferences.AI.Model" xml:space="preserve">Model</x:String>
   <x:String x:Key="Text.Preferences.AI.Model.AutoFetchAvailableModels" xml:space="preserve">Fetch available model-ids automatically</x:String>
   <x:String x:Key="Text.Preferences.AI.Name" xml:space="preserve">Name</x:String>

--- a/src/Resources/Locales/id_ID.axaml
+++ b/src/Resources/Locales/id_ID.axaml
@@ -657,6 +657,7 @@
   <x:String x:Key="Text.Preferences.AI" xml:space="preserve">AI</x:String>
   <x:String x:Key="Text.Preferences.AI.AdditionalPrompt" xml:space="preserve">Prompt Tambahan (Gunakan `-` untuk mencantumkan kebutuhan Anda)</x:String>
   <x:String x:Key="Text.Preferences.AI.ApiKey" xml:space="preserve">API Key</x:String>
+  <x:String x:Key="Text.Preferences.AI.ExtraHeaders" xml:space="preserve">Header Tambahan (satu `Nama: Nilai` per baris)</x:String>
   <x:String x:Key="Text.Preferences.AI.Model" xml:space="preserve">Model</x:String>
   <x:String x:Key="Text.Preferences.AI.Model.AutoFetchAvailableModels" xml:space="preserve">Ambil model-id yang tersedia secara otomatis</x:String>
   <x:String x:Key="Text.Preferences.AI.Name" xml:space="preserve">Nama</x:String>

--- a/src/Views/Preferences.axaml
+++ b/src/Views/Preferences.axaml
@@ -932,6 +932,15 @@
                              Text="{Binding AdditionalPrompt, Mode=TwoWay}"
                              AcceptsReturn="true"
                              TextWrapping="Wrap"/>
+
+                    <TextBlock Margin="0,12,0,0" Text="{DynamicResource Text.Preferences.AI.ExtraHeaders}"/>
+                    <TextBox Height="60"
+                             Margin="0,4,0,0"
+                             CornerRadius="3"
+                             VerticalContentAlignment="Top"
+                             Text="{Binding ExtraHeadersText, Mode=TwoWay, UpdateSourceTrigger=LostFocus}"
+                             AcceptsReturn="true"
+                             TextWrapping="Wrap"/>
                   </StackPanel>
                 </DataTemplate>
               </ContentControl.DataTemplates>


### PR DESCRIPTION
## Summary

Adds support for custom HTTP headers in the AI service configuration. This fixes #2686.

Some OpenAI-compatible providers require extra headers that SourceGit previously had no way to send. For example, OpenCode Go now requires an `x-opencode-session` header on every request and rejects calls without it:

```
HTTP 400 (MissingSessionID: )
Error from provider (Console Go): Request is missing x-opencode-session
and cannot be routed efficiently.
```

## Changes

- `src/AI/Service.cs`
  - New `ExtraHeaders` property (`Dictionary<string, string>`, persisted in preferences JSON; old configs without it default to empty).
  - New `ExtraHeadersText` facade for UI editing: one `Name: Value` pair per line; lines without a colon or with an empty/invalid name are ignored; names are case-insensitive.
  - Headers are injected via a small `System.ClientModel` `PipelinePolicy` (`PerCall`) in `GetOpenAIClient()`, so they apply to both `OpenAIClient` and `AzureOpenAIClient` — covering AI chat, commit-message generation, and model-list fetching.
- `src/Views/Preferences.axaml` — new "Extra Headers" multi-line field in the AI service editor.
- `src/Resources/Locales/en_US.axaml`, `id_ID.axaml` — label string (other locales fall back to the existing localization-bot sync).

## How to use (OpenCode Go example)

In **Preferences > AI Services**, add to the **Extra Headers** field:

```
x-opencode-session: <a-stable-uuid>
```

## Evidence

AI Assistant successfully generating a commit message through the OpenCode Go endpoint with the custom header set (model `mimo-v2.5`, token usage reported normally instead of the previous HTTP 400):

![AI Assistant generating a commit message via OpenCode Go with x-opencode-session header](https://raw.githubusercontent.com/yopichy/sourcegit/assets/pr-evidence/docs/ai-extra-headers-evidence.png)

## Verification

- `dotnet build src/SourceGit.csproj -c Release` → succeeded, 0 warnings, 0 errors.
- Runtime check of the header parsing: valid pairs parsed, malformed lines ignored, case-insensitive de-duplication (last wins), text and JSON round-trips verified, empty default confirmed.
