### PR TITLE
fix: scroll to the first change using the real text layout in diff view

### DIFF
--- a/src/Views/TextDiffView.axaml.cs
+++ b/src/Views/TextDiffView.axaml.cs
@@ -640,7 +640,7 @@ namespace SourceGit.Views
         protected override void OnDataContextChanged(EventArgs e)
         {
             base.OnDataContextChanged(e);
-            AutoScrollToFirstChange();
+            _execSizeChanged = false;
         }
 
         protected override void OnSizeChanged(SizeChangedEventArgs e)
@@ -857,18 +857,38 @@ namespace SourceGit.Views
             if (curBlock == null)
                 return;
 
-            var lineHeight = TextArea.TextView.DefaultLineHeight;
-            var vOffset = lineHeight * (curBlock.Start - 1) - Bounds.Height * 0.5;
+            ApplyTemplate();
+            var scroller = this.FindDescendantOfType<ScrollViewer>();
+            if (scroller == null)
+            {
+                _execSizeChanged = false;
+                return;
+            }
+
+            var target = Math.Min(curBlock.Start, Document.LineCount);
+            if (target < 1)
+                return;
+
+            var textView = TextArea.TextView;
+            for (var i = 1; i < target; i++)
+                textView.GetOrConstructVisualLine(Document.GetLineByNumber(i));
+
+            var visualLine = textView.GetOrConstructVisualLine(Document.GetLineByNumber(target));
+            var vOffset = visualLine.VisualTop - scroller.Viewport.Height * 0.5;
             if (vOffset >= 0)
             {
-                var scroller = this.FindDescendantOfType<ScrollViewer>();
-                if (scroller != null)
-                {
-                    var scrollOffset = new Vector(0, vOffset);
-                    scroller.Offset = scrollOffset;
-                    ctx.ScrollOffset = scrollOffset;
-                }
+                var scrollOffset = new Vector(0, vOffset);
+                scroller.Offset = scrollOffset;
+                ctx.ScrollOffset = scrollOffset;
             }
+        }
+
+        protected void ScheduleAutoScrollToFirstChange()
+        {
+            if (DataContext is not ViewModels.TextDiffContext)
+                return;
+
+            Dispatcher.UIThread.Post(AutoScrollToFirstChange, DispatcherPriority.Background);
         }
 
         private bool CanCopyText()
@@ -1061,6 +1081,8 @@ namespace SourceGit.Views
                 Text = string.Empty;
             }
 
+            ScheduleAutoScrollToFirstChange();
+
             GC.Collect();
         }
 
@@ -1252,6 +1274,8 @@ namespace SourceGit.Views
             {
                 Text = string.Empty;
             }
+
+            ScheduleAutoScrollToFirstChange();
         }
 
         protected override void UpdateSelectedChunk(double y)


### PR DESCRIPTION
## Problem

With "Line Word Wrap" enabled, opening a changed file does not scroll to the first change — the view stays at the top of the diff, above the change.

`AutoScrollToFirstChange()` estimates the offset as `lineHeight * (curBlock.Start - 1)`, which assumes one visual row per line. Wrapped long lines break that assumption, so the estimate is several times too small: the view either stays at the top of the diff or lands short of the change, instead of centering it.

## Before / After

`src/Resources/Icons.axaml` from `90d9e2ddc2`, word wrap enabled:

**Before** — the view stays at the top of the diff, the first change is out of view:

![before](https://github.com/user-attachments/assets/e15ad8a9-4a90-4085-be18-4f808b2554e0)

**After** — the first change is brought into view (block indicator 1/1):

![after](https://github.com/user-attachments/assets/4432d183-cb08-40a1-9c56-a7d8263f5f56)

## Fix

**Offset calculation** — ask the real text layout instead of estimating: build the visual lines above the target so their wrapped heights are recorded in the height tree, then use `VisualLine.VisualTop`. Lines already built by previous layouts are reused, so only the not-yet-built ones cost anything.

**Timing** — the calculation now depends on the document and the layout, so:

- It used to run from `OnDataContextChanged()`, before the subclass writes the new text, which means it measured a stale document. It is now scheduled by the subclasses right after the text is written.
- It is dispatched at `DispatcherPriority.Background`, so it runs after the layout pass, when the document, the scroll extent and the wrapped heights are all up-to-date.

## Notes

- The `vOffset >= 0` guard is kept: no scrolling when the first change is already in the top half of the viewport.
- `ScrollToLine()` was avoided — its 0.3 viewport minimum-scroll threshold is meant for caret following and would swallow legitimate jump corrections.