### PR TITLE
fix: size working copy pane for commit push action

### DIFF
--- a/src/Views/WorkingCopy.axaml
+++ b/src/Views/WorkingCopy.axaml
@@ -12,7 +12,7 @@
     <Grid.ColumnDefinitions>
       <ColumnDefinition Width="{Binding Source={x:Static vm:Preferences.Instance}, Path=Layout.WorkingCopyLeftWidth, Mode=TwoWay}" MinWidth="300"/>
       <ColumnDefinition Width="4"/>
-      <ColumnDefinition Width="*" MinWidth="300"/>
+      <ColumnDefinition Width="*" MinWidth="470"/>
     </Grid.ColumnDefinitions>
 
     <!-- Left -->


### PR DESCRIPTION
## Problem

  The Working Copy right panel could become too narrow, causing the Commit and Commit & Push buttons to be
  clipped or disappear.

  ## Fix

  Set the right panel minimum width to 470 pixels so the commit actions remain visible while resizing the
  working copy layout.

  ## Validation

  - Verified the XAML change.
  - Confirmed the branch is pushed to GitHub.


### bug video


https://github.com/user-attachments/assets/37a7fa15-db68-41f4-bb23-eb5fa022299e

### without bug


https://github.com/user-attachments/assets/daf28e69-669d-452d-943e-2a39b43a9dad

