### PR TITLE
Bug Fix: keep local changes commit controls visible on short windows

### DIFF
--- a/src/Views/WorkingCopy.axaml
+++ b/src/Views/WorkingCopy.axaml
@@ -205,9 +205,9 @@
     <!-- Right -->
     <Grid Grid.Column="2" Margin="0,4,4,4">
       <Grid.RowDefinitions>
-        <RowDefinition Height="*" MinHeight="400"/>
+        <RowDefinition Height="3*" MinHeight="100"/>
         <RowDefinition Height="4"/>
-        <RowDefinition Height="128" MinHeight="100"/>
+        <RowDefinition Height="1*" MinHeight="100"/>
         <RowDefinition Height="36"/>
       </Grid.RowDefinitions>
 
@@ -239,6 +239,7 @@
 
       <!-- Splitter -->
       <GridSplitter Grid.Row="1" MinHeight="1"
+                    ResizeBehavior="PreviousAndNext"
                     HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
                     Background="Transparent"
                     Focusable="False"/>

--- a/src/Views/WorkingCopy.axaml
+++ b/src/Views/WorkingCopy.axaml
@@ -205,9 +205,9 @@
     <!-- Right -->
     <Grid Grid.Column="2" Margin="0,4,4,4">
       <Grid.RowDefinitions>
-        <RowDefinition Height="3*" MinHeight="100"/>
+        <RowDefinition Height="*" MinHeight="100"/>
         <RowDefinition Height="4"/>
-        <RowDefinition Height="1*" MinHeight="100"/>
+        <RowDefinition Height="128" MinHeight="100"/>
         <RowDefinition Height="36"/>
       </Grid.RowDefinitions>
 
@@ -239,7 +239,6 @@
 
       <!-- Splitter -->
       <GridSplitter Grid.Row="1" MinHeight="1"
-                    ResizeBehavior="PreviousAndNext"
                     HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
                     Background="Transparent"
                     Focusable="False"/>


### PR DESCRIPTION
Description

  ## Problem

  The commit editor and commit action buttons disappear from the `Local
  Changes` page when the application window is resized to a shorter height.

  This happens because the diff panel has a fixed minimum height of 400
  pixels, while the commit message editor also reserves a fixed height of 128
  pixels. When the available vertical space becomes smaller than the combined
  layout requirements, the commit editor and action row are pushed outside the
  visible area.

  ## Solution

  Make the right side of the `Local Changes` page responsive to the available
  height:

  - Use a `3*` row for the diff panel and a `1*` row for the commit message
  editor.
  - Reduce the minimum height of both sections to 100 pixels.
  - Configure the splitter to resize the diff and commit message sections
  together.
  - Preserve the commit options and action buttons at the bottom of the page.

  This keeps the commit controls accessible when the application window is
  vertically constrained while preserving the existing layout behavior at
  larger sizes.

  ## Validation

### video with bug


https://github.com/user-attachments/assets/fff54efc-5ea5-4e88-b3d0-4ce932b62885


### video without bug


https://github.com/user-attachments/assets/6f45f96d-4e39-41eb-88d6-6be0edb514fa

